### PR TITLE
Replace BiblePlus license from GPLv3 to dual license Apache/GPL

### DIFF
--- a/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/BiblePlusPDB.java
+++ b/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/BiblePlusPDB.java
@@ -2,18 +2,9 @@
     Bible Plus A Bible Reader for Blackberry
     Copyright (C) 2010 Yohanes Nugroho
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    Bibleplus is dual licensed under either:
+    - Apache license, Version 2.0, (http://www.apache.org/licenses/LICENSE-2.0)
+    - GPL version 3 or later (http://www.gnu.org/licenses/)
 
     Yohanes Nugroho (yohanes@gmail.com)
  */

--- a/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/BookInfo.java
+++ b/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/BookInfo.java
@@ -2,18 +2,9 @@
     Bible Plus A Bible Reader for Blackberry
     Copyright (C) 2010 Yohanes Nugroho
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    Bibleplus is dual licensed under either:
+    - Apache license, Version 2.0, (http://www.apache.org/licenses/LICENSE-2.0)
+    - GPL version 3 or later (http://www.gnu.org/licenses/)
 
     Yohanes Nugroho (yohanes@gmail.com)
  */

--- a/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/PDBAccess.java
+++ b/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/PDBAccess.java
@@ -2,18 +2,9 @@
     Bible Plus A Bible Reader for Blackberry
     Copyright (C) 2010 Yohanes Nugroho
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    Bibleplus is dual licensed under either:
+    - Apache license, Version 2.0, (http://www.apache.org/licenses/LICENSE-2.0)
+    - GPL version 3 or later (http://www.gnu.org/licenses/)
 
     Yohanes Nugroho (yohanes@gmail.com)
  */

--- a/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/PDBDataStream.java
+++ b/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/PDBDataStream.java
@@ -2,18 +2,9 @@
     Bible Plus A Bible Reader for Blackberry
     Copyright (C) 2010 Yohanes Nugroho
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    Bibleplus is dual licensed under either:
+    - Apache license, Version 2.0, (http://www.apache.org/licenses/LICENSE-2.0)
+    - GPL version 3 or later (http://www.gnu.org/licenses/)
 
     Yohanes Nugroho (yohanes@gmail.com)
  */

--- a/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/PDBHeader.java
+++ b/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/PDBHeader.java
@@ -2,18 +2,9 @@
     Bible Plus A Bible Reader for Blackberry
     Copyright (C) 2010 Yohanes Nugroho
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    Bibleplus is dual licensed under either:
+    - Apache license, Version 2.0, (http://www.apache.org/licenses/LICENSE-2.0)
+    - GPL version 3 or later (http://www.gnu.org/licenses/)
 
     Yohanes Nugroho (yohanes@gmail.com)
  */

--- a/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/PDBRecord.java
+++ b/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/PDBRecord.java
@@ -2,18 +2,9 @@
     Bible Plus A Bible Reader for Blackberry
     Copyright (C) 2010 Yohanes Nugroho
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    Bibleplus is dual licensed under either:
+    - Apache license, Version 2.0, (http://www.apache.org/licenses/LICENSE-2.0)
+    - GPL version 3 or later (http://www.gnu.org/licenses/)
 
     Yohanes Nugroho (yohanes@gmail.com)
  */

--- a/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/Util.java
+++ b/BiblePlus/src/main/java/com/compactbyte/bibleplus/reader/Util.java
@@ -2,18 +2,9 @@
     Bible Plus A Bible Reader for Blackberry
     Copyright (C) 2010 Yohanes Nugroho
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    Bibleplus is dual licensed under either:
+    - Apache license, Version 2.0, (http://www.apache.org/licenses/LICENSE-2.0)
+    - GPL version 3 or later (http://www.gnu.org/licenses/)
 
     Yohanes Nugroho (yohanes@gmail.com)
  */


### PR DESCRIPTION
As the author of BiblePlus code, I hereby relicense the code from GPL v3 to dual license Apache 2.0/GPL 3.0 or later.

This is to resolve the following issue:

https://github.com/yukuku/androidbible/issues/62