### PR TITLE
Replace Preferences.hold/unhold with withTransaction helper

### DIFF
--- a/Afw/src/main/java/yuku/afw/storage/Preferences.java
+++ b/Afw/src/main/java/yuku/afw/storage/Preferences.java
@@ -232,6 +232,19 @@ public class Preferences {
 		}
 	}
 
+	/**
+	 * Batches all preference writes inside {@code block} into a single commit.
+	 * Guarantees {@link #unhold()} is called even if {@code block} throws.
+	 */
+	public static void withTransaction(Runnable block) {
+		hold();
+		try {
+			block.run();
+		} finally {
+			unhold();
+		}
+	}
+
 	public synchronized static void hold() {
 		held++;
 	}

--- a/Afw/src/main/java/yuku/afw/storage/Preferences.java
+++ b/Afw/src/main/java/yuku/afw/storage/Preferences.java
@@ -245,11 +245,11 @@ public class Preferences {
 		}
 	}
 
-	public synchronized static void hold() {
+	private synchronized static void hold() {
 		held++;
 	}
 
-	public synchronized static void unhold() {
+	private synchronized static void unhold() {
 		if (held <= 0) {
 			throw new RuntimeException("unhold called too many times");
 		}

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -1768,8 +1768,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
     override fun onStop() {
         super.onStop()
 
-        Preferences.hold()
-        try {
+        Preferences.withTransaction {
             Preferences.setInt(Prefkey.lastBookId, activeSplit0.book.bookId)
             Preferences.setInt(Prefkey.lastChapter, chapter_1)
             Preferences.setInt(Prefkey.lastVerse, getVerse_1BasedOnScrolls())
@@ -1781,8 +1780,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
                 Preferences.setString(Prefkey.lastSplitVersionId, activeSplit1.versionId)
                 Preferences.setString(Prefkey.lastSplitOrientation, splitHandleButton.orientation.name)
             }
-        } finally {
-            Preferences.unhold()
         }
 
         history.save()

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/SecretSyncDebugActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/SecretSyncDebugActivity.kt
@@ -309,11 +309,11 @@ class SecretSyncDebugActivity : BaseActivity() {
     }
 
     private var bLogout_click = View.OnClickListener {
-        Preferences.hold()
-        Preferences.remove(getString(R.string.pref_syncAccountName_key))
-        Preferences.remove(Prefkey.sync_simpleToken)
-        Preferences.remove(Prefkey.sync_token_obtained_time)
-        Preferences.unhold()
+        Preferences.withTransaction {
+            Preferences.remove(getString(R.string.pref_syncAccountName_key))
+            Preferences.remove(Prefkey.sync_simpleToken)
+            Preferences.remove(Prefkey.sync_token_obtained_time)
+        }
 
         for (syncSetName in SyncShadow.ALL_SYNC_SET_NAMES) {
             S.db.deleteSyncShadowBySyncSetName(syncSetName)

--- a/Alkitab/src/main/java/yuku/alkitab/base/appwidget/DailyVerseData.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/appwidget/DailyVerseData.java
@@ -173,8 +173,7 @@ public abstract class DailyVerseData {
 	 * @param savedState null to delete saved state for the specified appWidgetId.
 	 */
 	public static void saveSavedState(final int appWidgetId, final SavedState savedState) {
-		Preferences.hold();
-		try {
+		Preferences.withTransaction(() -> {
 			if (savedState == null) {
 				Preferences.remove("app_widget_" + appWidgetId + "_option_dark_text");
 				Preferences.remove("app_widget_" + appWidgetId + "_option_hide_app_icon");
@@ -192,8 +191,6 @@ public abstract class DailyVerseData {
 				Preferences.setInt("app_widget_" + appWidgetId + "_click", savedState.click);
 				Preferences.setInt("app_widget_" + appWidgetId + "_option_backgroundAlpha", savedState.backgroundAlpha);
 			}
-		} finally {
-			Preferences.unhold();
-		}
+		});
 	}
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/InternalDbHelper.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/InternalDbHelper.java
@@ -595,68 +595,68 @@ public class InternalDbHelper extends SQLiteOpenHelper {
 
         db.beginTransaction();
         try {
-            Preferences.hold();
-            final ContentValues cv = new ContentValues();
-            int ordering = MVersionDb.DEFAULT_ORDERING_START;
+            Preferences.withTransaction(() -> {
+                final ContentValues cv = new ContentValues();
+                final int[] ordering = {MVersionDb.DEFAULT_ORDERING_START};
 
-            /*
-             * Automatically add v3 preset versions as {@link yuku.alkitab.base.storage.Db.Version} table rows,
-             * if there are files with the same preset_name as those defined in {@link yuku.alkitab.base.config.VersionConfig}.
-             * In version 3, preset versions are not stored in the database. In version 4, they are.
-             */
-            {
-                final VersionConfig vc = VersionConfig.get();
-                for (final MVersionPreset mv : vc.presets) {
-                    final File yesFile = AddonManager.getReadableVersionFile(mv.preset_name + ".yes");
-                    if (yesFile != null) {
+                /*
+                 * Automatically add v3 preset versions as {@link yuku.alkitab.base.storage.Db.Version} table rows,
+                 * if there are files with the same preset_name as those defined in {@link yuku.alkitab.base.config.VersionConfig}.
+                 * In version 3, preset versions are not stored in the database. In version 4, they are.
+                 */
+                {
+                    final VersionConfig vc = VersionConfig.get();
+                    for (final MVersionPreset mv : vc.presets) {
+                        final File yesFile = AddonManager.getReadableVersionFile(mv.preset_name + ".yes");
+                        if (yesFile != null) {
+                            cv.clear();
+                            cv.put(Db.Version.locale, mv.locale);
+                            cv.put(Db.Version.shortName, mv.shortName);
+                            cv.put(Db.Version.longName, mv.longName);
+                            cv.put(Db.Version.description, mv.description);
+                            cv.put(Db.Version.filename, yesFile.getAbsolutePath());
+                            cv.put(Db.Version.preset_name, mv.preset_name);
+                            cv.put(Db.Version.modifyTime, (int) (yesFile.lastModified() / 1000L));
+                            cv.put(Db.Version.active, Preferences.getBoolean("edisi/preset/" + mv.preset_name + ".yes/aktif", true) ? 1 : 0);
+                            cv.put(Db.Version.ordering, ++ordering[0]);
+                            db.insert(Db.TABLE_Version, null, cv);
+                        }
+                    }
+                }
+
+                { // Remove all preferences about active state of preset versions. We don't need them any more.
+                    for (String key : Preferences.getAllKeys()) {
+                        if (key.startsWith("edisi/preset/") && key.endsWith(".yes/aktif")) {
+                            Preferences.remove(key);
+                        }
+                    }
+                }
+
+                { // Edisi -> Version
+                    final Cursor c = db.query(TABLE_Edisi,
+                        new String[]{Edisi.shortName, Edisi.title, Edisi.description, Edisi.filename, Edisi.active},
+                        null, null, null, null, Edisi.ordering + " asc"
+                    );
+                    while (c.moveToNext()) {
                         cv.clear();
-                        cv.put(Db.Version.locale, mv.locale);
-                        cv.put(Db.Version.shortName, mv.shortName);
-                        cv.put(Db.Version.longName, mv.longName);
-                        cv.put(Db.Version.description, mv.description);
-                        cv.put(Db.Version.filename, yesFile.getAbsolutePath());
-                        cv.put(Db.Version.preset_name, mv.preset_name);
-                        cv.put(Db.Version.modifyTime, (int) (yesFile.lastModified() / 1000L));
-                        cv.put(Db.Version.active, Preferences.getBoolean("edisi/preset/" + mv.preset_name + ".yes/aktif", true) ? 1 : 0);
-                        cv.put(Db.Version.ordering, ++ordering);
+                        cv.put(Db.Version.locale, (String) null);
+                        cv.put(Db.Version.shortName, c.getString(0));
+                        cv.put(Db.Version.longName, c.getString(1));
+                        cv.put(Db.Version.description, c.getString(2));
+                        cv.put(Db.Version.filename, c.getString(3));
+                        cv.put(Db.Version.active, c.getInt(4));
+                        cv.put(Db.Version.ordering, ++ordering[0]);
                         db.insert(Db.TABLE_Version, null, cv);
                     }
-                }
-            }
 
-            { // Remove all preferences about active state of preset versions. We don't need them any more.
-                for (String key : Preferences.getAllKeys()) {
-                    if (key.startsWith("edisi/preset/") && key.endsWith(".yes/aktif")) {
-                        Preferences.remove(key);
-                    }
-                }
-            }
-
-            { // Edisi -> Version
-                final Cursor c = db.query(TABLE_Edisi,
-                    new String[]{Edisi.shortName, Edisi.title, Edisi.description, Edisi.filename, Edisi.active},
-                    null, null, null, null, Edisi.ordering + " asc"
-                );
-                while (c.moveToNext()) {
-                    cv.clear();
-                    cv.put(Db.Version.locale, (String) null);
-                    cv.put(Db.Version.shortName, c.getString(0));
-                    cv.put(Db.Version.longName, c.getString(1));
-                    cv.put(Db.Version.description, c.getString(2));
-                    cv.put(Db.Version.filename, c.getString(3));
-                    cv.put(Db.Version.active, c.getInt(4));
-                    cv.put(Db.Version.ordering, ++ordering);
-                    db.insert(Db.TABLE_Version, null, cv);
+                    c.close();
                 }
 
-                c.close();
-            }
-
-            db.execSQL("drop table " + TABLE_Edisi);
+                db.execSQL("drop table " + TABLE_Edisi);
+            });
 
             db.setTransactionSuccessful();
         } finally {
-            Preferences.unhold();
             db.endTransaction();
         }
     }

--- a/Alkitab/src/main/java/yuku/alkitab/base/sync/SyncSettingsActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/sync/SyncSettingsActivity.java
@@ -126,16 +126,15 @@ public class SyncSettingsActivity extends BaseActivity {
 					() -> {
 						SyncRecorder.log(SyncRecorder.EventKind.logout_pre, null, "accountName", syncAccountName);
 
-						Preferences.hold();
-						Preferences.remove(getString(R.string.pref_syncAccountName_key));
-						Preferences.remove(Prefkey.sync_simpleToken);
-						Preferences.remove(Prefkey.sync_token_obtained_time);
+						Preferences.withTransaction(() -> {
+							Preferences.remove(getString(R.string.pref_syncAccountName_key));
+							Preferences.remove(Prefkey.sync_simpleToken);
+							Preferences.remove(Prefkey.sync_token_obtained_time);
 
-						for (final String syncSetName : SyncShadow.ALL_SYNC_SET_NAMES) {
-							S.getDb().deleteSyncShadowBySyncSetName(syncSetName);
-						}
-
-						Preferences.unhold();
+							for (final String syncSetName : SyncShadow.ALL_SYNC_SET_NAMES) {
+								S.getDb().deleteSyncShadowBySyncSetName(syncSetName);
+							}
+						});
 
 						SyncRecorder.removeAllLastSuccessTimes();
 
@@ -161,11 +160,11 @@ public class SyncSettingsActivity extends BaseActivity {
 					// Success!
 					SyncRecorder.log(SyncRecorder.EventKind.login_success_pre, null, "accountName", result.accountName);
 
-					Preferences.hold();
-					Preferences.setString(R.string.pref_syncAccountName_key, result.accountName);
-					Preferences.setString(Prefkey.sync_simpleToken, result.simpleToken);
-					Preferences.setInt(Prefkey.sync_token_obtained_time, Sqlitil.nowDateTime());
-					Preferences.unhold();
+					Preferences.withTransaction(() -> {
+						Preferences.setString(R.string.pref_syncAccountName_key, result.accountName);
+						Preferences.setString(Prefkey.sync_simpleToken, result.simpleToken);
+						Preferences.setInt(Prefkey.sync_token_obtained_time, Sqlitil.nowDateTime());
+					});
 
 					SyncRecorder.log(SyncRecorder.EventKind.login_success_post, null, "accountName", result.accountName);
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/CurrentReading.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/CurrentReading.java
@@ -12,25 +12,19 @@ public class CurrentReading {
 	public static final String ACTION_CURRENT_READING_CHANGED = CurrentReading.class.getName() + ".action.CURRENT_READING_CHANGED";
 
 	public static void set(final int ari_start, final int ari_end) {
-		Preferences.hold();
-		try {
+		Preferences.withTransaction(() -> {
 			Preferences.setInt(Prefkey.current_reading_ari_start, ari_start);
 			Preferences.setInt(Prefkey.current_reading_ari_end, ari_end);
-		} finally {
-			Preferences.unhold();
-		}
+		});
 
 		App.getLbm().sendBroadcast(new Intent(ACTION_CURRENT_READING_CHANGED));
 	}
 
 	public static void clear() {
-		Preferences.hold();
-		try {
+		Preferences.withTransaction(() -> {
 			Preferences.remove(Prefkey.current_reading_ari_start);
 			Preferences.remove(Prefkey.current_reading_ari_end);
-		} finally {
-			Preferences.unhold();
-		}
+		});
 
 		App.getLbm().sendBroadcast(new Intent(ACTION_CURRENT_READING_CHANGED));
 	}


### PR DESCRIPTION
## Summary
Refactored preference transaction handling by introducing a new `Preferences.withTransaction()` helper method that encapsulates the hold/unhold pattern, improving code clarity and reducing boilerplate.

## Key Changes
- Added `Preferences.withTransaction(Runnable block)` method in the Afw library that automatically calls `hold()` before executing the block and `unhold()` in a finally block, guaranteeing cleanup even if an exception occurs
- Replaced all manual `Preferences.hold()`/`Preferences.unhold()` patterns with calls to `withTransaction()` across multiple files:
  - `InsiActivity.kt`: Preference writes in `onStop()`
  - `CurrentReading.java`: Preference updates in `set()` and `clear()` methods
  - `DailyVerseData.java`: Widget state persistence in `saveSavedState()`
  - `SyncSettingsActivity.java`: Account logout and login preference handling
  - `SecretSyncDebugActivity.kt`: Debug logout functionality
  - `InternalDbHelper.java`: Database migration with preference cleanup

## Implementation Details
- The new `withTransaction()` method uses a try-finally block to ensure `unhold()` is always called, even if the runnable throws an exception
- This eliminates the need for explicit try-finally blocks in calling code
- The refactoring maintains the same transactional semantics while reducing code duplication and improving readability
- In `InternalDbHelper.java`, the ordering variable was converted to a single-element array to allow modification within the lambda closure

https://claude.ai/code/session_01K9KsMAcFw94WsZ2WrPqPZD