### PR TITLE
Add Bible audio playback with verse highlighting

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -245,7 +245,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
     private lateinit var overlayContainer: FrameLayout
     lateinit var root: ViewGroup
     lateinit var toolbar: Toolbar
-    private lateinit var nontoolbar: View
+    private lateinit var nontoolbar: FrameLayout
     lateinit var lsSplit0: VersesController
     lateinit var lsSplit1: VersesController
     lateinit var splitRoot: TwofingerLinearLayout
@@ -2925,9 +2925,8 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
         }
 
         val ctrl = audioController ?: run {
-            val nontoolbarFrame = nontoolbar as FrameLayout
-            val audioBar = layoutInflater.inflate(R.layout.activity_audio, nontoolbarFrame, false)
-            nontoolbarFrame.addView(audioBar)
+            val audioBar = layoutInflater.inflate(R.layout.activity_audio, nontoolbar, false)
+            nontoolbar.addView(audioBar)
 
             val controller = AudioPlaybackController(
                 context = this,
@@ -2956,7 +2955,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
         val ctrl = audioController ?: return
         ctrl.audioBar.isVisible = false
         ctrl.release()
-        (nontoolbar as FrameLayout).removeView(ctrl.audioBar)
+        nontoolbar.removeView(ctrl.audioBar)
         audioController = null
         lsSplit0.setAudioHighlight(0)
         lsSplit1.setAudioHighlight(0)
@@ -2964,8 +2963,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
     }
 
     private fun adjustBackForwardListForAudioBar(visible: Boolean) {
-        val extraDp = if (visible) 64 else 0
-        val extraPx = (extraDp * resources.displayMetrics.density).toInt()
+        val extraPx = if (visible) resources.getDimensionPixelSize(R.dimen.audio_bar_height) else 0
         val basePx = (8 * resources.displayMetrics.density).toInt()
         panelBackForwardList.updateLayoutParams<FrameLayout.LayoutParams> {
             bottomMargin = basePx + extraPx

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -2315,7 +2315,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
                 val spec1 = activeSplit1?.let { s1 ->
                     BibleAudioRepository.findAudio(s1.versionId)
                 }
-                ctrl.loadChapter(activeSplit0.book.bookId, available_chapter_1, spec0, spec1)
+                ctrl.loadChapter(activeSplit0.book, available_chapter_1, spec0, spec1)
             }
         }
 
@@ -2948,7 +2948,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
         val spec1 = activeSplit1?.let { s1 ->
             BibleAudioRepository.findAudio(s1.versionId)
         }
-        ctrl.loadChapter(activeSplit0.book.bookId, chapter_1, spec0, spec1)
+        ctrl.loadChapter(activeSplit0.book, chapter_1, spec0, spec1)
     }
 
     private fun closeAudioBar() {

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -63,7 +63,10 @@ import yuku.alkitab.base.ac.MarkerListActivity
 import yuku.alkitab.base.ac.MarkersActivity
 import yuku.alkitab.base.ac.NoteActivity
 import yuku.alkitab.base.ac.SearchActivity
+import androidx.lifecycle.lifecycleScope
 import yuku.alkitab.base.ac.base.BaseLeftDrawerActivity
+import yuku.alkitab.base.audio.AudioPlaybackController
+import yuku.alkitab.base.util.BibleAudioRepository
 import yuku.alkitab.base.config.AppConfig
 import yuku.alkitab.base.dialog.ProgressMarkListDialog
 import yuku.alkitab.base.dialog.ProgressMarkRenameDialog
@@ -254,6 +257,10 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
     lateinit var floater: Floater
     private lateinit var backForwardListController: BackForwardListController<ImageButton, ImageButton>
     private var fullscreenReferenceToast: Toast? = null
+
+    // Audio playback
+    private var audioController: AudioPlaybackController? = null
+    private lateinit var panelBackForwardList: View
 
     private var dataSplit0 = VersesDataModel.EMPTY
         set(value) {
@@ -1107,6 +1114,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
         }
 
         nontoolbar = findViewById(R.id.nontoolbar)
+        panelBackForwardList = findViewById(R.id.panelBackForwardList)
 
         bGoto = findViewById(R.id.bGoto)
         bLeft = findViewById(R.id.bLeft)
@@ -1338,6 +1346,9 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
 
     override fun onDestroy() {
         super.onDestroy()
+
+        audioController?.release()
+        audioController = null
 
         App.getLbm().unregisterReceiver(reloadAttributeMapReceiver)
 
@@ -1964,6 +1975,11 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
                 menuSearch_click()
                 return true
             }
+
+            R.id.menuAudio -> {
+                toggleAudioBar()
+                return true
+            }
         }
 
         return super.onOptionsItemSelected(item)
@@ -2290,6 +2306,17 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
 
         if (dictionaryMode) {
             finishDictionaryMode()
+        }
+
+        // Reload audio for the new chapter if the audio bar is active.
+        audioController?.let { ctrl ->
+            val spec0 = BibleAudioRepository.findAudio(activeSplit0.versionId)
+            if (spec0 != null) {
+                val spec1 = activeSplit1?.let { s1 ->
+                    BibleAudioRepository.findAudio(s1.versionId)
+                }
+                ctrl.loadChapter(activeSplit0.book.bookId, available_chapter_1, spec0, spec1)
+            }
         }
 
         return Ari.encode(0, available_chapter_1, available_verse_1)
@@ -2874,6 +2901,74 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
                 message(R.string.pm_activate_tutorial)
                 positiveButton(R.string.ok)
             }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Audio bar
