### PR TITLE
Add deeplink capability to manifest

### DIFF
--- a/Alkitab/src/main/AndroidManifest.xml
+++ b/Alkitab/src/main/AndroidManifest.xml
@@ -44,6 +44,20 @@
 		<activity
 			android:name="yuku.alkitab.base.IsiActivity"
 			android:exported="true">
+
+			<!-- deeplink for opening bible reading page -->
+			<intent-filter android:autoVerify="true">
+				<action android:name="android.intent.action.VIEW" />
+
+				<category android:name="android.intent.category.DEFAULT" />
+				<category android:name="android.intent.category.BROWSABLE" />
+
+				<data
+					android:scheme="https"
+					android:host="alkitab.app"
+					android:pathPrefix="/a" />
+			</intent-filter>
+
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -1361,15 +1361,27 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
     private fun extractIntent(intent: Intent): IntentResult? {
         dumpIntent(intent, "IsiActivity#onCreate")
 
-        return tryGetIntentResultFromView(intent)
+        return when (intent.action) {
+            "yuku.alkitab.action.VIEW" -> tryGetIntentResultFromCustomViewAction(intent)
+            Intent.ACTION_VIEW -> tryGetIntentResultFromViewAction(intent)
+            else -> null
+        }
+    }
+
+    private fun tryGetIntentResultFromViewAction(intent: Intent): IntentResult? {
+        val data = intent.data ?: return null
+        val pathSegments = data.pathSegments
+        if (pathSegments.size >= 2 && pathSegments[0] == "a") {
+            // TODO JS navigate content
+            IntentResult(0, false, 1)
+        }
+        return null
     }
 
     /**
      * did we get here from VIEW intent?
      */
-    private fun tryGetIntentResultFromView(intent: Intent): IntentResult? {
-        if (intent.action != "yuku.alkitab.action.VIEW") return null
-
+    private fun tryGetIntentResultFromCustomViewAction(intent: Intent): IntentResult? {
         val selectVerse = intent.getBooleanExtra("selectVerse", false)
         val selectVerseCount = intent.getIntExtra("selectVerseCount", 1)
 


### PR DESCRIPTION
The app now can be opened using URL such as `https://alkitab.app/a/Kej1:1`.

Note: currently the app will disregard data after `a/`. Search capability will be implemented on another PR.
