### PR TITLE
Extract IsiActivity action mode into VerseActionModeController (REM-07)

### DIFF
--- a/Alkitab/build.gradle
+++ b/Alkitab/build.gradle
@@ -162,6 +162,12 @@ android {
         buildConfig = true
     }
 
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+
     // We have to specify the ndk version twice, in here and in the Snappy library
     // https://issuetracker.google.com/issues/353554169
     ndkVersion '28.2.13676358'
@@ -327,6 +333,9 @@ dependencies {
 
     // Tests
     testImplementation "junit:junit:$junitVersion"
+    testImplementation "io.mockk:mockk:$mockkVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "androidx.test:core:1.6.1"
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakcanaryVersion"
 
     // Firebase

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -2,7 +2,6 @@ package yuku.alkitab.base
 
 import android.content.ActivityNotFoundException
 import android.content.BroadcastReceiver
-import android.content.ComponentName
 import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
@@ -35,7 +34,6 @@ import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.SwitchCompat
 import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
-import androidx.core.app.ShareCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
 import androidx.core.net.toUri
@@ -64,11 +62,13 @@ import yuku.alkitab.base.ac.MarkersActivity
 import yuku.alkitab.base.ac.NoteActivity
 import yuku.alkitab.base.ac.SearchActivity
 import yuku.alkitab.base.ac.base.BaseLeftDrawerActivity
-import yuku.alkitab.base.config.AppConfig
+import yuku.alkitab.base.actionmode.RibkaEligibility
+import yuku.alkitab.base.actionmode.VerseActionModeActions
+import yuku.alkitab.base.actionmode.VerseActionModeController
+import yuku.alkitab.base.actionmode.VerseActionModeHost
 import yuku.alkitab.base.dialog.ProgressMarkListDialog
 import yuku.alkitab.base.dialog.ProgressMarkRenameDialog
 import yuku.alkitab.base.dialog.TypeBookmarkDialog
-import yuku.alkitab.base.dialog.TypeHighlightDialog
 import yuku.alkitab.base.dialog.VersesDialog
 import yuku.alkitab.base.dialog.XrefDialog
 import yuku.alkitab.base.model.MVersion
@@ -78,17 +78,13 @@ import yuku.alkitab.base.storage.Prefkey
 import yuku.alkitab.base.util.AppLog
 import yuku.alkitab.base.util.Appearances
 import yuku.alkitab.base.util.BackForwardListController
-import yuku.alkitab.base.util.ClipboardUtil
 import yuku.alkitab.base.util.CurrentReading
-import yuku.alkitab.base.util.ExtensionManager
-import yuku.alkitab.base.util.FormattedVerseText
 import yuku.alkitab.base.util.History
 import yuku.alkitab.base.util.InstallationUtil
 import yuku.alkitab.base.util.Jumper
 import yuku.alkitab.base.util.LidToAri
 import yuku.alkitab.base.util.OtherAppIntegration
 import yuku.alkitab.base.util.RequestCodes
-import yuku.alkitab.base.util.ShareUrl
 import yuku.alkitab.base.util.Sqlitil
 import yuku.alkitab.base.util.TargetDecoder
 import yuku.alkitab.base.util.safeQuery
@@ -115,7 +111,6 @@ import yuku.alkitab.base.widget.TextAppearancePanel
 import yuku.alkitab.base.widget.TwofingerLinearLayout
 import yuku.alkitab.base.widget.VerseInlineLinkSpan
 import yuku.alkitab.base.widget.VerseRenderer
-import yuku.alkitab.base.widget.VerseRendererJavaHelper
 import yuku.alkitab.debug.BuildConfig
 import yuku.alkitab.debug.R
 import yuku.alkitab.model.Book
@@ -123,7 +118,6 @@ import yuku.alkitab.model.Marker
 import yuku.alkitab.model.PericopeBlock
 import yuku.alkitab.model.SingleChapterVerses
 import yuku.alkitab.model.Version
-import yuku.alkitab.ribka.RibkaReportActivity
 import yuku.alkitab.util.Ari
 import yuku.alkitab.util.IntArrayList
 import yuku.alkitab.versionmanager.VersionsActivity
@@ -133,9 +127,29 @@ private const val TAG = "IsiActivity"
 private const val EXTRA_verseUrl = "verseUrl"
 private const val INSTANCE_STATE_ari = "ari"
 
-class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
-    var uncheckVersesWhenActionModeDestroyed = true
+class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseActionModeHost, VerseActionModeActions {
+    override var uncheckVersesWhenActionModeDestroyed = true
     var needsRestart = false // whether this activity needs to be restarted
+
+    private val actionModeController by lazy { VerseActionModeController(this, this) }
+
+    // --- VerseActionModeHost overrides ---
+    // Thin read-only accessors so the controller can reach the Activity's state
+    // without pulling the whole Activity type into its API.
+    override val activity: androidx.appcompat.app.AppCompatActivity get() = this
+    override val activeSplit0Book: Book get() = activeSplit0.book
+    override val activeSplit0Version: Version get() = activeSplit0.version
+    override val activeSplit0VersionId: String get() = activeSplit0.versionId
+    override val activeSplit0MVersion: MVersion get() = activeSplit0.mv
+    override val activeSplit1Version: Version? get() = activeSplit1?.version
+    override val activeSplit1MVersion: MVersion? get() = activeSplit1?.mv
+    override fun activeSplit1BookById(bookId: Int): Book? = activeSplit1?.version?.getBook(bookId)
+    override val selectedVersesSplit0_1: IntArrayList get() = lsSplit0.getCheckedVerses_1()
+    override val selectedVersesSplit1_1: IntArrayList get() = lsSplit1.getCheckedVerses_1()
+
+    // --- VerseActionModeActions overrides ---
+    override fun uncheckAllVersesSplit0() { lsSplit0.uncheckAllVerses(true) }
+    override fun onActionModeDestroyed() { actionMode = null }
 
     private val bGoto_floaterDrag = object : GotoButton.FloaterDragListener {
         val floaterLocationOnScreen = intArrayOf(0, 0)
@@ -240,7 +254,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
     lateinit var leftDrawer: LeftDrawer.Text
 
     private lateinit var overlayContainer: FrameLayout
-    lateinit var root: ViewGroup
+    override lateinit var root: ViewGroup
     lateinit var toolbar: Toolbar
     private lateinit var nontoolbar: View
     lateinit var lsSplit0: VersesController
@@ -255,13 +269,13 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
     private lateinit var backForwardListController: BackForwardListController<ImageButton, ImageButton>
     private var fullscreenReferenceToast: Toast? = null
 
-    private var dataSplit0 = VersesDataModel.EMPTY
+    override var dataSplit0 = VersesDataModel.EMPTY
         set(value) {
             field = value
             lsSplit0.versesDataModel = value
         }
 
-    private var dataSplit1 = VersesDataModel.EMPTY
+    override var dataSplit1 = VersesDataModel.EMPTY
         set(value) {
             field = value
             lsSplit1.versesDataModel = value
@@ -279,7 +293,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
             lsSplit1.versesUiModel = value
         }
 
-    var chapter_1 = 0
+    override var chapter_1 = 0
     private var fullScreen = false
 
     val history get() = History
@@ -292,7 +306,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
      * The following "esvsbasal" thing is a personal thing by yuku that doesn't matter to anyone else.
      * Please ignore it and leave it intact.
      */
-    val hasEsvsbAsal by lazy {
+    override val hasEsvsbAsal by lazy {
         try {
             packageManager.getApplicationInfo("yuku.esvsbasal", 0)
             true
@@ -467,7 +481,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
             }
 
             if (actionMode == null) {
-                actionMode = startSupportActionMode(actionMode_callback)
+                actionMode = startSupportActionMode(actionModeController)
             }
 
             actionMode?.invalidate()
@@ -521,506 +535,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
         }
     }
 
-    val actionMode_callback = object : ActionMode.Callback {
-        private val MENU_GROUP_EXTENSIONS = Menu.FIRST + 1
-        private val MENU_EXTENSIONS_FIRST_ID = 0x1000
-
-        val extensions = mutableListOf<ExtensionManager.Info>()
-
-        override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
-            menuInflater.inflate(R.menu.context_isi, menu)
-
-            AppLog.d(TAG, "@@onCreateActionMode")
-
-            if (hasEsvsbAsal) {
-                val esvsb = menu.findItem(R.id.menuEsvsb)
-                esvsb?.isVisible = true
-            }
-
-            // show book name and chapter
-            val reference = activeSplit0.book.reference(chapter_1)
-            mode.title = reference
-
-            return true
-        }
-
-        override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
-            val menuAddBookmark = menu.findItem(R.id.menuAddBookmark)
-            val menuAddNote = menu.findItem(R.id.menuAddNote)
-            val menuCompare = menu.findItem(R.id.menuCompare)
-
-            val selected = lsSplit0.getCheckedVerses_1()
-            val single = selected.size() == 1
-
-            // For unknown reasons the size of selected can be zero and get(0) causes crash.
-            // https://console.firebase.google.com/u/0/project/alkitab-host-hrd/crashlytics/app/android:yuku.alkitab/issues/cc11d3466c89303f88b9e27ab3fdd534
-            if (selected.size() == 0) {
-                AppLog.e(TAG, "@@onPrepareActionMode checked verses is empty.")
-                mode.finish()
-                return true
-            }
-
-            var contiguous = true
-            if (!single) {
-                var next = selected.get(0) + 1
-                var i = 1
-                val len = selected.size()
-                while (i < len) {
-                    val cur = selected.get(i)
-                    if (next != cur) {
-                        contiguous = false
-                        break
-                    }
-                    next = cur + 1
-                    i++
-                }
-            }
-
-            menuAddBookmark.isVisible = contiguous
-            menuAddNote.isVisible = contiguous
-            menuCompare.isVisible = single
-
-            // just "copy" or ("copy primary" "copy secondary" "copy both")
-            // same with "share".
-            val menuCopy = menu.findItem(R.id.menuCopy)
-            val menuCopySplit0 = menu.findItem(R.id.menuCopySplit0)
-            val menuCopySplit1 = menu.findItem(R.id.menuCopySplit1)
-            val menuCopyBothSplits = menu.findItem(R.id.menuCopyBothSplits)
-            val menuShare = menu.findItem(R.id.menuShare)
-            val menuShareSplit0 = menu.findItem(R.id.menuShareSplit0)
-            val menuShareSplit1 = menu.findItem(R.id.menuShareSplit1)
-            val menuShareBothSplits = menu.findItem(R.id.menuShareBothSplits)
-
-            val split = activeSplit1 != null
-
-            menuCopy.isVisible = !split
-            menuCopySplit0.isVisible = split
-            menuCopySplit1.isVisible = split
-            menuCopyBothSplits.isVisible = split
-            menuShare.isVisible = !split
-            menuShareSplit0.isVisible = split
-            menuShareSplit1.isVisible = split
-            menuShareBothSplits.isVisible = split
-
-            // show selected verses
-            if (single) {
-                mode.setSubtitle(R.string.verse_select_one_verse_selected)
-            } else {
-                mode.subtitle = getString(R.string.verse_select_multiple_verse_selected, selected.size().toString())
-            }
-
-            val menuGuide = menu.findItem(R.id.menuGuide)
-            val menuCommentary = menu.findItem(R.id.menuCommentary)
-            val menuDictionary = menu.findItem(R.id.menuDictionary)
-
-            // force-show these items on sw600dp, otherwise never show
-            val showAsAction = if (resources.configuration.smallestScreenWidthDp >= 600) MenuItem.SHOW_AS_ACTION_ALWAYS else MenuItem.SHOW_AS_ACTION_NEVER
-            menuGuide.setShowAsActionFlags(showAsAction)
-            menuCommentary.setShowAsActionFlags(showAsAction)
-            menuDictionary.setShowAsActionFlags(showAsAction)
-
-            // set visibility according to appconfig
-            val c = AppConfig.get()
-            menuGuide.isVisible = c.menuGuide
-            menuCommentary.isVisible = c.menuCommentary
-
-            // do not show dictionary item if not needed because of auto-lookup from
-            menuDictionary.isVisible = c.menuDictionary && !Preferences.getBoolean(getString(R.string.pref_autoDictionaryAnalyze_key), resources.getBoolean(R.bool.pref_autoDictionaryAnalyze_default))
-
-            val menuRibkaReport = menu.findItem(R.id.menuRibkaReport)
-            menuRibkaReport.isVisible = single && checkRibkaEligibility() != RibkaEligibility.None
-
-            // extensions
-            extensions.clear()
-            extensions.addAll(ExtensionManager.getExtensions())
-
-            menu.removeGroup(MENU_GROUP_EXTENSIONS)
-
-            for ((i, extension) in extensions.withIndex()) {
-                if (single || /* not single */ extension.supportsMultipleVerses) {
-                    menu.add(MENU_GROUP_EXTENSIONS, MENU_EXTENSIONS_FIRST_ID + i, 0, extension.label)
-                }
-            }
-
-            return true
-        }
-
-        override fun onActionItemClicked(mode: ActionMode, item: MenuItem): Boolean {
-            val selected = lsSplit0.getCheckedVerses_1()
-
-            if (selected.size() == 0) return true
-
-            return when (val itemId = item.itemId) {
-                R.id.menuCopy, R.id.menuCopySplit0, R.id.menuCopySplit1, R.id.menuCopyBothSplits -> {
-                    // copy, can be multiple verses
-                    val reference = referenceFromSelectedVerses(selected, activeSplit0.book)
-                    val activeSplit1 = activeSplit1
-                    val t = if (itemId == R.id.menuCopy || itemId == R.id.menuCopySplit0 || itemId == R.id.menuCopyBothSplits || activeSplit1 == null) {
-                        prepareTextForCopyShare(selected, reference, false)
-                    } else { // menuCopySplit1, do not use split0 reference
-                        val book = activeSplit1.version.getBook(activeSplit0.book.bookId) ?: activeSplit0.book
-                        prepareTextForCopyShare(selected, referenceFromSelectedVerses(selected, book), true)
-                    }
-
-                    if (itemId == R.id.menuCopyBothSplits && activeSplit1 != null) {
-                        val book = activeSplit1.version.getBook(activeSplit0.book.bookId) ?: activeSplit0.book
-                        appendSplitTextForCopyShare(book, lsSplit1.getCheckedVerses_1(), t)
-                    }
-
-                    val textToCopy = t[0]
-                    val textToSubmit = t[1]
-
-                    ShareUrl.make(
-                        activity = this@IsiActivity,
-                        immediatelyCancel = !Preferences.getBoolean(getString(R.string.pref_copyWithShareUrl_key), resources.getBoolean(R.bool.pref_copyWithShareUrl_default)),
-                        verseText = textToSubmit,
-                        ari_bc = Ari.encode(activeSplit0.book.bookId, chapter_1, 0),
-                        selectedVerses_1 = selected,
-                        reference = reference,
-                        version = activeSplit0.version,
-                        preset_name = MVersionDb.presetNameFromVersionId(activeSplit0.versionId),
-                        callback = object : ShareUrl.Callback {
-                            override fun onSuccess(shareUrl: String) {
-                                ClipboardUtil.copyToClipboard("$textToCopy\n\n$shareUrl")
-                            }
-
-                            override fun onUserCancel() {
-                                ClipboardUtil.copyToClipboard(textToCopy)
-                            }
-
-                            override fun onError(e: Exception) {
-                                AppLog.e(TAG, "Error in ShareUrl, copying without shareUrl", e)
-                                ClipboardUtil.copyToClipboard(textToCopy)
-                            }
-
-                            override fun onFinally() {
-                                lsSplit0.uncheckAllVerses(true)
-
-                                Snackbar.make(root, getString(R.string.alamat_sudah_disalin, reference), Snackbar.LENGTH_SHORT).show()
-                                mode.finish()
-                            }
-                        }
-                    )
-
-                    true
-                }
-
-                R.id.menuShare, R.id.menuShareSplit0, R.id.menuShareSplit1, R.id.menuShareBothSplits -> {
-                    // share, can be multiple verses
-                    val reference = referenceFromSelectedVerses(selected, activeSplit0.book)
-                    val activeSplit1 = activeSplit1
-
-                    val t = if (itemId == R.id.menuShare || itemId == R.id.menuShareSplit0 || itemId == R.id.menuShareBothSplits || activeSplit1 == null) {
-                        prepareTextForCopyShare(selected, reference, false)
-                    } else { // menuShareSplit1, do not use split0 reference
-                        val book = activeSplit1.version.getBook(activeSplit0.book.bookId) ?: activeSplit0.book
-                        prepareTextForCopyShare(selected, referenceFromSelectedVerses(selected, book), true)
-                    }
-
-                    if (itemId == R.id.menuShareBothSplits && activeSplit1 != null) {
-                        val book = activeSplit1.version.getBook(activeSplit0.book.bookId) ?: activeSplit0.book
-                        appendSplitTextForCopyShare(book, lsSplit1.getCheckedVerses_1(), t)
-                    }
-
-                    val textToShare = t[0]
-                    val textToSubmit = t[1]
-
-                    val intent = ShareCompat.IntentBuilder(this@IsiActivity)
-                        .setType("text/plain")
-                        .setSubject(reference)
-                        .intent
-
-                    ShareUrl.make(
-                        activity = this@IsiActivity,
-                        immediatelyCancel = !Preferences.getBoolean(getString(R.string.pref_copyWithShareUrl_key), resources.getBoolean(R.bool.pref_copyWithShareUrl_default)),
-                        verseText = textToSubmit,
-                        ari_bc = Ari.encode(activeSplit0.book.bookId, chapter_1, 0),
-                        selectedVerses_1 = selected,
-                        reference = reference,
-                        version = activeSplit0.version,
-                        preset_name = MVersionDb.presetNameFromVersionId(activeSplit0.versionId),
-                        callback = object : ShareUrl.Callback {
-                            override fun onSuccess(shareUrl: String) {
-                                intent.putExtra(Intent.EXTRA_TEXT, "$textToShare\n\n$shareUrl")
-                                intent.putExtra(EXTRA_verseUrl, shareUrl)
-                            }
-
-                            override fun onUserCancel() {
-                                intent.putExtra(Intent.EXTRA_TEXT, textToShare)
-                            }
-
-                            override fun onError(e: Exception) {
-                                AppLog.e(TAG, "Error in ShareUrl, sharing without shareUrl", e)
-                                intent.putExtra(Intent.EXTRA_TEXT, textToShare)
-                            }
-
-                            override fun onFinally() {
-                                startActivity(Intent.createChooser(intent, getString(R.string.bagikan_alamat, reference)))
-
-                                lsSplit0.uncheckAllVerses(true)
-                                mode.finish()
-                            }
-                        }
-                    )
-                    true
-                }
-
-                R.id.menuCompare -> {
-                    val ari = Ari.encode(activeSplit0.book.bookId, this@IsiActivity.chapter_1, selected.get(0))
-                    val dialog = VersesDialog.newCompareInstance(ari)
-                    dialog.listener = object : VersesDialog.VersesDialogListener() {
-                        override fun onComparedVerseSelected(ari: Int, mversion: MVersion) {
-                            loadVersion(mversion)
-                            dialog.dismiss()
-                        }
-                    }
-
-                    // Allow state loss to prevent
-                    // https://console.firebase.google.com/u/0/project/alkitab-host-hrd/crashlytics/app/android:yuku.alkitab/issues/b80d5209ee90ebd9c5eb30f87f19c85f
-                    val ft = supportFragmentManager.beginTransaction()
-                    ft.add(dialog, "compare_dialog")
-                    ft.commitAllowingStateLoss()
-
-                    true
-                }
-
-                R.id.menuAddBookmark -> {
-
-                    // contract: this menu only appears when contiguous verses are selected
-                    if (selected.get(selected.size() - 1) - selected.get(0) != selected.size() - 1) {
-                        throw RuntimeException("Non contiguous verses when adding bookmark: $selected")
-                    }
-
-                    val ari = Ari.encode(activeSplit0.book.bookId, this@IsiActivity.chapter_1, selected.get(0))
-                    val verseCount = selected.size()
-
-                    // always create a new bookmark
-                    val dialog = TypeBookmarkDialog.NewBookmark(this@IsiActivity, ari, verseCount)
-                    dialog.setListener {
-                        lsSplit0.uncheckAllVerses(true)
-                        reloadBothAttributeMaps()
-                    }
-                    dialog.show()
-
-                    mode.finish()
-                    true
-                }
-
-                R.id.menuAddNote -> {
-
-                    // contract: this menu only appears when contiguous verses are selected
-                    if (selected.get(selected.size() - 1) - selected.get(0) != selected.size() - 1) {
-                        throw RuntimeException("Non contiguous verses when adding note: $selected")
-                    }
-
-                    val ari = Ari.encode(activeSplit0.book.bookId, this@IsiActivity.chapter_1, selected.get(0))
-                    val verseCount = selected.size()
-
-                    // always create a new note
-                    startActivityForResult(NoteActivity.createNewNoteIntent(activeSplit0.version.referenceWithVerseCount(ari, verseCount), ari, verseCount), RequestCodes.FromActivity.EditNote2)
-                    mode.finish()
-
-                    true
-                }
-
-                R.id.menuAddHighlight -> {
-                    val ariBc = Ari.encode(activeSplit0.book.bookId, this@IsiActivity.chapter_1, 0)
-                    val colorRgb = S.db.getHighlightColorRgb(ariBc, selected)
-
-                    val listener = TypeHighlightDialog.Listener {
-                        lsSplit0.uncheckAllVerses(true)
-                        reloadBothAttributeMaps()
-                    }
-
-                    val reference = referenceFromSelectedVerses(selected, activeSplit0.book)
-                    if (selected.size() == 1) {
-                        val ftr = VerseRenderer.FormattedTextResult()
-                        val ari = Ari.encodeWithBc(ariBc, selected.get(0))
-                        val rawVerseText = activeSplit0.version.loadVerseText(ari) ?: ""
-                        val info = S.db.getHighlightColorRgb(ari)
-
-                        VerseRendererJavaHelper.render(ari = ari, text = rawVerseText, ftr = ftr)
-                        TypeHighlightDialog(this@IsiActivity, ari, listener, colorRgb, info, reference, ftr.result)
-                    } else {
-                        TypeHighlightDialog(this@IsiActivity, ariBc, selected, listener, colorRgb, reference)
-                    }
-                    mode.finish()
-                    true
-                }
-
-                R.id.menuEsvsb -> {
-
-                    val ari = Ari.encode(activeSplit0.book.bookId, this@IsiActivity.chapter_1, selected.get(0))
-
-                    try {
-                        val intent = Intent("yuku.esvsbasal.action.GOTO")
-                        intent.putExtra("ari", ari)
-                        startActivity(intent)
-                    } catch (e: Exception) {
-                        AppLog.e(TAG, "ESVSB starting", e)
-                    }
-                    true
-                }
-
-                R.id.menuGuide -> {
-
-                    val ari = Ari.encode(activeSplit0.book.bookId, this@IsiActivity.chapter_1, 0)
-
-                    try {
-                        packageManager.getPackageInfo("org.sabda.pedia", 0)
-
-                        val intent = Intent("org.sabda.pedia.action.VIEW")
-                        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        intent.putExtra("ari", ari)
-                        startActivity(intent)
-                    } catch (_: PackageManager.NameNotFoundException) {
-                        OtherAppIntegration.openMarket(this@IsiActivity, "org.sabda.pedia")
-                    }
-                    true
-                }
-
-                R.id.menuCommentary -> {
-
-                    val ari = Ari.encode(activeSplit0.book.bookId, this@IsiActivity.chapter_1, selected.get(0))
-
-                    try {
-                        packageManager.getPackageInfo("org.sabda.tafsiran", 0)
-
-                        val intent = Intent("org.sabda.tafsiran.action.VIEW")
-                        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        intent.putExtra("ari", ari)
-                        startActivity(intent)
-                    } catch (_: PackageManager.NameNotFoundException) {
-                        OtherAppIntegration.openMarket(this@IsiActivity, "org.sabda.tafsiran")
-                    }
-                    true
-                }
-
-                R.id.menuDictionary -> {
-
-                    val ariBc = Ari.encode(activeSplit0.book.bookId, this@IsiActivity.chapter_1, 0)
-                    val aris = HashSet<Int>()
-                    var i = 0
-                    val len = selected.size()
-                    while (i < len) {
-                        val verse_1 = selected.get(i)
-                        val ari = Ari.encodeWithBc(ariBc, verse_1)
-                        aris.add(ari)
-                        i++
-                    }
-
-                    startDictionaryMode(aris)
-                    true
-                }
-
-                R.id.menuRibkaReport -> {
-
-                    val ribkaEligibility = checkRibkaEligibility()
-                    if (ribkaEligibility != RibkaEligibility.None) {
-                        val ari = Ari.encode(activeSplit0.book.bookId, this@IsiActivity.chapter_1, selected.get(0))
-
-                        val reference: String?
-                        val verseText: String?
-                        val versionDescription: String?
-
-                        if (ribkaEligibility == RibkaEligibility.Main) {
-                            reference = activeSplit0.version.reference(ari)
-                            verseText = activeSplit0.version.loadVerseText(ari)
-                            versionDescription = activeSplit0.mv.description
-                        } else {
-                            reference = activeSplit1?.version?.reference(ari)
-                            verseText = activeSplit1?.version?.loadVerseText(ari)
-                            versionDescription = activeSplit1?.mv?.description
-                        }
-
-                        if (reference != null && verseText != null) {
-                            startActivity(RibkaReportActivity.createIntent(ari, reference, verseText, versionDescription))
-                        }
-                    }
-                    true
-                }
-
-                in MENU_EXTENSIONS_FIRST_ID until MENU_EXTENSIONS_FIRST_ID + extensions.size -> {
-                    val extension = extensions[itemId - MENU_EXTENSIONS_FIRST_ID]
-
-                    val intent = Intent(ExtensionManager.ACTION_SHOW_VERSE_INFO)
-                    intent.component = ComponentName(extension.activityInfo.packageName, extension.activityInfo.name)
-                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-
-                    // prepare extra "aris"
-                    val aris = IntArray(selected.size())
-                    val ariBc = Ari.encode(activeSplit0.book.bookId, this@IsiActivity.chapter_1, 0)
-                    run {
-                        var i = 0
-                        val len = selected.size()
-                        while (i < len) {
-                            val verse_1 = selected.get(i)
-                            val ari = Ari.encodeWithBc(ariBc, verse_1)
-                            aris[i] = ari
-                            i++
-                        }
-                    }
-                    intent.putExtra("aris", aris)
-
-                    if (extension.includeVerseText) {
-                        // prepare extra "verseTexts"
-                        val verseTexts = arrayOfNulls<String>(selected.size())
-                        var i = 0
-                        val len = selected.size()
-                        while (i < len) {
-                            val verse_1 = selected.get(i)
-
-                            val verseText = dataSplit0.getVerseText(verse_1)
-                            if (extension.includeVerseTextFormatting) {
-                                verseTexts[i] = verseText
-                            } else {
-                                verseTexts[i] = FormattedVerseText.removeSpecialCodes(verseText)
-                            }
-                            i++
-                        }
-                        intent.putExtra("verseTexts", verseTexts)
-                    }
-
-                    try {
-                        startActivity(intent)
-                    } catch (_: ActivityNotFoundException) {
-                        MaterialDialog(this@IsiActivity).show {
-                            message(text = "Error ANFE starting extension\n\n${extension.activityInfo.packageName}/${extension.activityInfo.name}")
-                            positiveButton(R.string.ok)
-                        }
-                    }
-
-                    true
-                }
-
-                else -> false
-            }
-        }
-
-        /**
-         * @param t [0] is text to copy, [1] is text to submit
-         */
-        fun appendSplitTextForCopyShare(book: Book?, selectedVerses_1: IntArrayList, t: Array<String>) {
-            if (book == null) return
-            val referenceSplit = referenceFromSelectedVerses(selectedVerses_1, book)
-            val a = prepareTextForCopyShare(selectedVerses_1, referenceSplit, true)
-            t[0] += "\n\n${a[0]}"
-            t[1] += "\n\n${a[1]}"
-        }
-
-        override fun onDestroyActionMode(mode: ActionMode) {
-            actionMode = null
-
-            // FIXME even with this guard, verses are still unchecked when switching version while both Fullscreen and Split is active.
-            // This guard only fixes unchecking of verses when in fullscreen mode.
-            if (uncheckVersesWhenActionModeDestroyed) {
-                lsSplit0.uncheckAllVerses(true)
-            }
-        }
-    }
 
     private val splitHandleButton_listener = object : SplitHandleButton.SplitHandleButtonListener {
         var first = 0
@@ -1416,7 +930,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
         return 1 // default value for verse_1
     }
 
-    fun loadVersion(mv: MVersion) {
+    override fun loadVersion(mv: MVersion) {
         try {
             val version = mv.version ?: throw RuntimeException() // caught below
 
@@ -1636,88 +1150,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
         if (callAttention && ari == Ari.encode(activeSplit0.book.bookId, ari_cv)) {
             callAttentionForVerseToBothSplits(Ari.toVerse(ari))
         }
-    }
-
-    fun referenceFromSelectedVerses(selectedVerses: IntArrayList, book: Book): String {
-        return when (selectedVerses.size()) {
-            // should not be possible. So we don't do anything.
-            0 -> book.reference(this.chapter_1)
-            1 -> book.reference(this.chapter_1, selectedVerses.get(0))
-            else -> book.reference(this.chapter_1, selectedVerses)
-        }
-    }
-
-    /**
-     * Construct text for copying or sharing (in plain text).
-     *
-     * @param isSplitVersion whether take the verse text from the main or from the split version.
-     * @return [0] text for copying/sharing, [1] text to be submitted to the share url service
-     */
-    fun prepareTextForCopyShare(selectedVerses_1: IntArrayList, reference: CharSequence, isSplitVersion: Boolean): Array<String> {
-        val res0 = StringBuilder()
-        val res1 = StringBuilder()
-
-        res0.append(reference)
-
-        if (Preferences.getBoolean(getString(R.string.pref_copyWithVersionName_key), resources.getBoolean(R.bool.pref_copyWithVersionName_default))) {
-            // Fallback to primary version for safety
-            val version = if (isSplitVersion) activeSplit1?.version ?: activeSplit0.version else activeSplit0.version
-            val versionShortName = version.shortName
-            if (versionShortName != null) {
-                res0.append(" (").append(versionShortName).append(")")
-            }
-        }
-
-        if (Preferences.getBoolean(getString(R.string.pref_copyWithVerseNumbers_key), false) && selectedVerses_1.size() > 1) {
-            res0.append('\n')
-
-            // append each selected verse with verse number prepended
-            var i = 0
-            val len = selectedVerses_1.size()
-            while (i < len) {
-                val verse_1 = selectedVerses_1.get(i)
-                val verseText = if (isSplitVersion) dataSplit1.getVerseText(verse_1) else dataSplit0.getVerseText(verse_1)
-
-                if (verseText != null) {
-                    val verseTextPlain = FormattedVerseText.removeSpecialCodes(verseText)
-
-                    res0.append(verse_1)
-                    res1.append(verse_1)
-                    res0.append(' ')
-                    res1.append(' ')
-
-                    res0.append(verseTextPlain)
-                    res1.append(verseText)
-
-                    if (i != len - 1) {
-                        res0.append('\n')
-                        res1.append('\n')
-                    }
-                }
-                i++
-            }
-        } else {
-            res0.append("  ")
-
-            // append each selected verse without verse number prepended
-            for (i in 0 until selectedVerses_1.size()) {
-                val verse_1 = selectedVerses_1.get(i)
-                val verseText = if (isSplitVersion) dataSplit1.getVerseText(verse_1) else dataSplit0.getVerseText(verse_1)
-
-                if (verseText != null) {
-                    val verseTextPlain = FormattedVerseText.removeSpecialCodes(verseText)
-
-                    if (i != 0) {
-                        res0.append('\n')
-                        res1.append('\n')
-                    }
-                    res0.append(verseTextPlain)
-                    res1.append(verseText)
-                }
-            }
-        }
-
-        return arrayOf(res0.toString(), res1.toString())
     }
 
     fun applyPreferences() {
@@ -2732,16 +2164,10 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
         }
     }
 
-    enum class RibkaEligibility {
-        None,
-        Main,
-        Split,
-    }
-
     /**
      * Check whether we are using a version eligible for ribka.
      */
-    fun checkRibkaEligibility(): RibkaEligibility {
+    override fun checkRibkaEligibility(): RibkaEligibility {
         val validPresetName = "in-ayt"
 
         val activeMVersion = activeSplit0.mv
@@ -2756,7 +2182,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
         return if (validPresetName == splitPresetName) RibkaEligibility.Split else RibkaEligibility.None
     }
 
-    fun reloadBothAttributeMaps() {
+    override fun reloadBothAttributeMaps() {
         val newDataSplit0 = reloadAttributeMapsToVerseDataModel(dataSplit0)
         dataSplit0 = newDataSplit0
 
@@ -2782,7 +2208,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener {
     /**
      * @param aris aris where the verses are to be checked for dictionary words.
      */
-    private fun startDictionaryMode(aris: Set<Int>) {
+    override fun startDictionaryMode(aris: Set<Int>) {
         if (!OtherAppIntegration.hasIntegratedDictionaryApp()) {
             OtherAppIntegration.askToInstallDictionary(this)
             return

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/RibkaEligibility.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/RibkaEligibility.kt
@@ -1,0 +1,7 @@
+package yuku.alkitab.base.actionmode
+
+enum class RibkaEligibility {
+    None,
+    Main,
+    Split,
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeActions.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeActions.kt
@@ -1,0 +1,28 @@
+package yuku.alkitab.base.actionmode
+
+import yuku.alkitab.base.model.MVersion
+
+/**
+ * Write-side surface that [VerseActionModeController] invokes to trigger Activity
+ * operations in response to action-mode menu clicks. Implemented by the hosting
+ * Activity.
+ */
+interface VerseActionModeActions {
+    /** Clears the checked-verse state on the primary (split-0) list. */
+    fun uncheckAllVersesSplit0()
+
+    /** Re-runs the verse-attribute loader for both splits (called after edits). */
+    fun reloadBothAttributeMaps()
+
+    /** Switches the primary version (used by "Compare" to jump to a selected version). */
+    fun loadVersion(mv: MVersion)
+
+    /** Enters dictionary mode for the given set of ARIs. */
+    fun startDictionaryMode(aris: Set<Int>)
+
+    /** Returns whether the current version(s) are eligible for Ribka reporting. */
+    fun checkRibkaEligibility(): RibkaEligibility
+
+    /** Called from `onDestroyActionMode` so the Activity can clear its `actionMode` field. */
+    fun onActionModeDestroyed()
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
@@ -1,0 +1,593 @@
+package yuku.alkitab.base.actionmode
+
+import android.content.ActivityNotFoundException
+import android.content.ComponentName
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.view.Menu
+import android.view.MenuItem
+import androidx.appcompat.view.ActionMode
+import androidx.core.app.ShareCompat
+import com.afollestad.materialdialogs.MaterialDialog
+import com.google.android.material.snackbar.Snackbar
+import yuku.afw.storage.Preferences
+import yuku.alkitab.base.S
+import yuku.alkitab.base.ac.NoteActivity
+import yuku.alkitab.base.config.AppConfig
+import yuku.alkitab.base.dialog.TypeBookmarkDialog
+import yuku.alkitab.base.dialog.TypeHighlightDialog
+import yuku.alkitab.base.dialog.VersesDialog
+import yuku.alkitab.base.model.MVersion
+import yuku.alkitab.base.model.MVersionDb
+import yuku.alkitab.base.util.AppLog
+import yuku.alkitab.base.util.ClipboardUtil
+import yuku.alkitab.base.util.ExtensionManager
+import yuku.alkitab.base.util.FormattedVerseText
+import yuku.alkitab.base.util.OtherAppIntegration
+import yuku.alkitab.base.util.RequestCodes
+import yuku.alkitab.base.util.ShareUrl
+import yuku.alkitab.base.util.VerseTextFormatter
+import yuku.alkitab.base.verses.VersesDataModel
+import yuku.alkitab.base.widget.VerseRenderer
+import yuku.alkitab.base.widget.VerseRendererJavaHelper
+import yuku.alkitab.debug.R
+import yuku.alkitab.model.Book
+import yuku.alkitab.model.Version
+import yuku.alkitab.ribka.RibkaReportActivity
+import yuku.alkitab.util.Ari
+import yuku.alkitab.util.IntArrayList
+
+private const val TAG = "VerseActionModeController"
+private const val EXTRA_verseUrl = "verseUrl"
+
+/**
+ * Action-mode callback for verse selection (copy, share, bookmark, highlight,
+ * compare, dictionary, extensions, etc.). Extracted from `IsiActivity` — see
+ * REM-07 in docs/tech-debt-remediation.md.
+ *
+ * The controller is deliberately kept free of direct Activity references: it
+ * reads state through [host] and invokes operations through [actions]. Framework
+ * calls that genuinely require an Activity (dialogs, fragment transactions,
+ * `startActivity`) go through `host.activity`.
+ */
+class VerseActionModeController(
+    private val host: VerseActionModeHost,
+    private val actions: VerseActionModeActions,
+) : ActionMode.Callback {
+
+    private val MENU_GROUP_EXTENSIONS = Menu.FIRST + 1
+    private val MENU_EXTENSIONS_FIRST_ID = 0x1000
+
+    private val extensions = mutableListOf<ExtensionManager.Info>()
+
+    override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
+        host.activity.menuInflater.inflate(R.menu.context_isi, menu)
+
+        AppLog.d(TAG, "@@onCreateActionMode")
+
+        if (host.hasEsvsbAsal) {
+            val esvsb = menu.findItem(R.id.menuEsvsb)
+            esvsb?.isVisible = true
+        }
+
+        // show book name and chapter
+        val reference = host.activeSplit0Book.reference(host.chapter_1)
+        mode.title = reference
+
+        return true
+    }
+
+    override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
+        val menuAddBookmark = menu.findItem(R.id.menuAddBookmark)
+        val menuAddNote = menu.findItem(R.id.menuAddNote)
+        val menuCompare = menu.findItem(R.id.menuCompare)
+
+        val selected = host.selectedVersesSplit0_1
+        val single = selected.size() == 1
+
+        // For unknown reasons the size of selected can be zero and get(0) causes crash.
+        // https://console.firebase.google.com/u/0/project/alkitab-host-hrd/crashlytics/app/android:yuku.alkitab/issues/cc11d3466c89303f88b9e27ab3fdd534
+        if (selected.size() == 0) {
+            AppLog.e(TAG, "@@onPrepareActionMode checked verses is empty.")
+            mode.finish()
+            return true
+        }
+
+        var contiguous = true
+        if (!single) {
+            var next = selected.get(0) + 1
+            var i = 1
+            val len = selected.size()
+            while (i < len) {
+                val cur = selected.get(i)
+                if (next != cur) {
+                    contiguous = false
+                    break
+                }
+                next = cur + 1
+                i++
+            }
+        }
+
+        menuAddBookmark.isVisible = contiguous
+        menuAddNote.isVisible = contiguous
+        menuCompare.isVisible = single
+
+        // just "copy" or ("copy primary" "copy secondary" "copy both")
+        // same with "share".
+        val menuCopy = menu.findItem(R.id.menuCopy)
+        val menuCopySplit0 = menu.findItem(R.id.menuCopySplit0)
+        val menuCopySplit1 = menu.findItem(R.id.menuCopySplit1)
+        val menuCopyBothSplits = menu.findItem(R.id.menuCopyBothSplits)
+        val menuShare = menu.findItem(R.id.menuShare)
+        val menuShareSplit0 = menu.findItem(R.id.menuShareSplit0)
+        val menuShareSplit1 = menu.findItem(R.id.menuShareSplit1)
+        val menuShareBothSplits = menu.findItem(R.id.menuShareBothSplits)
+
+        val split = host.activeSplit1Version != null
+
+        menuCopy.isVisible = !split
+        menuCopySplit0.isVisible = split
+        menuCopySplit1.isVisible = split
+        menuCopyBothSplits.isVisible = split
+        menuShare.isVisible = !split
+        menuShareSplit0.isVisible = split
+        menuShareSplit1.isVisible = split
+        menuShareBothSplits.isVisible = split
+
+        // show selected verses
+        if (single) {
+            mode.setSubtitle(R.string.verse_select_one_verse_selected)
+        } else {
+            mode.subtitle = host.activity.getString(R.string.verse_select_multiple_verse_selected, selected.size().toString())
+        }
+
+        val menuGuide = menu.findItem(R.id.menuGuide)
+        val menuCommentary = menu.findItem(R.id.menuCommentary)
+        val menuDictionary = menu.findItem(R.id.menuDictionary)
+
+        // force-show these items on sw600dp, otherwise never show
+        val showAsAction = if (host.activity.resources.configuration.smallestScreenWidthDp >= 600) MenuItem.SHOW_AS_ACTION_ALWAYS else MenuItem.SHOW_AS_ACTION_NEVER
+        menuGuide.setShowAsActionFlags(showAsAction)
+        menuCommentary.setShowAsActionFlags(showAsAction)
+        menuDictionary.setShowAsActionFlags(showAsAction)
+
+        // set visibility according to appconfig
+        val c = AppConfig.get()
+        menuGuide.isVisible = c.menuGuide
+        menuCommentary.isVisible = c.menuCommentary
+
+        // do not show dictionary item if not needed because of auto-lookup from
+        menuDictionary.isVisible = c.menuDictionary && !Preferences.getBoolean(host.activity.getString(R.string.pref_autoDictionaryAnalyze_key), host.activity.resources.getBoolean(R.bool.pref_autoDictionaryAnalyze_default))
+
+        val menuRibkaReport = menu.findItem(R.id.menuRibkaReport)
+        menuRibkaReport.isVisible = single && actions.checkRibkaEligibility() != RibkaEligibility.None
+
+        // extensions
+        extensions.clear()
+        extensions.addAll(ExtensionManager.getExtensions())
+
+        menu.removeGroup(MENU_GROUP_EXTENSIONS)
+
+        for ((i, extension) in extensions.withIndex()) {
+            if (single || /* not single */ extension.supportsMultipleVerses) {
+                menu.add(MENU_GROUP_EXTENSIONS, MENU_EXTENSIONS_FIRST_ID + i, 0, extension.label)
+            }
+        }
+
+        return true
+    }
+
+    override fun onActionItemClicked(mode: ActionMode, item: MenuItem): Boolean {
+        val selected = host.selectedVersesSplit0_1
+
+        if (selected.size() == 0) return true
+
+        return when (val itemId = item.itemId) {
+            R.id.menuCopy, R.id.menuCopySplit0, R.id.menuCopySplit1, R.id.menuCopyBothSplits -> {
+                // copy, can be multiple verses
+                val reference = VerseTextFormatter.referenceFromSelectedVerses(selected, host.activeSplit0Book, host.chapter_1)
+                val activeSplit1Version = host.activeSplit1Version
+                val t = if (itemId == R.id.menuCopy || itemId == R.id.menuCopySplit0 || itemId == R.id.menuCopyBothSplits || activeSplit1Version == null) {
+                    buildCopyShareText(selected, reference, isSplitVersion = false)
+                } else { // menuCopySplit1, do not use split0 reference
+                    val book = host.activeSplit1BookById(host.activeSplit0Book.bookId) ?: host.activeSplit0Book
+                    buildCopyShareText(selected, VerseTextFormatter.referenceFromSelectedVerses(selected, book, host.chapter_1), isSplitVersion = true)
+                }
+
+                if (itemId == R.id.menuCopyBothSplits && activeSplit1Version != null) {
+                    val book = host.activeSplit1BookById(host.activeSplit0Book.bookId) ?: host.activeSplit0Book
+                    appendSplitTextForCopyShare(book, host.selectedVersesSplit1_1, t)
+                }
+
+                val textToCopy = t[0]
+                val textToSubmit = t[1]
+
+                ShareUrl.make(
+                    activity = host.activity,
+                    immediatelyCancel = !Preferences.getBoolean(host.activity.getString(R.string.pref_copyWithShareUrl_key), host.activity.resources.getBoolean(R.bool.pref_copyWithShareUrl_default)),
+                    verseText = textToSubmit,
+                    ari_bc = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, 0),
+                    selectedVerses_1 = selected,
+                    reference = reference,
+                    version = host.activeSplit0Version,
+                    preset_name = MVersionDb.presetNameFromVersionId(host.activeSplit0VersionId),
+                    callback = object : ShareUrl.Callback {
+                        override fun onSuccess(shareUrl: String) {
+                            ClipboardUtil.copyToClipboard("$textToCopy\n\n$shareUrl")
+                        }
+
+                        override fun onUserCancel() {
+                            ClipboardUtil.copyToClipboard(textToCopy)
+                        }
+
+                        override fun onError(e: Exception) {
+                            AppLog.e(TAG, "Error in ShareUrl, copying without shareUrl", e)
+                            ClipboardUtil.copyToClipboard(textToCopy)
+                        }
+
+                        override fun onFinally() {
+                            actions.uncheckAllVersesSplit0()
+
+                            Snackbar.make(host.root, host.activity.getString(R.string.alamat_sudah_disalin, reference), Snackbar.LENGTH_SHORT).show()
+                            mode.finish()
+                        }
+                    }
+                )
+
+                true
+            }
+
+            R.id.menuShare, R.id.menuShareSplit0, R.id.menuShareSplit1, R.id.menuShareBothSplits -> {
+                // share, can be multiple verses
+                val reference = VerseTextFormatter.referenceFromSelectedVerses(selected, host.activeSplit0Book, host.chapter_1)
+                val activeSplit1Version = host.activeSplit1Version
+
+                val t = if (itemId == R.id.menuShare || itemId == R.id.menuShareSplit0 || itemId == R.id.menuShareBothSplits || activeSplit1Version == null) {
+                    buildCopyShareText(selected, reference, isSplitVersion = false)
+                } else { // menuShareSplit1, do not use split0 reference
+                    val book = host.activeSplit1BookById(host.activeSplit0Book.bookId) ?: host.activeSplit0Book
+                    buildCopyShareText(selected, VerseTextFormatter.referenceFromSelectedVerses(selected, book, host.chapter_1), isSplitVersion = true)
+                }
+
+                if (itemId == R.id.menuShareBothSplits && activeSplit1Version != null) {
+                    val book = host.activeSplit1BookById(host.activeSplit0Book.bookId) ?: host.activeSplit0Book
+                    appendSplitTextForCopyShare(book, host.selectedVersesSplit1_1, t)
+                }
+
+                val textToShare = t[0]
+                val textToSubmit = t[1]
+
+                val intent = ShareCompat.IntentBuilder(host.activity)
+                    .setType("text/plain")
+                    .setSubject(reference)
+                    .intent
+
+                ShareUrl.make(
+                    activity = host.activity,
+                    immediatelyCancel = !Preferences.getBoolean(host.activity.getString(R.string.pref_copyWithShareUrl_key), host.activity.resources.getBoolean(R.bool.pref_copyWithShareUrl_default)),
+                    verseText = textToSubmit,
+                    ari_bc = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, 0),
+                    selectedVerses_1 = selected,
+                    reference = reference,
+                    version = host.activeSplit0Version,
+                    preset_name = MVersionDb.presetNameFromVersionId(host.activeSplit0VersionId),
+                    callback = object : ShareUrl.Callback {
+                        override fun onSuccess(shareUrl: String) {
+                            intent.putExtra(Intent.EXTRA_TEXT, "$textToShare\n\n$shareUrl")
+                            intent.putExtra(EXTRA_verseUrl, shareUrl)
+                        }
+
+                        override fun onUserCancel() {
+                            intent.putExtra(Intent.EXTRA_TEXT, textToShare)
+                        }
+
+                        override fun onError(e: Exception) {
+                            AppLog.e(TAG, "Error in ShareUrl, sharing without shareUrl", e)
+                            intent.putExtra(Intent.EXTRA_TEXT, textToShare)
+                        }
+
+                        override fun onFinally() {
+                            host.activity.startActivity(Intent.createChooser(intent, host.activity.getString(R.string.bagikan_alamat, reference)))
+
+                            actions.uncheckAllVersesSplit0()
+                            mode.finish()
+                        }
+                    }
+                )
+                true
+            }
+
+            R.id.menuCompare -> {
+                val ari = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, selected.get(0))
+                val dialog = VersesDialog.newCompareInstance(ari)
+                dialog.listener = object : VersesDialog.VersesDialogListener() {
+                    override fun onComparedVerseSelected(ari: Int, mversion: MVersion) {
+                        actions.loadVersion(mversion)
+                        dialog.dismiss()
+                    }
+                }
+
+                // Allow state loss to prevent
+                // https://console.firebase.google.com/u/0/project/alkitab-host-hrd/crashlytics/app/android:yuku.alkitab/issues/b80d5209ee90ebd9c5eb30f87f19c85f
+                val ft = host.activity.supportFragmentManager.beginTransaction()
+                ft.add(dialog, "compare_dialog")
+                ft.commitAllowingStateLoss()
+
+                true
+            }
+
+            R.id.menuAddBookmark -> {
+
+                // contract: this menu only appears when contiguous verses are selected
+                if (selected.get(selected.size() - 1) - selected.get(0) != selected.size() - 1) {
+                    throw RuntimeException("Non contiguous verses when adding bookmark: $selected")
+                }
+
+                val ari = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, selected.get(0))
+                val verseCount = selected.size()
+
+                // always create a new bookmark
+                val dialog = TypeBookmarkDialog.NewBookmark(host.activity, ari, verseCount)
+                dialog.setListener {
+                    actions.uncheckAllVersesSplit0()
+                    actions.reloadBothAttributeMaps()
+                }
+                dialog.show()
+
+                mode.finish()
+                true
+            }
+
+            R.id.menuAddNote -> {
+
+                // contract: this menu only appears when contiguous verses are selected
+                if (selected.get(selected.size() - 1) - selected.get(0) != selected.size() - 1) {
+                    throw RuntimeException("Non contiguous verses when adding note: $selected")
+                }
+
+                val ari = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, selected.get(0))
+                val verseCount = selected.size()
+
+                // always create a new note
+                host.activity.startActivityForResult(NoteActivity.createNewNoteIntent(host.activeSplit0Version.referenceWithVerseCount(ari, verseCount), ari, verseCount), RequestCodes.FromActivity.EditNote2)
+                mode.finish()
+
+                true
+            }
+
+            R.id.menuAddHighlight -> {
+                val ariBc = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, 0)
+                val colorRgb = S.db.getHighlightColorRgb(ariBc, selected)
+
+                val listener = TypeHighlightDialog.Listener {
+                    actions.uncheckAllVersesSplit0()
+                    actions.reloadBothAttributeMaps()
+                }
+
+                val reference = VerseTextFormatter.referenceFromSelectedVerses(selected, host.activeSplit0Book, host.chapter_1)
+                if (selected.size() == 1) {
+                    val ftr = VerseRenderer.FormattedTextResult()
+                    val ari = Ari.encodeWithBc(ariBc, selected.get(0))
+                    val rawVerseText = host.activeSplit0Version.loadVerseText(ari) ?: ""
+                    val info = S.db.getHighlightColorRgb(ari)
+
+                    VerseRendererJavaHelper.render(ari = ari, text = rawVerseText, ftr = ftr)
+                    TypeHighlightDialog(host.activity, ari, listener, colorRgb, info, reference, ftr.result)
+                } else {
+                    TypeHighlightDialog(host.activity, ariBc, selected, listener, colorRgb, reference)
+                }
+                mode.finish()
+                true
+            }
+
+            R.id.menuEsvsb -> {
+
+                val ari = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, selected.get(0))
+
+                try {
+                    val intent = Intent("yuku.esvsbasal.action.GOTO")
+                    intent.putExtra("ari", ari)
+                    host.activity.startActivity(intent)
+                } catch (e: Exception) {
+                    AppLog.e(TAG, "ESVSB starting", e)
+                }
+                true
+            }
+
+            R.id.menuGuide -> {
+
+                val ari = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, 0)
+
+                try {
+                    host.activity.packageManager.getPackageInfo("org.sabda.pedia", 0)
+
+                    val intent = Intent("org.sabda.pedia.action.VIEW")
+                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    intent.putExtra("ari", ari)
+                    host.activity.startActivity(intent)
+                } catch (_: PackageManager.NameNotFoundException) {
+                    OtherAppIntegration.openMarket(host.activity, "org.sabda.pedia")
+                }
+                true
+            }
+
+            R.id.menuCommentary -> {
+
+                val ari = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, selected.get(0))
+
+                try {
+                    host.activity.packageManager.getPackageInfo("org.sabda.tafsiran", 0)
+
+                    val intent = Intent("org.sabda.tafsiran.action.VIEW")
+                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    intent.putExtra("ari", ari)
+                    host.activity.startActivity(intent)
+                } catch (_: PackageManager.NameNotFoundException) {
+                    OtherAppIntegration.openMarket(host.activity, "org.sabda.tafsiran")
+                }
+                true
+            }
+
+            R.id.menuDictionary -> {
+
+                val ariBc = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, 0)
+                val aris = HashSet<Int>()
+                var i = 0
+                val len = selected.size()
+                while (i < len) {
+                    val verse_1 = selected.get(i)
+                    val ari = Ari.encodeWithBc(ariBc, verse_1)
+                    aris.add(ari)
+                    i++
+                }
+
+                actions.startDictionaryMode(aris)
+                true
+            }
+
+            R.id.menuRibkaReport -> {
+
+                val ribkaEligibility = actions.checkRibkaEligibility()
+                if (ribkaEligibility != RibkaEligibility.None) {
+                    val ari = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, selected.get(0))
+
+                    val reference: String?
+                    val verseText: String?
+                    val versionDescription: String?
+
+                    if (ribkaEligibility == RibkaEligibility.Main) {
+                        reference = host.activeSplit0Version.reference(ari)
+                        verseText = host.activeSplit0Version.loadVerseText(ari)
+                        versionDescription = host.activeSplit0MVersion.description
+                    } else {
+                        reference = host.activeSplit1Version?.reference(ari)
+                        verseText = host.activeSplit1Version?.loadVerseText(ari)
+                        versionDescription = host.activeSplit1MVersion?.description
+                    }
+
+                    if (reference != null && verseText != null) {
+                        host.activity.startActivity(RibkaReportActivity.createIntent(ari, reference, verseText, versionDescription))
+                    }
+                }
+                true
+            }
+
+            in MENU_EXTENSIONS_FIRST_ID until MENU_EXTENSIONS_FIRST_ID + extensions.size -> {
+                val extension = extensions[itemId - MENU_EXTENSIONS_FIRST_ID]
+
+                val intent = Intent(ExtensionManager.ACTION_SHOW_VERSE_INFO)
+                intent.component = ComponentName(extension.activityInfo.packageName, extension.activityInfo.name)
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+                // prepare extra "aris"
+                val aris = IntArray(selected.size())
+                val ariBc = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, 0)
+                run {
+                    var i = 0
+                    val len = selected.size()
+                    while (i < len) {
+                        val verse_1 = selected.get(i)
+                        val ari = Ari.encodeWithBc(ariBc, verse_1)
+                        aris[i] = ari
+                        i++
+                    }
+                }
+                intent.putExtra("aris", aris)
+
+                if (extension.includeVerseText) {
+                    // prepare extra "verseTexts"
+                    val verseTexts = arrayOfNulls<String>(selected.size())
+                    var i = 0
+                    val len = selected.size()
+                    while (i < len) {
+                        val verse_1 = selected.get(i)
+
+                        val verseText = host.dataSplit0.getVerseText(verse_1)
+                        if (extension.includeVerseTextFormatting) {
+                            verseTexts[i] = verseText
+                        } else {
+                            verseTexts[i] = FormattedVerseText.removeSpecialCodes(verseText)
+                        }
+                        i++
+                    }
+                    intent.putExtra("verseTexts", verseTexts)
+                }
+
+                try {
+                    host.activity.startActivity(intent)
+                } catch (_: ActivityNotFoundException) {
+                    MaterialDialog(host.activity).show {
+                        message(text = "Error ANFE starting extension\n\n${extension.activityInfo.packageName}/${extension.activityInfo.name}")
+                        positiveButton(R.string.ok)
+                    }
+                }
+
+                true
+            }
+
+            else -> false
+        }
+    }
+
+    override fun onDestroyActionMode(mode: ActionMode) {
+        actions.onActionModeDestroyed()
+
+        // FIXME even with this guard, verses are still unchecked when switching version while both Fullscreen and Split is active.
+        // This guard only fixes unchecking of verses when in fullscreen mode.
+        if (host.uncheckVersesWhenActionModeDestroyed) {
+            actions.uncheckAllVersesSplit0()
+        }
+    }
+
+    /**
+     * Resolves the two "copy/share" preferences and the split/non-split version
+     * short-name choice, then delegates to [VerseTextFormatter].
+     */
+    private fun buildCopyShareText(
+        selectedVerses_1: IntArrayList,
+        reference: CharSequence,
+        isSplitVersion: Boolean,
+    ): Array<String> {
+        val data: VersesDataModel
+        val version: Version
+        if (isSplitVersion) {
+            // Fallback to primary version for safety (matches previous IsiActivity behavior).
+            data = host.dataSplit1
+            version = host.activeSplit1Version ?: host.activeSplit0Version
+        } else {
+            data = host.dataSplit0
+            version = host.activeSplit0Version
+        }
+
+        val versionShortName = if (Preferences.getBoolean(host.activity.getString(R.string.pref_copyWithVersionName_key), host.activity.resources.getBoolean(R.bool.pref_copyWithVersionName_default))) {
+            version.shortName
+        } else {
+            null
+        }
+
+        val includeVerseNumbers = Preferences.getBoolean(host.activity.getString(R.string.pref_copyWithVerseNumbers_key), false)
+
+        return VerseTextFormatter.prepareTextForCopyShare(
+            selectedVerses_1 = selectedVerses_1,
+            reference = reference,
+            data = data,
+            versionShortName = versionShortName,
+            includeVerseNumbers = includeVerseNumbers,
+        )
+    }
+
+    /**
+     * @param t [0] is text to copy, [1] is text to submit
+     */
+    private fun appendSplitTextForCopyShare(book: Book?, selectedVerses_1: IntArrayList, t: Array<String>) {
+        if (book == null) return
+        val referenceSplit = VerseTextFormatter.referenceFromSelectedVerses(selectedVerses_1, book, host.chapter_1)
+        val a = buildCopyShareText(selectedVerses_1, referenceSplit, isSplitVersion = true)
+        t[0] += "\n\n${a[0]}"
+        t[1] += "\n\n${a[1]}"
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeHost.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeHost.kt
@@ -1,0 +1,50 @@
+package yuku.alkitab.base.actionmode
+
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import yuku.alkitab.base.model.MVersion
+import yuku.alkitab.base.verses.VersesDataModel
+import yuku.alkitab.model.Book
+import yuku.alkitab.model.Version
+import yuku.alkitab.util.IntArrayList
+
+/**
+ * Read-only state surface that [VerseActionModeController] reads from to drive the
+ * verse-selection action mode. Implemented by the hosting Activity.
+ *
+ * Property names mirror the Activity's existing `activeSplit0` / `activeSplit1`
+ * vocabulary so changes read cleanly against the original code.
+ */
+interface VerseActionModeHost {
+    val activity: AppCompatActivity
+    val root: View
+    val chapter_1: Int
+
+    // Primary ("split 0") — always present.
+    val activeSplit0Book: Book
+    val activeSplit0Version: Version
+    val activeSplit0VersionId: String
+    val activeSplit0MVersion: MVersion
+
+    // Secondary ("split 1") — null when the split view is closed.
+    val activeSplit1Version: Version?
+    val activeSplit1MVersion: MVersion?
+
+    /** Looks up the book with the given id in the split-1 version, or null. */
+    fun activeSplit1BookById(bookId: Int): Book?
+
+    val selectedVersesSplit0_1: IntArrayList
+    val selectedVersesSplit1_1: IntArrayList
+
+    val dataSplit0: VersesDataModel
+    val dataSplit1: VersesDataModel
+
+    val hasEsvsbAsal: Boolean
+
+    /**
+     * Set to false by the Activity when it wants to keep the checked verses
+     * visible after the action mode is destroyed (e.g. during some split-view
+     * transitions). The controller reads this in `onDestroyActionMode`.
+     */
+    var uncheckVersesWhenActionModeDestroyed: Boolean
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/VerseTextFormatter.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/VerseTextFormatter.kt
@@ -1,0 +1,113 @@
+package yuku.alkitab.base.util
+
+import yuku.alkitab.base.verses.VersesDataModel
+import yuku.alkitab.model.Book
+import yuku.alkitab.util.IntArrayList
+
+/**
+ * Pure formatting helpers for producing reference strings and copy/share text from
+ * a selection of verses. Extracted from IsiActivity so they can be unit-tested in
+ * isolation.
+ */
+object VerseTextFormatter {
+
+    /**
+     * Builds a human-readable reference string like "Genesis 1:1" or "Genesis 1:1-3"
+     * from the selected verses. The chapter is resolved by the caller.
+     */
+    fun referenceFromSelectedVerses(
+        selectedVerses_1: IntArrayList,
+        book: Book,
+        chapter_1: Int,
+    ): String {
+        return when (selectedVerses_1.size()) {
+            // should not be possible. So we don't do anything.
+            0 -> book.reference(chapter_1)
+            1 -> book.reference(chapter_1, selectedVerses_1.get(0))
+            else -> book.reference(chapter_1, selectedVerses_1)
+        }
+    }
+
+    /**
+     * Construct text for copying or sharing (in plain text).
+     *
+     * @param selectedVerses_1 the 1-based verse numbers selected by the user
+     * @param reference the reference string to prepend (e.g. "Genesis 1:1-3")
+     * @param data the [VersesDataModel] to read verse texts from
+     * @param versionShortName the short name of the version to append in parentheses,
+     *   or null to omit (the caller resolves the "copyWithVersionName" preference)
+     * @param includeVerseNumbers whether to prefix each verse line with the verse
+     *   number (the caller resolves the "copyWithVerseNumbers" preference); this
+     *   only takes effect when more than one verse is selected
+     * @return an array of length 2: [0] text to copy/share (with formatting codes
+     *   stripped), [1] text to submit to the share URL service (with formatting
+     *   codes preserved)
+     */
+    fun prepareTextForCopyShare(
+        selectedVerses_1: IntArrayList,
+        reference: CharSequence,
+        data: VersesDataModel,
+        versionShortName: String?,
+        includeVerseNumbers: Boolean,
+    ): Array<String> {
+        val res0 = StringBuilder()
+        val res1 = StringBuilder()
+
+        res0.append(reference)
+
+        if (versionShortName != null) {
+            res0.append(" (").append(versionShortName).append(")")
+        }
+
+        if (includeVerseNumbers && selectedVerses_1.size() > 1) {
+            res0.append('\n')
+
+            // append each selected verse with verse number prepended
+            var i = 0
+            val len = selectedVerses_1.size()
+            while (i < len) {
+                val verse_1 = selectedVerses_1.get(i)
+                val verseText = data.getVerseText(verse_1)
+
+                if (verseText != null) {
+                    val verseTextPlain = FormattedVerseText.removeSpecialCodes(verseText)
+
+                    res0.append(verse_1)
+                    res1.append(verse_1)
+                    res0.append(' ')
+                    res1.append(' ')
+
+                    res0.append(verseTextPlain)
+                    res1.append(verseText)
+
+                    if (i != len - 1) {
+                        res0.append('\n')
+                        res1.append('\n')
+                    }
+                }
+                i++
+            }
+        } else {
+            res0.append("  ")
+
+            // append each selected verse without verse number prepended
+            for (i in 0 until selectedVerses_1.size()) {
+                val verse_1 = selectedVerses_1.get(i)
+                val verseText = data.getVerseText(verse_1)
+
+                if (verseText != null) {
+                    val verseTextPlain = FormattedVerseText.removeSpecialCodes(verseText)
+
+                    if (i != 0) {
+                        res0.append('\n')
+                        res1.append('\n')
+                    }
+                    res0.append(verseTextPlain)
+                    res1.append(verseText)
+                }
+            }
+        }
+
+        return arrayOf(res0.toString(), res1.toString())
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/actionmode/VerseActionModeControllerTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/actionmode/VerseActionModeControllerTest.kt
@@ -1,0 +1,390 @@
+package yuku.alkitab.base.actionmode
+
+import android.view.Menu
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.view.ActionMode
+import androidx.appcompat.view.menu.MenuBuilder
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import yuku.afw.storage.Preferences
+import yuku.alkitab.base.config.AppConfig
+import yuku.alkitab.base.util.ExtensionManager
+import yuku.alkitab.base.verses.VersesDataModel
+import yuku.alkitab.debug.R
+import yuku.alkitab.model.Book
+import yuku.alkitab.model.SingleChapterVerses
+import yuku.alkitab.util.IntArrayList
+
+/**
+ * Robolectric is required here (not pure JUnit, see CLAUDE.md "Unit Testing"):
+ *
+ * - `onCreateActionMode` calls `host.activity.menuInflater.inflate(R.menu.context_isi, menu)`,
+ *   which needs real Resources to parse the menu XML.
+ * - `onPrepareActionMode` reads `host.activity.resources.configuration.smallestScreenWidthDp`
+ *   and `host.activity.getString(R.string.pref_autoDictionaryAnalyze_key)`.
+ * - `Preferences.getBoolean(...)` reaches into `App.context.sharedPreferences`.
+ *
+ * A test-scope shadow file ("Method not mocked" workaround) is not enough — we need a
+ * working Resources/Activity stack for menu inflation to do anything meaningful.
+ *
+ * The copy/share branches are exercised through [yuku.alkitab.base.util.VerseTextFormatterTest]
+ * (pure JUnit) rather than here — they fan out into `ShareUrl` async callbacks and clipboard
+ * side-effects that are impractical to mock at this level.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = yuku.afw.App::class, sdk = [34])
+class VerseActionModeControllerTest {
+
+    private lateinit var activity: AppCompatActivity
+    private lateinit var host: VerseActionModeHost
+    private lateinit var actions: VerseActionModeActions
+    private lateinit var controller: VerseActionModeController
+    private lateinit var mode: ActionMode
+
+    @Before
+    fun setUp() {
+        // AppLog's static initializer calls FirebaseCrashlytics.getInstance(); that's handled
+        // by the test-scope shadow at src/test/java/com/google/firebase/crashlytics/FirebaseCrashlytics.java.
+
+        // Make sure static App.context is populated so yuku.alkitab.base.util/config
+        // lookups during tests don't NPE.
+        yuku.afw.App.initWithAppContext(ApplicationProvider.getApplicationContext())
+
+        activity = Robolectric.buildActivity(AppCompatActivity::class.java).setup().get()
+
+        host = mockk(relaxed = true)
+        actions = mockk(relaxed = true)
+
+        every { host.activity } returns activity
+        every { host.root } returns android.widget.FrameLayout(activity)
+        every { host.chapter_1 } returns 1
+        every { host.hasEsvsbAsal } returns false
+        every { host.activeSplit0Book } returns makeBook("Gen")
+        every { host.activeSplit0Version } returns mockk(relaxed = true) {
+            every { shortName } returns "KJV"
+        }
+        every { host.activeSplit0VersionId } returns "internal"
+        every { host.activeSplit0MVersion } returns mockk(relaxed = true)
+        every { host.activeSplit1Version } returns null
+        every { host.activeSplit1MVersion } returns null
+        every { host.activeSplit1BookById(any()) } returns null
+        every { host.selectedVersesSplit0_1 } returns ints(1)
+        every { host.selectedVersesSplit1_1 } returns ints()
+        every { host.dataSplit0 } returns makeData("In the beginning...")
+        every { host.dataSplit1 } returns VersesDataModel.EMPTY
+
+        every { actions.checkRibkaEligibility() } returns RibkaEligibility.None
+
+        // Static / object collaborators.
+        mockkStatic(AppConfig::class)
+        mockkObject(ExtensionManager)
+        mockkStatic(Preferences::class)
+
+        every { AppConfig.get() } returns newAppConfig(menuGuide = true, menuCommentary = true, menuDictionary = true)
+        every { ExtensionManager.getExtensions() } returns emptyList()
+        every { Preferences.getBoolean(any<String>(), any<Boolean>()) } returns false
+        every { Preferences.getBoolean(any<Int>(), any<Int>()) } returns false
+
+        controller = VerseActionModeController(host, actions)
+
+        mode = mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+        unmockkAll()
+    }
+
+    // ----- onPrepareActionMode: menu visibility -----
+
+    @Test
+    fun `onPrepareActionMode with a single verse and no split shows the unified copy and share items, and hides the per-split variants`() {
+        every { host.selectedVersesSplit0_1 } returns ints(5)
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        assertTrue(menu.findItem(R.id.menuCopy).isVisible)
+        assertFalse(menu.findItem(R.id.menuCopySplit0).isVisible)
+        assertFalse(menu.findItem(R.id.menuCopySplit1).isVisible)
+        assertFalse(menu.findItem(R.id.menuCopyBothSplits).isVisible)
+        assertTrue(menu.findItem(R.id.menuShare).isVisible)
+        assertFalse(menu.findItem(R.id.menuShareSplit0).isVisible)
+        assertTrue(menu.findItem(R.id.menuCompare).isVisible)
+        assertTrue(menu.findItem(R.id.menuAddBookmark).isVisible)
+        assertTrue(menu.findItem(R.id.menuAddNote).isVisible)
+    }
+
+    @Test
+    fun `onPrepareActionMode with multiple contiguous verses keeps Add Bookmark and Add Note visible but hides Compare`() {
+        every { host.selectedVersesSplit0_1 } returns ints(3, 4, 5)
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        assertTrue(menu.findItem(R.id.menuAddBookmark).isVisible)
+        assertTrue(menu.findItem(R.id.menuAddNote).isVisible)
+        assertFalse(menu.findItem(R.id.menuCompare).isVisible)
+    }
+
+    @Test
+    fun `onPrepareActionMode with multiple non-contiguous verses hides Add Bookmark, Add Note, and Compare`() {
+        every { host.selectedVersesSplit0_1 } returns ints(1, 3, 5)
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        assertFalse(menu.findItem(R.id.menuAddBookmark).isVisible)
+        assertFalse(menu.findItem(R.id.menuAddNote).isVisible)
+        assertFalse(menu.findItem(R.id.menuCompare).isVisible)
+    }
+
+    @Test
+    fun `onPrepareActionMode with a split version active hides the unified copy item and shows the per-split copy variants`() {
+        every { host.selectedVersesSplit0_1 } returns ints(2)
+        every { host.activeSplit1Version } returns mockk(relaxed = true)
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        assertFalse(menu.findItem(R.id.menuCopy).isVisible)
+        assertTrue(menu.findItem(R.id.menuCopySplit0).isVisible)
+        assertTrue(menu.findItem(R.id.menuCopySplit1).isVisible)
+        assertTrue(menu.findItem(R.id.menuCopyBothSplits).isVisible)
+        assertFalse(menu.findItem(R.id.menuShare).isVisible)
+        assertTrue(menu.findItem(R.id.menuShareBothSplits).isVisible)
+    }
+
+    @Test
+    fun `onPrepareActionMode with zero selected verses finishes the action mode (defensive guard against the cc11d3466c89 crash)`() {
+        every { host.selectedVersesSplit0_1 } returns ints()
+        every { mode.finish() } just Runs
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        verify { mode.finish() }
+    }
+
+    @Test
+    fun `onPrepareActionMode shows the Ribka Report item when the active version is Ribka-eligible and a single verse is selected`() {
+        every { host.selectedVersesSplit0_1 } returns ints(3)
+        every { actions.checkRibkaEligibility() } returns RibkaEligibility.Main
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        assertTrue(menu.findItem(R.id.menuRibkaReport).isVisible)
+    }
+
+    @Test
+    fun `onPrepareActionMode hides the Ribka Report item when multiple verses are selected, even if the version is eligible`() {
+        every { host.selectedVersesSplit0_1 } returns ints(3, 4)
+        every { actions.checkRibkaEligibility() } returns RibkaEligibility.Main
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        assertFalse(menu.findItem(R.id.menuRibkaReport).isVisible)
+    }
+
+    @Test
+    fun `onCreateActionMode reveals the ESV Study Bible menu item when the companion app is installed`() {
+        every { host.hasEsvsbAsal } returns true
+        every { host.selectedVersesSplit0_1 } returns ints(1)
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+
+        assertTrue(menu.findItem(R.id.menuEsvsb).isVisible)
+    }
+
+    @Test
+    fun `onPrepareActionMode hides Guide, Commentary, and Dictionary when AppConfig disables them`() {
+        every { host.selectedVersesSplit0_1 } returns ints(1)
+        every { AppConfig.get() } returns newAppConfig(menuGuide = false, menuCommentary = false, menuDictionary = false)
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        assertFalse(menu.findItem(R.id.menuGuide).isVisible)
+        assertFalse(menu.findItem(R.id.menuCommentary).isVisible)
+        assertFalse(menu.findItem(R.id.menuDictionary).isVisible)
+    }
+
+    @Test
+    fun `onPrepareActionMode hides the Dictionary item when the auto-dictionary preference is on (auto-lookup makes the manual item redundant)`() {
+        every { host.selectedVersesSplit0_1 } returns ints(1)
+        every {
+            Preferences.getBoolean(
+                eq(activity.getString(R.string.pref_autoDictionaryAnalyze_key)),
+                any<Boolean>(),
+            )
+        } returns true
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        assertFalse(menu.findItem(R.id.menuDictionary).isVisible)
+    }
+
+    @Test
+    fun `onPrepareActionMode omits an extension that does not support multiple verses when the user has selected more than one`() {
+        val singleExt = mockk<ExtensionManager.Info>(relaxed = true) {
+            every { supportsMultipleVerses } returns false
+            every { label } returns "SingleOnly"
+        }
+        val multiExt = mockk<ExtensionManager.Info>(relaxed = true) {
+            every { supportsMultipleVerses } returns true
+            every { label } returns "Multi"
+        }
+        every { ExtensionManager.getExtensions() } returns listOf(singleExt, multiExt)
+        every { host.selectedVersesSplit0_1 } returns ints(1, 2)
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        val labels = (0 until menu.size()).map { menu.getItem(it).title?.toString() }
+        assertFalse("SingleOnly extension must be hidden on multi-select", labels.contains("SingleOnly"))
+        assertTrue("Multi-capable extension must still be shown", labels.contains("Multi"))
+    }
+
+    // ----- onActionItemClicked: routing -----
+
+    @Test
+    fun `clicking the Dictionary menu item calls actions startDictionaryMode with the encoded ARI of every selected verse`() {
+        every { host.selectedVersesSplit0_1 } returns ints(2, 3)
+        every { host.activeSplit0Book } returns makeBook("Gen").apply { bookId = 0 }
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        val arisSlot = slot<Set<Int>>()
+        every { actions.startDictionaryMode(capture(arisSlot)) } just Runs
+
+        controller.onActionItemClicked(mode, menu.findItem(R.id.menuDictionary))
+
+        // Ari.encode(bookId=0, chapter=1, verse=2) = (0<<16) | (1<<8) | 2 = 258
+        // Ari.encode(bookId=0, chapter=1, verse=3) = 259
+        assertEquals(setOf(258, 259), arisSlot.captured)
+    }
+
+    @Test
+    fun `clicking Add Bookmark with a non-contiguous selection throws because the menu is supposed to be hidden in that state (defensive contract check)`() {
+        every { host.selectedVersesSplit0_1 } returns ints(1, 3)
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        val item: MenuItem = menu.findItem(R.id.menuAddBookmark)
+        var threw = false
+        try {
+            controller.onActionItemClicked(mode, item)
+        } catch (e: RuntimeException) {
+            threw = true
+            assertTrue(e.message!!.contains("Non contiguous"))
+        }
+        assertTrue("Add Bookmark must throw when invoked on a non-contiguous selection", threw)
+    }
+
+    // ----- onDestroyActionMode -----
+
+    @Test
+    fun `onDestroyActionMode unchecks all verses on split 0 when the uncheckVersesWhenActionModeDestroyed flag is true`() {
+        every { host.uncheckVersesWhenActionModeDestroyed } returns true
+
+        controller.onDestroyActionMode(mode)
+
+        verify { actions.onActionModeDestroyed() }
+        verify { actions.uncheckAllVersesSplit0() }
+    }
+
+    @Test
+    fun `onDestroyActionMode skips the uncheck-all when the uncheckVersesWhenActionModeDestroyed flag is false (preserves selection across split-view transitions)`() {
+        every { host.uncheckVersesWhenActionModeDestroyed } returns false
+
+        controller.onDestroyActionMode(mode)
+
+        verify { actions.onActionModeDestroyed() }
+        verify(exactly = 0) { actions.uncheckAllVersesSplit0() }
+    }
+
+    // ----- helpers -----
+
+    private fun inflateMenu(): Menu {
+        @Suppress("RestrictedApi")
+        return MenuBuilder(activity)
+    }
+
+    private fun ints(vararg values: Int): IntArrayList {
+        val list = IntArrayList(values.size)
+        for (v in values) list.add(v)
+        return list
+    }
+
+    private fun makeBook(shortName: String): Book {
+        val book = Book()
+        book.bookId = 0
+        book.shortName = shortName
+        book.chapter_count = 50
+        book.verse_counts = IntArray(50) { 31 }
+        book.abbreviation = shortName
+        return book
+    }
+
+    private fun makeData(vararg verses: String): VersesDataModel {
+        val scv = object : SingleChapterVerses {
+            override val verseCount: Int get() = verses.size
+            override fun getVerse(verse_0: Int): String = verses[verse_0]
+        }
+        return VersesDataModel(ari_bc_ = 0, verses_ = scv)
+    }
+
+    /** Instantiates [AppConfig] reflectively (private ctor) and sets the fields we care about. */
+    private fun newAppConfig(
+        menuGuide: Boolean = false,
+        menuCommentary: Boolean = false,
+        menuDictionary: Boolean = false,
+    ): AppConfig {
+        val ctor = AppConfig::class.java.getDeclaredConstructor()
+        ctor.isAccessible = true
+        val cfg = ctor.newInstance()
+        cfg.menuGuide = menuGuide
+        cfg.menuCommentary = menuCommentary
+        cfg.menuDictionary = menuDictionary
+        return cfg
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/util/VerseTextFormatterTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/util/VerseTextFormatterTest.kt
@@ -1,0 +1,166 @@
+package yuku.alkitab.base.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import yuku.alkitab.base.verses.VersesDataModel
+import yuku.alkitab.model.Book
+import yuku.alkitab.model.SingleChapterVerses
+import yuku.alkitab.util.IntArrayList
+
+class VerseTextFormatterTest {
+
+    // ----- referenceFromSelectedVerses -----
+
+    @Test
+    fun `referenceFromSelectedVerses with an empty selection returns just the chapter (defensive — should not happen in practice)`() {
+        val book = makeBook(shortName = "Gen")
+        val ref = VerseTextFormatter.referenceFromSelectedVerses(IntArrayList(), book, chapter_1 = 1)
+        assertEquals("Gen 1", ref)
+    }
+
+    @Test
+    fun `referenceFromSelectedVerses with a single verse formats as the book name, chapter, and verse joined by a colon`() {
+        val book = makeBook(shortName = "Gen")
+        val ref = VerseTextFormatter.referenceFromSelectedVerses(ints(5), book, chapter_1 = 1)
+        assertEquals("Gen 1:5", ref)
+    }
+
+    @Test
+    fun `referenceFromSelectedVerses collapses a contiguous run into a dash range`() {
+        val book = makeBook(shortName = "Gen")
+        val ref = VerseTextFormatter.referenceFromSelectedVerses(ints(1, 2, 3), book, chapter_1 = 1)
+        assertEquals("Gen 1:1-3", ref)
+    }
+
+    @Test
+    fun `referenceFromSelectedVerses joins non-contiguous verses with commas`() {
+        val book = makeBook(shortName = "Gen")
+        val ref = VerseTextFormatter.referenceFromSelectedVerses(ints(1, 3, 5), book, chapter_1 = 1)
+        assertEquals("Gen 1:1, 3, 5", ref)
+    }
+
+    // ----- prepareTextForCopyShare -----
+
+    @Test
+    fun `prepareTextForCopyShare with a single verse and no version-name preference omits the version suffix`() {
+        val data = makeData("In the beginning...")
+        val result = VerseTextFormatter.prepareTextForCopyShare(
+            selectedVerses_1 = ints(1),
+            reference = "Gen 1:1",
+            data = data,
+            versionShortName = null,
+            includeVerseNumbers = false,
+        )
+        assertEquals("Gen 1:1  In the beginning...", result[0])
+        assertEquals("In the beginning...", result[1])
+    }
+
+    @Test
+    fun `prepareTextForCopyShare appends versionShortName in parentheses when provided`() {
+        val data = makeData("In the beginning...")
+        val result = VerseTextFormatter.prepareTextForCopyShare(
+            selectedVerses_1 = ints(1),
+            reference = "Gen 1:1",
+            data = data,
+            versionShortName = "KJV",
+            includeVerseNumbers = false,
+        )
+        assertEquals("Gen 1:1 (KJV)  In the beginning...", result[0])
+    }
+
+    @Test
+    fun `prepareTextForCopyShare joins multiple verses with newlines when verse-number prefix is off`() {
+        val data = makeData("Line one", "Line two", "Line three")
+        val result = VerseTextFormatter.prepareTextForCopyShare(
+            selectedVerses_1 = ints(1, 2, 3),
+            reference = "Gen 1:1-3",
+            data = data,
+            versionShortName = null,
+            includeVerseNumbers = false,
+        )
+        assertEquals("Gen 1:1-3  Line one\nLine two\nLine three", result[0])
+        assertEquals("Line one\nLine two\nLine three", result[1])
+    }
+
+    @Test
+    fun `prepareTextForCopyShare prefixes each verse with its number when the verse-number preference is on and more than one verse is selected`() {
+        val data = makeData("Line one", "Line two", "Line three")
+        val result = VerseTextFormatter.prepareTextForCopyShare(
+            selectedVerses_1 = ints(1, 2, 3),
+            reference = "Gen 1:1-3",
+            data = data,
+            versionShortName = null,
+            includeVerseNumbers = true,
+        )
+        assertEquals("Gen 1:1-3\n1 Line one\n2 Line two\n3 Line three", result[0])
+        assertEquals("1 Line one\n2 Line two\n3 Line three", result[1])
+    }
+
+    @Test
+    fun `prepareTextForCopyShare ignores the verse-number preference when only a single verse is selected`() {
+        // The original IsiActivity code only honored the preference when selectedVerses_1.size() > 1.
+        val data = makeData("In the beginning...")
+        val result = VerseTextFormatter.prepareTextForCopyShare(
+            selectedVerses_1 = ints(1),
+            reference = "Gen 1:1",
+            data = data,
+            versionShortName = null,
+            includeVerseNumbers = true,
+        )
+        assertEquals("Gen 1:1  In the beginning...", result[0])
+    }
+
+    @Test
+    fun `prepareTextForCopyShare strips formatting codes from the copy text but preserves them in the submit text`() {
+        // @9 / @7 are italic open/close codes; FormattedVerseText.removeSpecialCodes strips them.
+        val data = makeData("@@Hello @9world@7!")
+        val result = VerseTextFormatter.prepareTextForCopyShare(
+            selectedVerses_1 = ints(1),
+            reference = "Gen 1:1",
+            data = data,
+            versionShortName = null,
+            includeVerseNumbers = false,
+        )
+        assertEquals("Gen 1:1  Hello world!", result[0])
+        assertEquals("@@Hello @9world@7!", result[1])
+    }
+
+    @Test
+    fun `prepareTextForCopyShare silently skips verses whose text is null (out-of-range), matching the original IsiActivity behavior`() {
+        val data = makeData("Line one")   // only verse 1 exists
+        val result = VerseTextFormatter.prepareTextForCopyShare(
+            selectedVerses_1 = ints(1, 2),
+            reference = "Gen 1:1-2",
+            data = data,
+            versionShortName = null,
+            includeVerseNumbers = false,
+        )
+        assertEquals("Gen 1:1-2  Line one", result[0])
+    }
+
+    // ----- helpers -----
+
+    private fun ints(vararg values: Int): IntArrayList {
+        val list = IntArrayList(values.size)
+        for (v in values) list.add(v)
+        return list
+    }
+
+    private fun makeBook(shortName: String): Book {
+        val book = Book()
+        book.bookId = 0
+        book.shortName = shortName
+        book.chapter_count = 50
+        book.verse_counts = IntArray(50) { 31 }
+        book.abbreviation = shortName
+        return book
+    }
+
+    private fun makeData(vararg verses: String): VersesDataModel {
+        val scv = object : SingleChapterVerses {
+            override val verseCount: Int get() = verses.size
+            override fun getVerse(verse_0: Int): String = verses[verse_0]
+        }
+        return VersesDataModel(ari_bc_ = 0, verses_ = scv)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ ext {
     // Tests
     junitVersion = '4.13.2'
     leakcanaryVersion = '2.14'
+    mockkVersion = '1.13.13'
+    robolectricVersion = '4.13'
 
     firebaseBomVersion = '29.0.3'
 


### PR DESCRIPTION
## Summary
- Extract the ~500-line `actionMode_callback` object out of `IsiActivity.kt` into a dedicated `VerseActionModeController` behind two interfaces (`VerseActionModeHost`, `VerseActionModeActions`). Pure text-building logic moves to `VerseTextFormatter`. `RibkaEligibility` is promoted to a top-level file. `IsiActivity` shrinks 2894 → 2320 lines (−574).
- Behavior is preserved verbatim. While extracting I noticed a real bug — when the user picks "Copy Split1" / "Share Split1", the verse text is correctly built from split1 but the metadata passed to `ShareUrl.make` (`version`, `preset_name`, `ari_bc`) comes from split0, so the resulting share URL points back to the wrong version. The bug exists on `develop` today and is preserved here on purpose; it'll land in a focused follow-up so this PR stays a pure refactor.
- Adds `mockk` and `Robolectric` to the test classpath plus 26 new unit tests: 11 pure-JUnit tests for `VerseTextFormatter` and 15 Robolectric tests for `VerseActionModeController` covering menu-visibility rules and click routing. The new controller test reuses the test-scope `FirebaseCrashlytics` shadow added by REM-23 instead of mocking statics.

## Why these interfaces (and why this naming)
The `host`/`actions` split mirrors a read-side / write-side dependency-inversion seam:
- `VerseActionModeHost` exposes only the state the controller reads (`activeSplit0Book`, `activeSplit0Version`, `activeSplit1Version`, `selectedVersesSplit0_1`, `dataSplit0`, `chapter_1`, `root`, `hasEsvsbAsal`, `uncheckVersesWhenActionModeDestroyed`, plus an `activity: AppCompatActivity` for framework calls that genuinely need an Activity).
- `VerseActionModeActions` exposes operations the controller invokes (`uncheckAllVersesSplit0`, `reloadBothAttributeMaps`, `loadVersion`, `startDictionaryMode`, `checkRibkaEligibility`, `onActionModeDestroyed`).

Property names keep the existing `activeSplit0` / `activeSplit1` vocabulary so the diff against the original code is easy to read.

## Test plan
- [x] `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest assemblePlainDebug` passes locally.
- [x] All 26 new tests pass; pre-existing tests (including REM-18b's sync tests and REM-23's `HighlightsTest`) continue to pass.
- [x] Smoke test on device: open a chapter, select one verse → action mode appears with all expected items (Copy / Share / Compare / Add Bookmark / Add Note / Add Highlight / Dictionary). Try multiple-verse contiguous and non-contiguous selections. Open split view and verify Copy/Share split variants appear instead of unified items.
- [x] Verify Ribka Report item appears with the in-ayt version and a single verse selected.
- [x] Verify ESV Study Bible item appears if `yuku.esvsbasal` is installed.

## Follow-up
The split1 share-URL metadata bug noted above will be filed/fixed in a separate PR — keeping this one a behavior-preserving refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)