+    // -----------------------------------------------------------------------
+
+    private fun toggleAudioBar() {
+        val ctrl = audioController
+        if (ctrl != null && ctrl.audioBar.isVisible) {
+            closeAudioBar()
+        } else {
+            openAudioBar()
+        }
+    }
+
+    private fun openAudioBar() {
+        val spec0 = BibleAudioRepository.findAudio(activeSplit0.versionId)
+        if (spec0 == null) {
+            Toast.makeText(this, R.string.audio_not_available_for_version, Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val ctrl = audioController ?: run {
+            val nontoolbarFrame = nontoolbar as FrameLayout
+            val audioBar = layoutInflater.inflate(R.layout.activity_audio, nontoolbarFrame, false)
+            nontoolbarFrame.addView(audioBar)
+
+            val controller = AudioPlaybackController(
+                context = this,
+                lifecycleScope = lifecycleScope,
+                audioBar = audioBar,
+                onVerseHighlight0 = { verse_1 -> lsSplit0.setAudioHighlight(verse_1) },
+                onVerseHighlight1 = { verse_1 -> lsSplit1.setAudioHighlight(verse_1) },
+                onChapterNavigationRequested = { isNext ->
+                    if (isNext) bRight_click() else bLeft_click()
+                },
+            )
+            audioController = controller
+            controller
+        }
+
+        ctrl.audioBar.isVisible = true
+        adjustBackForwardListForAudioBar(visible = true)
+
+        val spec1 = activeSplit1?.let { s1 ->
+            BibleAudioRepository.findAudio(s1.versionId)
+        }
+        ctrl.loadChapter(activeSplit0.book.bookId, chapter_1, spec0, spec1)
+    }
+
+    private fun closeAudioBar() {
+        val ctrl = audioController ?: return
+        ctrl.audioBar.isVisible = false
+        ctrl.release()
+        (nontoolbar as FrameLayout).removeView(ctrl.audioBar)
+        audioController = null
+        lsSplit0.setAudioHighlight(0)
+        lsSplit1.setAudioHighlight(0)
+        adjustBackForwardListForAudioBar(visible = false)
+    }
+
+    private fun adjustBackForwardListForAudioBar(visible: Boolean) {
+        val extraDp = if (visible) 64 else 0
+        val extraPx = (extraDp * resources.displayMetrics.density).toInt()
+        val basePx = (8 * resources.displayMetrics.density).toInt()
+        panelBackForwardList.updateLayoutParams<FrameLayout.LayoutParams> {
+            bottomMargin = basePx + extraPx
         }
     }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioPlaybackController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioPlaybackController.kt
@@ -8,6 +8,7 @@ import android.widget.PopupMenu
 import android.widget.ProgressBar
 import androidx.lifecycle.LifecycleCoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -16,6 +17,7 @@ import yuku.alkitab.base.model.MTiming
 import yuku.alkitab.base.util.AppLog
 import yuku.alkitab.base.util.BibleAudioRepository
 import yuku.alkitab.debug.R
+import yuku.alkitab.model.Book
 
 private val SPEEDS = listOf(0.5f, 0.8f, 1.0f, 1.1f, 1.25f, 1.5f, 1.75f, 2.0f)
 
@@ -101,7 +103,7 @@ class AudioPlaybackController(
      * Timing data is fetched lazily when the user presses play.
      */
     fun loadChapter(
-        bookId: Int,
+        book: Book,
         chapter_1: Int,
         spec0: MAudio,
         spec1: MAudio? = null,
@@ -109,7 +111,7 @@ class AudioPlaybackController(
         stopPlayback()
         clearHighlights()
 
-        this.bookId = bookId
+        this.bookId = book.bookId
         this.chapter_1 = chapter_1
         this.audioSpec0 = spec0
         this.audioSpec1 = spec1
@@ -118,7 +120,7 @@ class AudioPlaybackController(
         this.timing1 = emptyList()
 
         // Pre-load audio players with the URL so buffering can start.
-        val url0 = BibleAudioRepository.buildUrl(bookId, chapter_1, spec0.audioFolder)
+        val url0 = BibleAudioRepository.buildUrl(book, chapter_1, spec0.audioFolder)
         if (url0 != null) {
             ensurePlayer0().load(url0)
         } else {
@@ -126,7 +128,7 @@ class AudioPlaybackController(
         }
 
         if (spec1 != null) {
-            val url1 = BibleAudioRepository.buildUrl(bookId, chapter_1, spec1.audioFolder)
+            val url1 = BibleAudioRepository.buildUrl(book, chapter_1, spec1.audioFolder)
             if (url1 != null) {
                 ensurePlayer1().load(url1)
             }
@@ -240,7 +242,7 @@ class AudioPlaybackController(
      * Single mode: poll player0's position and update verse highlight every [HIGHLIGHT_POLL_MS].
      */
     private suspend fun runSingleModeHighlighting() {
-        while (isActive) {
+        while (currentCoroutineContext().isActive) {
             val pos = player0?.currentPositionMs ?: break
             val verse = timing0.findVerseAt(pos)
             if (verse != null && verse != highlightedVerse0) {
@@ -264,7 +266,7 @@ class AudioPlaybackController(
 
         for (verse in allVerses) {
             if (verse < startVerse) continue
-            if (!isActive) break
+            if (!currentCoroutineContext().isActive) break
 
             // Play verse in player0
             val t0 = timing0.find { it.verseNumber == verse }
@@ -275,7 +277,7 @@ class AudioPlaybackController(
                 highlightedVerse0 = verse
                 onVerseHighlight0(verse)
 
-                while (isActive) {
+                while (currentCoroutineContext().isActive) {
                     val pos = player0?.currentPositionMs ?: break
                     if (pos >= t0.endMs) break
                     delay(HIGHLIGHT_POLL_MS)
@@ -283,7 +285,7 @@ class AudioPlaybackController(
                 player0?.pause()
             }
 
-            if (!isActive) break
+            if (!currentCoroutineContext().isActive) break
 
             // Play verse in player1
             val t1 = timing1.find { it.verseNumber == verse }
@@ -293,7 +295,7 @@ class AudioPlaybackController(
                 highlightedVerse1 = verse
                 onVerseHighlight1(verse)
 
-                while (isActive) {
+                while (currentCoroutineContext().isActive) {
                     val pos = player1?.currentPositionMs ?: break
                     if (pos >= t1.endMs) break
                     delay(HIGHLIGHT_POLL_MS)
@@ -303,7 +305,7 @@ class AudioPlaybackController(
         }
 
         // Chapter ended
-        if (isActive) {
+        if (currentCoroutineContext().isActive) {
             isPlaying = false
             updatePlayButton()
             if (repeat) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioPlaybackController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioPlaybackController.kt
@@ -1,0 +1,375 @@
+package yuku.alkitab.base.audio
+
+import android.content.Context
+import android.view.MenuItem
+import android.view.View
+import android.widget.ImageButton
+import android.widget.PopupMenu
+import android.widget.ProgressBar
+import androidx.lifecycle.LifecycleCoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import yuku.alkitab.base.model.MAudio
+import yuku.alkitab.base.model.MTiming
+import yuku.alkitab.base.util.AppLog
+import yuku.alkitab.base.util.BibleAudioRepository
+import yuku.alkitab.debug.R
+
+private const val TAG = "AudioPlaybackController"
+private const val HIGHLIGHT_POLL_MS = 100L
+
+/**
+ * Orchestrates Bible audio playback for a single chapter, in either single-stream or
+ * dual-stream (split-view interleaved) mode.
+ *
+ * Lifecycle: call [loadChapter] to set up audio for a book/chapter, [release] when done.
+ * All methods must be called on the main thread; coroutines are scoped to [lifecycleScope]
+ * so there are no memory leaks when the hosting Activity/Fragment is destroyed.
+ *
+ * @param audioBar  the inflated audio control bar view (activity_audio.xml)
+ * @param onVerseHighlight0  called on main thread with the currently active verse_1 for split 0
+ * @param onVerseHighlight1  called on main thread with the currently active verse_1 for split 1
+ * @param onChapterNavigationRequested  called when the user taps prev/next chapter
+ */
+class AudioPlaybackController(
+    private val context: Context,
+    private val lifecycleScope: LifecycleCoroutineScope,
+    val audioBar: View,
+    private val onVerseHighlight0: (verse_1: Int) -> Unit,
+    private val onVerseHighlight1: (verse_1: Int) -> Unit,
+    private val onChapterNavigationRequested: (isNext: Boolean) -> Unit,
+) {
+    // -----------------------------------------------------------------------
+    // UI references (wired once in init)
+    // -----------------------------------------------------------------------
+    private val buttonPlay: ImageButton = audioBar.findViewById(R.id.button_play)
+    private val buttonPrevVerse: ImageButton = audioBar.findViewById(R.id.button_prev_verse)
+    private val buttonNextVerse: ImageButton = audioBar.findViewById(R.id.button_next_verse)
+    private val buttonPrevChapter: ImageButton = audioBar.findViewById(R.id.button_prev_chapter)
+    private val buttonNextChapter: ImageButton = audioBar.findViewById(R.id.button_next_chapter)
+    private val buttonSpeed: ImageButton = audioBar.findViewById(R.id.button_speed)
+    private val buttonRepeat: ImageButton = audioBar.findViewById(R.id.button_repeat)
+    private val progressBar: ProgressBar = audioBar.findViewById(R.id.audio_progress_bar)
+
+    // -----------------------------------------------------------------------
+    // State
+    // -----------------------------------------------------------------------
+    private var player0: BibleAudioPlayer? = null
+    private var player1: BibleAudioPlayer? = null   // non-null only in dual mode
+
+    private var timing0: List<MTiming> = emptyList()
+    private var timing1: List<MTiming> = emptyList()
+
+    private var isDual = false
+    private var isPlaying = false
+    private var repeat = false
+    private var speed = 1.0f
+
+    /** Current chapter state – set by [loadChapter]. */
+    private var bookId = -1
+    private var chapter_1 = 0
+    private var audioSpec0: MAudio? = null
+    private var audioSpec1: MAudio? = null
+
+    /** Running coroutine job for highlight polling / dual-mode verse alternation. */
+    private var playbackJob: Job? = null
+
+    /** Verse currently being tracked for highlight (1-based; 0 = none). */
+    private var highlightedVerse0 = 0
+    private var highlightedVerse1 = 0
+
+    init {
+        buttonPlay.setOnClickListener { togglePlayPause() }
+        buttonPrevVerse.setOnClickListener { navigateVerse(isNext = false) }
+        buttonNextVerse.setOnClickListener { navigateVerse(isNext = true) }
+        buttonPrevChapter.setOnClickListener { onChapterNavigationRequested(false) }
+        buttonNextChapter.setOnClickListener { onChapterNavigationRequested(true) }
+        buttonSpeed.setOnClickListener { showSpeedMenu(it) }
+        buttonRepeat.setOnClickListener { toggleRepeat() }
+    }
+
+    // -----------------------------------------------------------------------
+    // Public API
+    // -----------------------------------------------------------------------
+
+    /**
+     * Load audio for a new book/chapter. Stops any ongoing playback first.
+     * Timing data is fetched lazily when the user presses play.
+     */
+    fun loadChapter(
+        bookId: Int,
+        chapter_1: Int,
+        spec0: MAudio,
+        spec1: MAudio? = null,
+    ) {
+        stopPlayback()
+        clearHighlights()
+
+        this.bookId = bookId
+        this.chapter_1 = chapter_1
+        this.audioSpec0 = spec0
+        this.audioSpec1 = spec1
+        this.isDual = spec1 != null
+        this.timing0 = emptyList()
+        this.timing1 = emptyList()
+
+        // Pre-load audio players with the URL so buffering can start.
+        val url0 = BibleAudioRepository.buildUrl(bookId, chapter_1, spec0.audioFolder)
+        if (url0 != null) {
+            ensurePlayer0().load(url0)
+        } else {
+            AppLog.w(TAG, "No audio URL for bookId=$bookId chapter=$chapter_1 spec=${spec0.versionId}")
+        }
+
+        if (spec1 != null) {
+            val url1 = BibleAudioRepository.buildUrl(bookId, chapter_1, spec1.audioFolder)
+            if (url1 != null) {
+                ensurePlayer1().load(url1)
+            }
+        }
+
+        updatePlayButton()
+        AppLog.d(TAG, "loadChapter bookId=$bookId chapter=$chapter_1 dual=$isDual")
+    }
+
+    fun togglePlayPause() {
+        if (isPlaying) {
+            pausePlayback()
+        } else {
+            startPlayback()
+        }
+    }
+
+    /**
+     * Seek to the start of [verse_1] in the current timing data (if available).
+     * Falls back to a no-op if timing has not yet been loaded.
+     */
+    fun navigateVerse(isNext: Boolean) {
+        val timing = timing0
+        if (timing.isEmpty()) return
+
+        val currentVerse = highlightedVerse0.coerceAtLeast(1)
+        val targetVerse = if (isNext) currentVerse + 1 else (currentVerse - 1).coerceAtLeast(1)
+        val entry = timing.find { it.verseNumber == targetVerse } ?: return
+
+        player0?.seekTo(entry.startMs)
+        if (isDual) {
+            val entry1 = timing1.find { it.verseNumber == targetVerse }
+            if (entry1 != null) player1?.seekTo(entry1.startMs)
+        }
+        AppLog.d(TAG, "navigateVerse target=$targetVerse")
+    }
+
+    fun setSpeed(newSpeed: Float) {
+        speed = newSpeed
+        player0?.setSpeed(newSpeed)
+        player1?.setSpeed(newSpeed)
+    }
+
+    fun release() {
+        stopPlayback()
+        player0?.release(); player0 = null
+        player1?.release(); player1 = null
+        AppLog.d(TAG, "released")
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    private fun startPlayback() {
+        isPlaying = true
+        updatePlayButton()
+        progressBar.visibility = View.VISIBLE
+
+        playbackJob?.cancel()
+        playbackJob = lifecycleScope.launch {
+            // Load timing data if not yet available.
+            if (timing0.isEmpty()) {
+                val spec = audioSpec0 ?: return@launch
+                timing0 = BibleAudioRepository.fetchTiming(bookId, chapter_1, spec.timingVersionParam)
+                AppLog.d(TAG, "timing0 loaded: ${timing0.size} entries")
+            }
+            if (isDual && timing1.isEmpty()) {
+                val spec = audioSpec1 ?: return@launch
+                timing1 = BibleAudioRepository.fetchTiming(bookId, chapter_1, spec.timingVersionParam)
+                AppLog.d(TAG, "timing1 loaded: ${timing1.size} entries")
+            }
+
+            progressBar.visibility = View.GONE
+            player0?.play()
+            if (isDual) player1?.pause() // player1 starts muted; dual mode drives it manually
+
+            if (isDual) {
+                runDualModePlayback()
+            } else {
+                runSingleModeHighlighting()
+            }
+        }
+    }
+
+    private fun pausePlayback() {
+        isPlaying = false
+        updatePlayButton()
+        playbackJob?.cancel()
+        player0?.pause()
+        player1?.pause()
+    }
+
+    private fun stopPlayback() {
+        isPlaying = false
+        playbackJob?.cancel()
+        player0?.pause()
+        player1?.pause()
+    }
+
+    /**
+     * Single mode: poll player0's position and update verse highlight every [HIGHLIGHT_POLL_MS].
+     */
+    private suspend fun runSingleModeHighlighting() {
+        while (isActive) {
+            val pos = player0?.currentPositionMs ?: break
+            val verse = timing0.findVerseAt(pos)
+            if (verse != null && verse != highlightedVerse0) {
+                highlightedVerse0 = verse
+                onVerseHighlight0(verse)
+            }
+            delay(HIGHLIGHT_POLL_MS)
+        }
+    }
+
+    /**
+     * Dual mode: interleave playback verse-by-verse between player0 and player1.
+     * For each verse: play it in player0 until the verse end time, then in player1.
+     */
+    private suspend fun runDualModePlayback() {
+        val allVerses = (timing0.map { it.verseNumber } + timing1.map { it.verseNumber })
+            .distinct()
+            .sorted()
+
+        for (verse in allVerses) {
+            if (!isActive) break
+
+            // Play verse in player0
+            val t0 = timing0.find { it.verseNumber == verse }
+            if (t0 != null) {
+                player0?.seekTo(t0.startMs)
+                player0?.play()
+                player1?.pause()
+                highlightedVerse0 = verse
+                onVerseHighlight0(verse)
+
+                while (isActive) {
+                    val pos = player0?.currentPositionMs ?: break
+                    if (pos >= t0.endMs) break
+                    delay(HIGHLIGHT_POLL_MS)
+                }
+                player0?.pause()
+            }
+
+            if (!isActive) break
+
+            // Play verse in player1
+            val t1 = timing1.find { it.verseNumber == verse }
+            if (t1 != null) {
+                player1?.seekTo(t1.startMs)
+                player1?.play()
+                highlightedVerse1 = verse
+                onVerseHighlight1(verse)
+
+                while (isActive) {
+                    val pos = player1?.currentPositionMs ?: break
+                    if (pos >= t1.endMs) break
+                    delay(HIGHLIGHT_POLL_MS)
+                }
+                player1?.pause()
+            }
+        }
+
+        // Chapter ended
+        if (isActive) {
+            isPlaying = false
+            updatePlayButton()
+            if (repeat) {
+                startPlayback()
+            } else {
+                onChapterNavigationRequested(true)
+            }
+        }
+    }
+
+    private fun toggleRepeat() {
+        repeat = !repeat
+        buttonRepeat.alpha = if (repeat) 1f else 0.4f
+        player0?.setRepeat(repeat && !isDual) // ExoPlayer repeat only in single mode
+        AppLog.d(TAG, "repeat=$repeat")
+    }
+
+    private fun showSpeedMenu(anchor: View) {
+        val speeds = listOf(0.5f, 0.8f, 1.0f, 1.1f, 1.25f, 1.5f, 1.75f, 2.0f)
+        val popup = PopupMenu(context, anchor)
+        speeds.forEachIndexed { index, s ->
+            val label = if (s == 1.0f) "1.0× (normal)" else "${s}×"
+            popup.menu.add(0, index, index, label)
+        }
+        popup.setOnMenuItemClickListener { item: MenuItem ->
+            setSpeed(speeds[item.itemId])
+            true
+        }
+        popup.show()
+    }
+
+    private fun updatePlayButton() {
+        buttonPlay.setImageResource(
+            if (isPlaying) R.drawable.ic_audio_pause else R.drawable.ic_audio_play
+        )
+    }
+
+    private fun clearHighlights() {
+        if (highlightedVerse0 != 0) { onVerseHighlight0(0); highlightedVerse0 = 0 }
+        if (highlightedVerse1 != 0) { onVerseHighlight1(0); highlightedVerse1 = 0 }
+    }
+
+    private fun ensurePlayer0(): BibleAudioPlayer {
+        return player0 ?: BibleAudioPlayer(context).also { p ->
+            p.listener = singleModeListener
+            player0 = p
+        }
+    }
+
+    private fun ensurePlayer1(): BibleAudioPlayer {
+        return player1 ?: BibleAudioPlayer(context).also { player1 = it }
+    }
+
+    private val singleModeListener = object : BibleAudioPlayer.Listener {
+        override fun onReady() {}
+        override fun onEnded() {
+            if (!isDual && isPlaying) {
+                isPlaying = false
+                updatePlayButton()
+                playbackJob?.cancel()
+                clearHighlights()
+                if (repeat) {
+                    startPlayback()
+                } else {
+                    onChapterNavigationRequested(true)
+                }
+            }
+        }
+        override fun onError(message: String) {
+            AppLog.e(TAG, "Playback error: $message")
+            pausePlayback()
+        }
+    }
+}
+
+// -----------------------------------------------------------------------
+// Extension: find which verse covers the given playback position
+// -----------------------------------------------------------------------
+
+private fun List<MTiming>.findVerseAt(positionMs: Long): Int? {
+    return lastOrNull { it.startMs <= positionMs && positionMs < it.endMs }?.verseNumber
+        ?: lastOrNull { positionMs >= it.startMs }?.verseNumber // fallback: last started verse
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioPlaybackController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioPlaybackController.kt
@@ -17,6 +17,8 @@ import yuku.alkitab.base.util.AppLog
 import yuku.alkitab.base.util.BibleAudioRepository
 import yuku.alkitab.debug.R
 
+private val SPEEDS = listOf(0.5f, 0.8f, 1.0f, 1.1f, 1.25f, 1.5f, 1.75f, 2.0f)
+
 private const val TAG = "AudioPlaybackController"
 private const val HIGHLIGHT_POLL_MS = 100L
 
@@ -145,6 +147,9 @@ class AudioPlaybackController(
     /**
      * Seek to the start of [verse_1] in the current timing data (if available).
      * Falls back to a no-op if timing has not yet been loaded.
+     *
+     * In dual mode the playback loop is restarted from the target verse so that
+     * the sequential verse-by-verse iteration stays in sync with the seek.
      */
     fun navigateVerse(isNext: Boolean) {
         val timing = timing0
@@ -158,6 +163,12 @@ class AudioPlaybackController(
         if (isDual) {
             val entry1 = timing1.find { it.verseNumber == targetVerse }
             if (entry1 != null) player1?.seekTo(entry1.startMs)
+            // Restart the dual-mode loop from the target verse so it stays in sync.
+            if (isPlaying) {
+                highlightedVerse0 = targetVerse
+                playbackJob?.cancel()
+                playbackJob = lifecycleScope.launch { runDualModePlayback(startVerse = targetVerse) }
+            }
         }
         AppLog.d(TAG, "navigateVerse target=$targetVerse")
     }
@@ -203,7 +214,7 @@ class AudioPlaybackController(
             if (isDual) player1?.pause() // player1 starts muted; dual mode drives it manually
 
             if (isDual) {
-                runDualModePlayback()
+                runDualModePlayback(startVerse = highlightedVerse0.coerceAtLeast(1))
             } else {
                 runSingleModeHighlighting()
             }
@@ -243,13 +254,16 @@ class AudioPlaybackController(
     /**
      * Dual mode: interleave playback verse-by-verse between player0 and player1.
      * For each verse: play it in player0 until the verse end time, then in player1.
+     *
+     * @param startVerse first verse to play; earlier verses are skipped (used after a seek)
      */
-    private suspend fun runDualModePlayback() {
+    private suspend fun runDualModePlayback(startVerse: Int = 1) {
         val allVerses = (timing0.map { it.verseNumber } + timing1.map { it.verseNumber })
             .distinct()
             .sorted()
 
         for (verse in allVerses) {
+            if (verse < startVerse) continue
             if (!isActive) break
 
             // Play verse in player0
@@ -308,14 +322,13 @@ class AudioPlaybackController(
     }
 
     private fun showSpeedMenu(anchor: View) {
-        val speeds = listOf(0.5f, 0.8f, 1.0f, 1.1f, 1.25f, 1.5f, 1.75f, 2.0f)
         val popup = PopupMenu(context, anchor)
-        speeds.forEachIndexed { index, s ->
-            val label = if (s == 1.0f) "1.0× (normal)" else "${s}×"
+        SPEEDS.forEachIndexed { index, s ->
+            val label = if (s == 1.0f) context.getString(R.string.audio_speed_normal) else "${s}×"
             popup.menu.add(0, index, index, label)
         }
         popup.setOnMenuItemClickListener { item: MenuItem ->
-            setSpeed(speeds[item.itemId])
+            setSpeed(SPEEDS[item.itemId])
             true
         }
         popup.show()

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioPlayer.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioPlayer.kt
@@ -1,0 +1,118 @@
+package yuku.alkitab.base.audio
+
+import android.content.Context
+import androidx.annotation.MainThread
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.RenderersFactory
+import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.extractor.ExtractorsFactory
+import androidx.media3.extractor.mp3.Mp3Extractor
+import yuku.alkitab.base.connection.Connections
+import yuku.alkitab.base.util.AppLog
+
+private const val TAG = "BibleAudioPlayer"
+
+/**
+ * Wraps a single ExoPlayer instance for Bible chapter audio playback.
+ * Must be created, used, and released on the main thread.
+ * Distinct from [yuku.alkitab.songs.ExoplayerController] so that song playback is unaffected.
+ */
+@OptIn(UnstableApi::class)
+class BibleAudioPlayer(appContext: Context) {
+
+    interface Listener {
+        fun onReady()
+        fun onEnded()
+        fun onError(message: String)
+    }
+
+    var listener: Listener? = null
+
+    private val player: ExoPlayer = run {
+        val audioOnlyFactory = RenderersFactory { handler, _, audioListener, _, _ ->
+            arrayOf<Renderer>(
+                MediaCodecAudioRenderer(appContext, MediaCodecSelector.DEFAULT, handler, audioListener)
+            )
+        }
+        val mp3Factory = ExtractorsFactory { arrayOf(Mp3Extractor()) }
+        val dataSourceFactory = OkHttpDataSource.Factory(Connections.okHttp)
+            .setUserAgent(Connections.httpUserAgent)
+
+        ExoPlayer.Builder(appContext, audioOnlyFactory, ProgressiveMediaSource.Factory(dataSourceFactory, mp3Factory))
+            .build()
+            .also { it.addListener(playerListener) }
+    }
+
+    val currentPositionMs: Long get() = player.currentPosition
+    val isPlaying: Boolean get() = player.isPlaying
+
+    @MainThread
+    fun load(url: String) {
+        player.stop()
+        player.setMediaItem(MediaItem.fromUri(url))
+        player.prepare()
+        AppLog.d(TAG, "load url=$url")
+    }
+
+    @MainThread
+    fun play() {
+        player.playWhenReady = true
+    }
+
+    @MainThread
+    fun pause() {
+        player.playWhenReady = false
+    }
+
+    @MainThread
+    fun seekTo(positionMs: Long) {
+        player.seekTo(positionMs)
+    }
+
+    @MainThread
+    fun setSpeed(speed: Float) {
+        player.playbackParameters = PlaybackParameters(speed)
+    }
+
+    @MainThread
+    fun setRepeat(repeat: Boolean) {
+        player.repeatMode = if (repeat) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
+    }
+
+    /** Release all ExoPlayer resources. Do not use this instance after calling release(). */
+    @MainThread
+    fun release() {
+        player.release()
+    }
+
+    private val playerListener = object : Player.Listener {
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            when (playbackState) {
+                Player.STATE_READY -> {
+                    AppLog.d(TAG, "STATE_READY")
+                    listener?.onReady()
+                }
+                Player.STATE_ENDED -> {
+                    AppLog.d(TAG, "STATE_ENDED")
+                    listener?.onEnded()
+                }
+                else -> {}
+            }
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            AppLog.e(TAG, "onPlayerError: $error")
+            listener?.onError(error.message ?: error.javaClass.simpleName)
+        }
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioPlayer.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioPlayer.kt
@@ -38,6 +38,29 @@ class BibleAudioPlayer(appContext: Context) {
 
     var listener: Listener? = null
 
+    private val playerListener = object : Player.Listener {
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            when (playbackState) {
+                Player.STATE_READY -> {
+                    AppLog.d(TAG, "STATE_READY")
+                    listener?.onReady()
+                }
+
+                Player.STATE_ENDED -> {
+                    AppLog.d(TAG, "STATE_ENDED")
+                    listener?.onEnded()
+                }
+
+                else -> {}
+            }
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            AppLog.e(TAG, "onPlayerError: $error")
+            listener?.onError(error.message ?: error.javaClass.simpleName)
+        }
+    }
+
     private val player: ExoPlayer = run {
         val audioOnlyFactory = RenderersFactory { handler, _, audioListener, _, _ ->
             arrayOf<Renderer>(
@@ -93,26 +116,5 @@ class BibleAudioPlayer(appContext: Context) {
     @MainThread
     fun release() {
         player.release()
-    }
-
-    private val playerListener = object : Player.Listener {
-        override fun onPlaybackStateChanged(playbackState: Int) {
-            when (playbackState) {
-                Player.STATE_READY -> {
-                    AppLog.d(TAG, "STATE_READY")
-                    listener?.onReady()
-                }
-                Player.STATE_ENDED -> {
-                    AppLog.d(TAG, "STATE_ENDED")
-                    listener?.onEnded()
-                }
-                else -> {}
-            }
-        }
-
-        override fun onPlayerError(error: PlaybackException) {
-            AppLog.e(TAG, "onPlayerError: $error")
-            listener?.onError(error.message ?: error.javaClass.simpleName)
-        }
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/model/MAudio.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/model/MAudio.kt
@@ -3,7 +3,7 @@ package yuku.alkitab.base.model
 /**
  * Describes an audio source for a given Bible version.
  *
- * @param versionId the Bible version identifier (e.g. "TB", "AYT")
+ * @param versionId the [MVersion] Bible version identifier (e.g. "preset/in-tb")
  * @param audioFolder the folder name on the audio server (e.g. "tb_alkitabsuara")
  * @param timingVersionParam the `version` query parameter for the timing API; defaults to [versionId]
  * @param supportsDual whether this version supports dual-audio (split-view interleaved) mode
@@ -11,6 +11,6 @@ package yuku.alkitab.base.model
 data class MAudio(
     val versionId: String,
     val audioFolder: String,
-    val timingVersionParam: String = versionId,
+    val timingVersionParam: String,
     val supportsDual: Boolean = false,
 )

--- a/Alkitab/src/main/java/yuku/alkitab/base/model/MAudio.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/model/MAudio.kt
@@ -1,0 +1,16 @@
+package yuku.alkitab.base.model
+
+/**
+ * Describes an audio source for a given Bible version.
+ *
+ * @param versionId the Bible version identifier (e.g. "TB", "AYT")
+ * @param audioFolder the folder name on the audio server (e.g. "tb_alkitabsuara")
+ * @param timingVersionParam the `version` query parameter for the timing API; defaults to [versionId]
+ * @param supportsDual whether this version supports dual-audio (split-view interleaved) mode
+ */
+data class MAudio(
+    val versionId: String,
+    val audioFolder: String,
+    val timingVersionParam: String = versionId,
+    val supportsDual: Boolean = false,
+)

--- a/Alkitab/src/main/java/yuku/alkitab/base/model/MTiming.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/model/MTiming.kt
@@ -1,0 +1,41 @@
+package yuku.alkitab.base.model
+
+import org.json.JSONObject
+
+/**
+ * Timing information for a single verse within a chapter audio file.
+ *
+ * @param startMs start time in milliseconds
+ * @param endMs end time in milliseconds
+ * @param verseNumber 1-based verse number
+ */
+data class MTiming(
+    val startMs: Long,
+    val endMs: Long,
+    val verseNumber: Int,
+) {
+    companion object {
+        private fun fromJson(json: JSONObject): MTiming {
+            val startMs = (json.getDouble("time_start") * 1000).toLong()
+            val durationMs = (json.getDouble("duration") * 1000).toLong()
+            return MTiming(
+                startMs = startMs,
+                endMs = startMs + durationMs,
+                verseNumber = json.getInt("verse"),
+            )
+        }
+
+        /**
+         * Parse a full timing JSON response into a list of [MTiming].
+         * Returns an empty list if parsing fails.
+         */
+        fun parseList(jsonText: String): List<MTiming> {
+            return try {
+                val arr = JSONObject(jsonText).getJSONArray("timestamps")
+                List(arr.length()) { i -> fromJson(arr.getJSONObject(i)) }
+            } catch (_: Exception) {
+                emptyList()
+            }
+        }
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/BibleAudioRepository.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/BibleAudioRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.withContext
 import yuku.alkitab.base.connection.Connections
 import yuku.alkitab.base.model.MAudio
 import yuku.alkitab.base.model.MTiming
+import yuku.alkitab.model.Book
 
 private const val TAG = "BibleAudioRepository"
 
@@ -22,28 +23,31 @@ object BibleAudioRepository {
 
     /** Bible versions that have audio available on the SABDA media server. */
     val SUPPORTED: List<MAudio> = listOf(
-        MAudio(versionId = "TB", audioFolder = "tb_alkitabsuara", supportsDual = true),
-        MAudio(versionId = "AYT", audioFolder = "ayt-ai-v2"),
-        MAudio(versionId = "AVB", audioFolder = "avb"),
-        MAudio(versionId = "KJV", audioFolder = "kjv"),
+        MAudio(versionId = "preset/in-tb", timingVersionParam = "tbsuara", audioFolder = "tb_alkitabsuara", supportsDual = true),
+        MAudio(versionId = "preset/in-ayt", timingVersionParam = "ayt", audioFolder = "ayt-ai-v2"),
+        MAudio(versionId = "preset/in-avb", timingVersionParam = "avb", audioFolder = "avb"),
+        MAudio(versionId = "preset/en-kjv", timingVersionParam = "kjv", audioFolder = "kjv"),
     )
 
     /** Returns the [MAudio] for [versionId], or null if this version has no audio. */
-    fun findAudio(versionId: String): MAudio? = SUPPORTED.find { it.versionId == versionId }
+    fun findAudio(versionId: String): MAudio? {
+        return SUPPORTED.find { it.versionId == versionId }
+    }
 
     /**
      * Builds the MP3 URL for a chapter.
      *
-     * @param bookId  0-based book index (0 = Genesis … 65 = Revelation)
+     * @param book  book
      * @param chapter_1  1-based chapter number
      * @param audioFolder  the [MAudio.audioFolder] value for the target version
-     * @return the fully-formed URL, or null when [bookId] is out of range
+     * @return the fully-formed URL, or null when [book] is out of range
      */
-    fun buildUrl(bookId: Int, chapter_1: Int, audioFolder: String): String? {
+    fun buildUrl(book: Book, chapter_1: Int, audioFolder: String): String? {
+        val bookId = book.bookId
         val info = BOOK_INFO.getOrNull(bookId) ?: return null
         val bookCode = (bookId + 1).toString().padStart(2, '0')
         val subdir = if (bookId < 39) "pl/mp3/cd" else "pb/mp3/cd"
-        val chapter = chapter_1.toString().padStart(3, '0')
+        val chapter = chapter_1.toString().padStart(if (book.chapter_count >= 100) 3 else 2, '0')
         return "$AUDIO_BASE/$audioFolder/$subdir/${bookCode}_${info.folderName}/${bookCode}_${info.abbr}$chapter.mp3"
     }
 
@@ -62,7 +66,7 @@ object BibleAudioRepository {
                 ).execute()
                 response.use { r ->
                     if (!r.isSuccessful) return@withContext emptyList()
-                    val body = r.body?.string() ?: return@withContext emptyList()
+                    val body = r.body.string()
                     MTiming.parseList(body)
                 }
             } catch (e: Exception) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/BibleAudioRepository.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/BibleAudioRepository.kt
@@ -1,0 +1,154 @@
+package yuku.alkitab.base.util
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import yuku.alkitab.base.connection.Connections
+import yuku.alkitab.base.model.MAudio
+import yuku.alkitab.base.model.MTiming
+
+private const val TAG = "BibleAudioRepository"
+
+/**
+ * Provides audio URLs and verse timing data for supported Bible versions.
+ *
+ * Audio files are served from media.sabda.org; timing data from karaoke.sabda.org.
+ * All URL building is pure and can be called on any thread. Timing fetches are
+ * suspending and should be called from a coroutine (they switch to Dispatchers.IO).
+ */
+object BibleAudioRepository {
+
+    private const val AUDIO_BASE = "https://media.sabda.org/alkitab_audio"
+    private const val TIMING_BASE = "https://karaoke.sabda.org/api/timming.php"
+
+    /** Bible versions that have audio available on the SABDA media server. */
+    val SUPPORTED: List<MAudio> = listOf(
+        MAudio(versionId = "TB", audioFolder = "tb_alkitabsuara", supportsDual = true),
+        MAudio(versionId = "AYT", audioFolder = "ayt-ai-v2"),
+        MAudio(versionId = "AVB", audioFolder = "avb"),
+        MAudio(versionId = "KJV", audioFolder = "kjv"),
+    )
+
+    /** Returns the [MAudio] for [versionId], or null if this version has no audio. */
+    fun findAudio(versionId: String): MAudio? = SUPPORTED.find { it.versionId == versionId }
+
+    /**
+     * Builds the MP3 URL for a chapter.
+     *
+     * @param bookId  0-based book index (0 = Genesis … 65 = Revelation)
+     * @param chapter_1  1-based chapter number
+     * @param audioFolder  the [MAudio.audioFolder] value for the target version
+     * @return the fully-formed URL, or null when [bookId] is out of range
+     */
+    fun buildUrl(bookId: Int, chapter_1: Int, audioFolder: String): String? {
+        val info = BOOK_INFO.getOrNull(bookId) ?: return null
+        val bookCode = (bookId + 1).toString().padStart(2, '0')
+        val subdir = if (bookId < 39) "pl/mp3/cd" else "pb/mp3/cd"
+        val chapter = chapter_1.toString().padStart(3, '0')
+        return "$AUDIO_BASE/$audioFolder/$subdir/${bookCode}_${info.folderName}/${bookCode}_${info.abbr}$chapter.mp3"
+    }
+
+    /**
+     * Fetches verse timing data for [bookId]/[chapter_1] in [versionId].
+     * Performs a network request on [Dispatchers.IO].
+     * Returns an empty list on network or parse failure (non-fatal).
+     */
+    suspend fun fetchTiming(bookId: Int, chapter_1: Int, versionId: String): List<MTiming> {
+        val info = BOOK_INFO.getOrNull(bookId) ?: return emptyList()
+        val url = "$TIMING_BASE?book=${info.timingName}&chapter=$chapter_1&version=$versionId"
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = Connections.okHttp.newCall(
+                    okhttp3.Request.Builder().url(url).build()
+                ).execute()
+                response.use { r ->
+                    if (!r.isSuccessful) return@withContext emptyList()
+                    val body = r.body?.string() ?: return@withContext emptyList()
+                    MTiming.parseList(body)
+                }
+            } catch (e: Exception) {
+                AppLog.w(TAG, "Failed to fetch timing for bookId=$bookId chapter=$chapter_1: ${e.message}")
+                emptyList()
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Static book data – indexed by bookId (0-based, 0=Genesis … 65=Revelation)
+    // folderName : lowercase canonical short name used in the audio URL path
+    // abbr       : lowercase abbreviation used in the audio filename
+    // timingName : full Indonesian name sent as the `book` param to the timing API
+    // -----------------------------------------------------------------------
+
+    private data class BookInfo(val folderName: String, val abbr: String, val timingName: String)
+
+    private val BOOK_INFO = arrayOf(
+        // OT (bookId 0–38)
+        BookInfo("kejadian",     "kej",  "Kejadian"),         // 0  Genesis
+        BookInfo("keluaran",     "kel",  "Keluaran"),         // 1  Exodus
+        BookInfo("imamat",       "ima",  "Imamat"),           // 2  Leviticus
+        BookInfo("bilangan",     "bil",  "Bilangan"),         // 3  Numbers
+        BookInfo("ulangan",      "ula",  "Ulangan"),          // 4  Deuteronomy
+        BookInfo("yosua",        "yos",  "Yosua"),            // 5  Joshua
+        BookInfo("hakim",        "hak",  "Hakim-hakim"),      // 6  Judges
+        BookInfo("rut",          "rut",  "Rut"),              // 7  Ruth
+        BookInfo("1samuel",      "1sa",  "1 Samuel"),         // 8  1 Samuel
+        BookInfo("2samuel",      "2sa",  "2 Samuel"),         // 9  2 Samuel
+        BookInfo("1raja",        "1ra",  "1 Raja-raja"),      // 10 1 Kings
+        BookInfo("2raja",        "2ra",  "2 Raja-raja"),      // 11 2 Kings
+        BookInfo("1tawarikh",    "1ta",  "1 Tawarikh"),       // 12 1 Chronicles
+        BookInfo("2tawarikh",    "2ta",  "2 Tawarikh"),       // 13 2 Chronicles
+        BookInfo("ezra",         "ezr",  "Ezra"),             // 14 Ezra
+        BookInfo("nehemia",      "neh",  "Nehemia"),          // 15 Nehemiah
+        BookInfo("ester",        "est",  "Ester"),            // 16 Esther
+        BookInfo("ayub",         "ayb",  "Ayub"),             // 17 Job
+        BookInfo("mazmur",       "mzm",  "Mazmur"),           // 18 Psalms
+        BookInfo("amsal",        "ams",  "Amsal"),            // 19 Proverbs
+        BookInfo("pengkhotbah",  "pkh",  "Pengkhotbah"),      // 20 Ecclesiastes
+        BookInfo("kidung",       "kid",  "Kidung Agung"),     // 21 Song of Songs
+        BookInfo("yesaya",       "yes",  "Yesaya"),           // 22 Isaiah
+        BookInfo("yeremia",      "yer",  "Yeremia"),          // 23 Jeremiah
+        BookInfo("ratapan",      "rat",  "Ratapan"),          // 24 Lamentations
+        BookInfo("yehezkiel",    "yeh",  "Yehezkiel"),        // 25 Ezekiel
+        BookInfo("daniel",       "dan",  "Daniel"),           // 26 Daniel
+        BookInfo("hosea",        "hos",  "Hosea"),            // 27 Hosea
+        BookInfo("yoel",         "yoe",  "Yoel"),             // 28 Joel
+        BookInfo("amos",         "amo",  "Amos"),             // 29 Amos
+        BookInfo("obaja",        "oba",  "Obaja"),            // 30 Obadiah
+        BookInfo("yunus",        "yun",  "Yunus"),            // 31 Jonah
+        BookInfo("mikha",        "mik",  "Mikha"),            // 32 Micah
+        BookInfo("nahum",        "nah",  "Nahum"),            // 33 Nahum
+        BookInfo("habakuk",      "hab",  "Habakuk"),          // 34 Habakkuk
+        BookInfo("zefanya",      "zef",  "Zefanya"),          // 35 Zephaniah
+        BookInfo("hagai",        "hag",  "Hagai"),            // 36 Haggai
+        BookInfo("zakharia",     "zak",  "Zakharia"),         // 37 Zechariah
+        BookInfo("maleakhi",     "mal",  "Maleakhi"),         // 38 Malachi
+        // NT (bookId 39–65)
+        BookInfo("matius",       "mat",  "Matius"),           // 39 Matthew
+        BookInfo("markus",       "mrk",  "Markus"),           // 40 Mark
+        BookInfo("lukas",        "luk",  "Lukas"),            // 41 Luke
+        BookInfo("yohanes",      "yoh",  "Yohanes"),          // 42 John
+        BookInfo("kisah",        "kis",  "Kisah Para Rasul"), // 43 Acts
+        BookInfo("roma",         "rom",  "Roma"),             // 44 Romans
+        BookInfo("1korintus",    "1ko",  "1 Korintus"),       // 45 1 Corinthians
+        BookInfo("2korintus",    "2ko",  "2 Korintus"),       // 46 2 Corinthians
+        BookInfo("galatia",      "gal",  "Galatia"),          // 47 Galatians
+        BookInfo("efesus",       "efe",  "Efesus"),           // 48 Ephesians
+        BookInfo("filipi",       "fil",  "Filipi"),           // 49 Philippians
+        BookInfo("kolose",       "kol",  "Kolose"),           // 50 Colossians
+        BookInfo("1tesalonika",  "1te",  "1 Tesalonika"),     // 51 1 Thessalonians
+        BookInfo("2tesalonika",  "2te",  "2 Tesalonika"),     // 52 2 Thessalonians
+        BookInfo("1timotius",    "1ti",  "1 Timotius"),       // 53 1 Timothy
+        BookInfo("2timotius",    "2ti",  "2 Timotius"),       // 54 2 Timothy
+        BookInfo("titus",        "tit",  "Titus"),            // 55 Titus
+        BookInfo("filemon",      "flm",  "Filemon"),          // 56 Philemon
+        BookInfo("ibrani",       "ibr",  "Ibrani"),           // 57 Hebrews
+        BookInfo("yakobus",      "yak",  "Yakobus"),          // 58 James
+        BookInfo("1petrus",      "1pe",  "1 Petrus"),         // 59 1 Peter
+        BookInfo("2petrus",      "2pe",  "2 Petrus"),         // 60 2 Peter
+        BookInfo("1yohanes",     "1yo",  "1 Yohanes"),        // 61 1 John
+        BookInfo("2yohanes",     "2yo",  "2 Yohanes"),        // 62 2 John
+        BookInfo("3yohanes",     "3yo",  "3 Yohanes"),        // 63 3 John
+        BookInfo("yudas",        "yud",  "Yudas"),            // 64 Jude
+        BookInfo("wahyu",        "wah",  "Wahyu"),            // 65 Revelation
+    )
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItem.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItem.kt
@@ -52,6 +52,12 @@ class VerseItem(context: Context, attrs: AttributeSet) : RelativeLayout(context,
         ResourcesCompat.getDrawable(resources, R.drawable.item_verse_bg_draghovered, context.theme) as Drawable
     }
 
+    var audioHighlighted = false
+        set(value) {
+            field = value
+            invalidate()
+        }
+
     private val checkedPaintSolid by lazy(LazyThreadSafetyMode.NONE) {
         Paint().apply {
             style = Paint.Style.FILL
@@ -60,6 +66,12 @@ class VerseItem(context: Context, attrs: AttributeSet) : RelativeLayout(context,
     private val attentionPaint by lazy(LazyThreadSafetyMode.NONE) {
         Paint().apply {
             style = Paint.Style.FILL
+        }
+    }
+    private val audioHighlightPaint by lazy(LazyThreadSafetyMode.NONE) {
+        Paint().apply {
+            style = Paint.Style.FILL
+            color = 0x33_4FC3F7.toInt() // semi-transparent light-blue
         }
     }
 
@@ -127,6 +139,10 @@ class VerseItem(context: Context, attrs: AttributeSet) : RelativeLayout(context,
     override fun onDraw(canvas: Canvas) {
         val w = width
         val h = height
+
+        if (audioHighlighted) {
+            canvas.drawRect(0f, 0f, w.toFloat(), h.toFloat(), audioHighlightPaint)
+        }
 
         if (checked) {
             val solid = checkedPaintSolid

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
@@ -102,5 +102,11 @@ interface VersesController {
 
     fun callAttentionForVerse(verse_1: Int)
 
+    /**
+     * Highlight a verse to indicate the currently-playing audio position.
+     * Pass [verse_1] = 0 to clear any existing highlight.
+     */
+    fun setAudioHighlight(verse_1: Int)
+
     fun setEmptyMessage(message: CharSequence?, textColor: Int)
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -431,6 +431,24 @@ class VersesControllerImpl(
         layoutManager.findViewByPosition(pos)?.invalidate()
     }
 
+    override fun setAudioHighlight(verse_1: Int) {
+        val old = adapter.audioHighlightedVerse_1
+        if (old == verse_1) return
+        adapter.audioHighlightedVerse_1 = verse_1
+
+        if (old != 0) {
+            val pos = versesDataModel.getPositionIgnoringPericopeFromVerse(old)
+            if (pos != -1) adapter.notifyItemChanged(pos)
+        }
+        if (verse_1 != 0) {
+            val pos = versesDataModel.getPositionIgnoringPericopeFromVerse(verse_1)
+            if (pos != -1) {
+                adapter.notifyItemChanged(pos)
+                scrollToVerse(verse_1)
+            }
+        }
+    }
+
     override fun setEmptyMessage(message: CharSequence?, textColor: Int) {
         rv.emptyMessage = message
         rv.emptyMessagePaint.color = textColor
@@ -470,6 +488,7 @@ class VerseTextHolder(private val view: VerseItem) : ItemHolder(view) {
         checked: Boolean,
         toggleChecked: (position: Int) -> Unit,
         index: Int,
+        audioHighlighted: Boolean = false,
     ) {
         val verse_1 = index + 1
         val ari = Ari.encodeWithBc(data.ari_bc_, verse_1)
@@ -570,6 +589,8 @@ class VerseTextHolder(private val view: VerseItem) : ItemHolder(view) {
 // 					Log.d(TAG, "Span " + span.getClass().getSimpleName() + " " + start + ".." + end + ": " + sb.toString().substring(start, end));
 // 				}
 // 			}
+
+        view.audioHighlighted = audioHighlighted
 
         // Do we need to call attention?
         if (attention.hasAny() && verse_1 in attention.verses_1) {
@@ -709,6 +730,9 @@ class VersesAdapter(
         setHasStableIds(true)
     }
 
+    /** 1-based verse number currently highlighted for audio playback; 0 = none. */
+    var audioHighlightedVerse_1: Int = 0
+
     var data = VersesDataModel.EMPTY
         set(value) {
             field = value
@@ -774,7 +798,8 @@ class VersesAdapter(
         when (holder) {
             is VerseTextHolder -> {
                 val index = data.getVerse_0(position)
-                holder.bind(data, ui, listeners, attention, isChecked(position), { toggleChecked(it) }, index)
+                val audioHighlighted = audioHighlightedVerse_1 != 0 && (index + 1) == audioHighlightedVerse_1
+                holder.bind(data, ui, listeners, attention, isChecked(position), { toggleChecked(it) }, index, audioHighlighted)
             }
 
             is PericopeHolder -> {

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -444,7 +444,9 @@ class VersesControllerImpl(
             val pos = versesDataModel.getPositionIgnoringPericopeFromVerse(verse_1)
             if (pos != -1) {
                 adapter.notifyItemChanged(pos)
-                scrollToVerse(verse_1)
+                val first = layoutManager.findFirstVisibleItemPosition()
+                val last = layoutManager.findLastVisibleItemPosition()
+                if (pos < first || pos > last) scrollToVerse(verse_1)
             }
         }
     }

--- a/Alkitab/src/main/res/drawable/ic_audio_forward.xml
+++ b/Alkitab/src/main/res/drawable/ic_audio_forward.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M4,18l8.5,-6L4,6v12zm9,-12v12l8.5,-6L13,6z" />
+</vector>

--- a/Alkitab/src/main/res/drawable/ic_audio_next.xml
+++ b/Alkitab/src/main/res/drawable/ic_audio_next.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2V6h-2z" />
+</vector>

--- a/Alkitab/src/main/res/drawable/ic_audio_pause.xml
+++ b/Alkitab/src/main/res/drawable/ic_audio_pause.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6,19h4V5H6v14zm8,-14v14h4V5h-4z" />
+</vector>

--- a/Alkitab/src/main/res/drawable/ic_audio_play.xml
+++ b/Alkitab/src/main/res/drawable/ic_audio_play.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M8,5v14l11,-7z" />
+</vector>

--- a/Alkitab/src/main/res/drawable/ic_audio_prev.xml
+++ b/Alkitab/src/main/res/drawable/ic_audio_prev.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6,6h2v12H6zm3.5,6 7.5,6V6z" />
+</vector>

--- a/Alkitab/src/main/res/drawable/ic_audio_repeat.xml
+++ b/Alkitab/src/main/res/drawable/ic_audio_repeat.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M7,7h10v3l4,-4 -4,-4v3H5v6h2V7zm10,10H7v-3l-4,4 4,4v-3h12v-6h-2v5z" />
+</vector>

--- a/Alkitab/src/main/res/drawable/ic_audio_rewind.xml
+++ b/Alkitab/src/main/res/drawable/ic_audio_rewind.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M11,18V6l-8.5,6 8.5,6zm0.5,-6 8.5,6V6l-8.5,6z" />
+</vector>

--- a/Alkitab/src/main/res/drawable/ic_audio_speed.xml
+++ b/Alkitab/src/main/res/drawable/ic_audio_speed.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M20.38,8.57l-1.23,1.85a8,8 0,0 1,-0.22 7.58H5.07A8,8 0,0 1,15.58 6.85l1.85,-1.23A10,10 0,0 0,3.35 19a2,2 0,0 0,1.72 1h13.85a2,2 0,0 0,1.74 -1,10 10,0 0,0 -0.27,-10.44zM10.59 15.41a2 2,0 0,0 2.83,0L19,8l-7.41,5.59a2,2 0,0 0,-1 1.82z" />
+</vector>

--- a/Alkitab/src/main/res/layout/activity_audio.xml
+++ b/Alkitab/src/main/res/layout/activity_audio.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="56dp"
+    android:layout_height="@dimen/audio_bar_height"
     android:layout_gravity="bottom|start"
     android:elevation="8dp"
     android:background="#455A64"

--- a/Alkitab/src/main/res/layout/activity_audio.xml
+++ b/Alkitab/src/main/res/layout/activity_audio.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="56dp"
+    android:layout_gravity="bottom|start"
+    android:elevation="8dp"
+    android:background="#455A64"
+    android:gravity="center_vertical">
+
+    <ImageButton
+        android:id="@+id/button_repeat"
+        android:layout_width="40dp"
+        android:layout_height="match_parent"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:alpha="0.4"
+        android:background="?selectableItemBackground"
+        android:contentDescription="@string/audio_repeat"
+        android:src="@drawable/ic_audio_repeat"
+        android:tint="#FFFFFF" />
+
+    <ImageButton
+        android:id="@+id/button_prev_chapter"
+        android:layout_width="40dp"
+        android:layout_height="match_parent"
+        android:layout_toEndOf="@id/button_repeat"
+        android:layout_centerVertical="true"
+        android:background="?selectableItemBackground"
+        android:contentDescription="@string/desc_previous_chapter"
+        android:src="@drawable/ic_audio_prev"
+        android:tint="#FFFFFF" />
+
+    <ImageButton
+        android:id="@+id/button_prev_verse"
+        android:layout_width="40dp"
+        android:layout_height="match_parent"
+        android:layout_toEndOf="@id/button_prev_chapter"
+        android:layout_centerVertical="true"
+        android:background="?selectableItemBackground"
+        android:contentDescription="@string/audio_prev_verse"
+        android:src="@drawable/ic_audio_rewind"
+        android:tint="#FFFFFF" />
+
+    <FrameLayout
+        android:id="@+id/audio_play_container"
+        android:layout_width="56dp"
+        android:layout_height="match_parent"
+        android:layout_centerInParent="true">
+
+        <ImageButton
+            android:id="@+id/button_play"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?selectableItemBackground"
+            android:contentDescription="@string/audio_play_pause"
+            android:src="@drawable/ic_audio_play"
+            android:tint="#FFFFFF" />
+
+        <ProgressBar
+            android:id="@+id/audio_progress_bar"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_gravity="center"
+            android:indeterminate="true"
+            android:indeterminateTint="#FFFFFF"
+            android:visibility="gone" />
+
+    </FrameLayout>
+
+    <ImageButton
+        android:id="@+id/button_next_verse"
+        android:layout_width="40dp"
+        android:layout_height="match_parent"
+        android:layout_toStartOf="@id/button_next_chapter"
+        android:layout_centerVertical="true"
+        android:background="?selectableItemBackground"
+        android:contentDescription="@string/audio_next_verse"
+        android:src="@drawable/ic_audio_forward"
+        android:tint="#FFFFFF" />
+
+    <ImageButton
+        android:id="@+id/button_next_chapter"
+        android:layout_width="40dp"
+        android:layout_height="match_parent"
+        android:layout_toStartOf="@id/button_speed"
+        android:layout_centerVertical="true"
+        android:background="?selectableItemBackground"
+        android:contentDescription="@string/desc_next_chapter"
+        android:src="@drawable/ic_audio_next"
+        android:tint="#FFFFFF" />
+
+    <ImageButton
+        android:id="@+id/button_speed"
+        android:layout_width="40dp"
+        android:layout_height="match_parent"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:background="?selectableItemBackground"
+        android:contentDescription="@string/audio_speed"
+        android:src="@drawable/ic_audio_speed"
+        android:tint="#FFFFFF" />
+
+</RelativeLayout>

--- a/Alkitab/src/main/res/menu/activity_isi.xml
+++ b/Alkitab/src/main/res/menu/activity_isi.xml
@@ -7,4 +7,10 @@
 		android:icon="@drawable/ic_menu_search"
 		app:showAsAction="always"
 		android:title="@string/search" />
+
+	<item
+		android:id="@+id/menuAudio"
+		android:icon="@drawable/ic_audio_play"
+		app:showAsAction="ifRoom"
+		android:title="@string/audio" />
 </menu>

--- a/Alkitab/src/main/res/values/dimens.xml
+++ b/Alkitab/src/main/res/values/dimens.xml
@@ -4,4 +4,5 @@
 	<dimen name="panel_text_appearance_width">240dp</dimen>
 	<dimen name="reading_plan_day_heading_side_padding">0dp</dimen>
 	<dimen name="left_drawer_width">280dp</dimen>
+	<dimen name="audio_bar_height">56dp</dimen>
 </resources>

--- a/Alkitab/src/main/res/values/strings.xml
+++ b/Alkitab/src/main/res/values/strings.xml
@@ -578,6 +578,7 @@
 	<string name="audio_next_verse">Next verse</string>
 	<string name="audio_repeat">Repeat chapter</string>
 	<string name="audio_speed">Playback speed</string>
+	<string name="audio_speed_normal">1.0× (normal)</string>
 	<string name="audio_not_available_for_version">Audio is not available for this Bible version</string>
 
 </resources>

--- a/Alkitab/src/main/res/values/strings.xml
+++ b/Alkitab/src/main/res/values/strings.xml
@@ -571,4 +571,13 @@
 	<string name="notification_channel_download_mapper_name">Downloads</string>
 	<string name="notification_channel_devotion_downloader_name">Devotion downloads</string>
 
+	<!-- Bible audio playback -->
+	<string name="audio">Audio</string>
+	<string name="audio_play_pause">Play/Pause audio</string>
+	<string name="audio_prev_verse">Previous verse</string>
+	<string name="audio_next_verse">Next verse</string>
+	<string name="audio_repeat">Repeat chapter</string>
+	<string name="audio_speed">Playback speed</string>
+	<string name="audio_not_available_for_version">Audio is not available for this Bible version</string>
+
 </resources>


### PR DESCRIPTION
## Summary

- Adds `BibleAudioPlayer` (ExoPlayer wrapper), `AudioPlaybackController`, `BibleAudioRepository`, and `MAudio`/`MTiming` models to support chapter audio playback from media.sabda.org
- Audio bar (play/pause, prev/next verse, prev/next chapter, speed, repeat) is toggled from a new toolbar icon in `IsiActivity`
- Real-time verse highlighting is synced to timing data from karaoke.sabda.org; supports both single-stream and dual-stream (split-view interleaved) modes
- `VerseItem` gains an `audioHighlighted` state drawn as a semi-transparent blue overlay; `VersesController` gains `setAudioHighlight(verse_1)`

## Test plan

- [ ] Open any chapter for a supported version (TB, AYT, AVB, KJV) and tap the Audio toolbar icon — audio bar should appear
- [ ] Press play; verse highlight should advance in sync with playback
- [ ] Tap prev/next verse buttons to seek between verses
- [ ] Tap prev/next chapter buttons to navigate chapters; audio should reload
- [ ] Test repeat mode (chapter restarts on end) and speed menu
- [ ] Open split view with two supported versions and verify dual-stream interleaved playback highlights both panes
- [ ] Tap Audio icon again to close the bar; highlight should clear
- [ ] Rotate device / navigate away and back — no crash, no leaked ExoPlayer

🤖 Generated with [Claude Code](https://claude.com/claude-code)