### PR TITLE
Fix Copy/Share Split1 using split0 metadata in share URL

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -142,6 +142,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     override val activeSplit0VersionId: String get() = activeSplit0.versionId
     override val activeSplit0MVersion: MVersion get() = activeSplit0.mv
     override val activeSplit1Version: Version? get() = activeSplit1?.version
+    override val activeSplit1VersionId: String? get() = activeSplit1?.versionId
     override val activeSplit1MVersion: MVersion? get() = activeSplit1?.mv
     override fun activeSplit1BookById(bookId: Int): Book? = activeSplit1?.version?.getBook(bookId)
     override val selectedVersesSplit0_1: IntArrayList get() = lsSplit0.getCheckedVerses_1()

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
@@ -203,15 +203,29 @@ class VerseActionModeController(
                 val textToCopy = t[0]
                 val textToSubmit = t[1]
 
+                // For menuCopySplit1 the clipboard text is built from split1, so the share URL
+                // metadata (version, preset_name, ari_bc) must also point at split1. For
+                // menuCopyBothSplits we intentionally keep split0's metadata because it is the
+                // primary version; the URL is anchored to the primary even though both texts
+                // are included in the clipboard.
+                val useSplit1Metadata = itemId == R.id.menuCopySplit1 && activeSplit1Version != null
+                val shareUrlBookId = if (useSplit1Metadata) {
+                    host.activeSplit1BookById(host.activeSplit0Book.bookId)?.bookId ?: host.activeSplit0Book.bookId
+                } else {
+                    host.activeSplit0Book.bookId
+                }
+                val shareUrlVersion = if (useSplit1Metadata) activeSplit1Version ?: host.activeSplit0Version else host.activeSplit0Version
+                val shareUrlVersionId = if (useSplit1Metadata) host.activeSplit1VersionId ?: host.activeSplit0VersionId else host.activeSplit0VersionId
+
                 ShareUrl.make(
                     activity = host.activity,
                     immediatelyCancel = !Preferences.getBoolean(host.activity.getString(R.string.pref_copyWithShareUrl_key), host.activity.resources.getBoolean(R.bool.pref_copyWithShareUrl_default)),
                     verseText = textToSubmit,
-                    ari_bc = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, 0),
+                    ari_bc = Ari.encode(shareUrlBookId, host.chapter_1, 0),
                     selectedVerses_1 = selected,
                     reference = reference,
-                    version = host.activeSplit0Version,
-                    preset_name = MVersionDb.presetNameFromVersionId(host.activeSplit0VersionId),
+                    version = shareUrlVersion,
+                    preset_name = MVersionDb.presetNameFromVersionId(shareUrlVersionId),
                     callback = object : ShareUrl.Callback {
                         override fun onSuccess(shareUrl: String) {
                             ClipboardUtil.copyToClipboard("$textToCopy\n\n$shareUrl")
@@ -263,15 +277,29 @@ class VerseActionModeController(
                     .setSubject(reference)
                     .intent
 
+                // For menuShareSplit1 the shared text is built from split1, so the share URL
+                // metadata (version, preset_name, ari_bc) must also point at split1. For
+                // menuShareBothSplits we intentionally keep split0's metadata because it is
+                // the primary version; the URL is anchored to the primary even though both
+                // texts are included in the share payload.
+                val useSplit1Metadata = itemId == R.id.menuShareSplit1 && activeSplit1Version != null
+                val shareUrlBookId = if (useSplit1Metadata) {
+                    host.activeSplit1BookById(host.activeSplit0Book.bookId)?.bookId ?: host.activeSplit0Book.bookId
+                } else {
+                    host.activeSplit0Book.bookId
+                }
+                val shareUrlVersion = if (useSplit1Metadata) activeSplit1Version ?: host.activeSplit0Version else host.activeSplit0Version
+                val shareUrlVersionId = if (useSplit1Metadata) host.activeSplit1VersionId ?: host.activeSplit0VersionId else host.activeSplit0VersionId
+
                 ShareUrl.make(
                     activity = host.activity,
                     immediatelyCancel = !Preferences.getBoolean(host.activity.getString(R.string.pref_copyWithShareUrl_key), host.activity.resources.getBoolean(R.bool.pref_copyWithShareUrl_default)),
                     verseText = textToSubmit,
-                    ari_bc = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, 0),
+                    ari_bc = Ari.encode(shareUrlBookId, host.chapter_1, 0),
                     selectedVerses_1 = selected,
                     reference = reference,
-                    version = host.activeSplit0Version,
-                    preset_name = MVersionDb.presetNameFromVersionId(host.activeSplit0VersionId),
+                    version = shareUrlVersion,
+                    preset_name = MVersionDb.presetNameFromVersionId(shareUrlVersionId),
                     callback = object : ShareUrl.Callback {
                         override fun onSuccess(shareUrl: String) {
                             intent.putExtra(Intent.EXTRA_TEXT, "$textToShare\n\n$shareUrl")

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
@@ -203,29 +203,17 @@ class VerseActionModeController(
                 val textToCopy = t[0]
                 val textToSubmit = t[1]
 
-                // For menuCopySplit1 the clipboard text is built from split1, so the share URL
-                // metadata (version, preset_name, ari_bc) must also point at split1. For
-                // menuCopyBothSplits we intentionally keep split0's metadata because it is the
-                // primary version; the URL is anchored to the primary even though both texts
-                // are included in the clipboard.
-                val useSplit1Metadata = itemId == R.id.menuCopySplit1 && activeSplit1Version != null
-                val shareUrlBookId = if (useSplit1Metadata) {
-                    host.activeSplit1BookById(host.activeSplit0Book.bookId)?.bookId ?: host.activeSplit0Book.bookId
-                } else {
-                    host.activeSplit0Book.bookId
-                }
-                val shareUrlVersion = if (useSplit1Metadata) activeSplit1Version ?: host.activeSplit0Version else host.activeSplit0Version
-                val shareUrlVersionId = if (useSplit1Metadata) host.activeSplit1VersionId ?: host.activeSplit0VersionId else host.activeSplit0VersionId
+                val meta = pickShareUrlMetadata(useSplit1 = itemId == R.id.menuCopySplit1 && activeSplit1Version != null)
 
                 ShareUrl.make(
                     activity = host.activity,
                     immediatelyCancel = !Preferences.getBoolean(host.activity.getString(R.string.pref_copyWithShareUrl_key), host.activity.resources.getBoolean(R.bool.pref_copyWithShareUrl_default)),
                     verseText = textToSubmit,
-                    ari_bc = Ari.encode(shareUrlBookId, host.chapter_1, 0),
+                    ari_bc = Ari.encode(meta.bookId, host.chapter_1, 0),
                     selectedVerses_1 = selected,
                     reference = reference,
-                    version = shareUrlVersion,
-                    preset_name = MVersionDb.presetNameFromVersionId(shareUrlVersionId),
+                    version = meta.version,
+                    preset_name = MVersionDb.presetNameFromVersionId(meta.versionId),
                     callback = object : ShareUrl.Callback {
                         override fun onSuccess(shareUrl: String) {
                             ClipboardUtil.copyToClipboard("$textToCopy\n\n$shareUrl")
@@ -277,29 +265,17 @@ class VerseActionModeController(
                     .setSubject(reference)
                     .intent
 
-                // For menuShareSplit1 the shared text is built from split1, so the share URL
-                // metadata (version, preset_name, ari_bc) must also point at split1. For
-                // menuShareBothSplits we intentionally keep split0's metadata because it is
-                // the primary version; the URL is anchored to the primary even though both
-                // texts are included in the share payload.
-                val useSplit1Metadata = itemId == R.id.menuShareSplit1 && activeSplit1Version != null
-                val shareUrlBookId = if (useSplit1Metadata) {
-                    host.activeSplit1BookById(host.activeSplit0Book.bookId)?.bookId ?: host.activeSplit0Book.bookId
-                } else {
-                    host.activeSplit0Book.bookId
-                }
-                val shareUrlVersion = if (useSplit1Metadata) activeSplit1Version ?: host.activeSplit0Version else host.activeSplit0Version
-                val shareUrlVersionId = if (useSplit1Metadata) host.activeSplit1VersionId ?: host.activeSplit0VersionId else host.activeSplit0VersionId
+                val meta = pickShareUrlMetadata(useSplit1 = itemId == R.id.menuShareSplit1 && activeSplit1Version != null)
 
                 ShareUrl.make(
                     activity = host.activity,
                     immediatelyCancel = !Preferences.getBoolean(host.activity.getString(R.string.pref_copyWithShareUrl_key), host.activity.resources.getBoolean(R.bool.pref_copyWithShareUrl_default)),
                     verseText = textToSubmit,
-                    ari_bc = Ari.encode(shareUrlBookId, host.chapter_1, 0),
+                    ari_bc = Ari.encode(meta.bookId, host.chapter_1, 0),
                     selectedVerses_1 = selected,
                     reference = reference,
-                    version = shareUrlVersion,
-                    preset_name = MVersionDb.presetNameFromVersionId(shareUrlVersionId),
+                    version = meta.version,
+                    preset_name = MVersionDb.presetNameFromVersionId(meta.versionId),
                     callback = object : ShareUrl.Callback {
                         override fun onSuccess(shareUrl: String) {
                             intent.putExtra(Intent.EXTRA_TEXT, "$textToShare\n\n$shareUrl")
@@ -618,4 +594,34 @@ class VerseActionModeController(
         t[0] += "\n\n${a[0]}"
         t[1] += "\n\n${a[1]}"
     }
+
+    /**
+     * The share-URL metadata (version, versionId, book id) for the current copy/share click.
+     *
+     * Pass `useSplit1 = true` only for the "...Split1" menu variants — the clipboard/share
+     * text is built from split1, so the URL must also point at split1. For the "...BothSplits"
+     * variants we intentionally pass `useSplit1 = false`: both verse texts are included in the
+     * payload, but the URL is anchored to the primary (split0) version.
+     */
+    private fun pickShareUrlMetadata(useSplit1: Boolean): ShareUrlMetadata {
+        return if (useSplit1) {
+            ShareUrlMetadata(
+                bookId = host.activeSplit1BookById(host.activeSplit0Book.bookId)?.bookId ?: host.activeSplit0Book.bookId,
+                version = host.activeSplit1Version ?: host.activeSplit0Version,
+                versionId = host.activeSplit1VersionId ?: host.activeSplit0VersionId,
+            )
+        } else {
+            ShareUrlMetadata(
+                bookId = host.activeSplit0Book.bookId,
+                version = host.activeSplit0Version,
+                versionId = host.activeSplit0VersionId,
+            )
+        }
+    }
+
+    private data class ShareUrlMetadata(
+        val bookId: Int,
+        val version: Version,
+        val versionId: String,
+    )
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeHost.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeHost.kt
@@ -28,6 +28,7 @@ interface VerseActionModeHost {
 
     // Secondary ("split 1") — null when the split view is closed.
     val activeSplit1Version: Version?
+    val activeSplit1VersionId: String?
     val activeSplit1MVersion: MVersion?
 
     /** Looks up the book with the given id in the split-1 version, or null. */

--- a/Alkitab/src/test/java/yuku/alkitab/base/actionmode/VerseActionModeControllerTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/actionmode/VerseActionModeControllerTest.kt
@@ -29,10 +29,13 @@ import org.robolectric.annotation.Config
 import yuku.afw.storage.Preferences
 import yuku.alkitab.base.config.AppConfig
 import yuku.alkitab.base.util.ExtensionManager
+import yuku.alkitab.base.util.ShareUrl
 import yuku.alkitab.base.verses.VersesDataModel
 import yuku.alkitab.debug.R
 import yuku.alkitab.model.Book
 import yuku.alkitab.model.SingleChapterVerses
+import yuku.alkitab.model.Version
+import yuku.alkitab.util.Ari
 import yuku.alkitab.util.IntArrayList
 
 /**
@@ -86,6 +89,7 @@ class VerseActionModeControllerTest {
         every { host.activeSplit0VersionId } returns "internal"
         every { host.activeSplit0MVersion } returns mockk(relaxed = true)
         every { host.activeSplit1Version } returns null
+        every { host.activeSplit1VersionId } returns null
         every { host.activeSplit1MVersion } returns null
         every { host.activeSplit1BookById(any()) } returns null
         every { host.selectedVersesSplit0_1 } returns ints(1)
@@ -340,6 +344,182 @@ class VerseActionModeControllerTest {
 
         verify { actions.onActionModeDestroyed() }
         verify(exactly = 0) { actions.uncheckAllVersesSplit0() }
+    }
+
+    // ----- onActionItemClicked: ShareUrl.make metadata routing -----
+    //
+    // Regression-and-fix coverage for the bug where Copy/Share Split1 would build the text
+    // from split1 but pass split0-anchored metadata (version, preset_name, ari_bc) to
+    // ShareUrl.make, producing a share URL that pointed back at the wrong version.
+
+    @Test
+    fun `clicking Copy Split1 passes split1 version, preset_name, and ari_bc to ShareUrl make (not split0 as before)`() {
+        val split0Book = makeBook("Gen").apply { bookId = 0 }
+        val split1Book = makeBook("Kej").apply { bookId = 2 }
+        val split1Version = mockk<Version>(relaxed = true) { every { shortName } returns "TB" }
+
+        every { host.activeSplit0Book } returns split0Book
+        every { host.activeSplit0Version } returns mockk(relaxed = true) { every { shortName } returns "KJV" }
+        every { host.activeSplit0VersionId } returns "internal"
+        every { host.activeSplit1Version } returns split1Version
+        every { host.activeSplit1VersionId } returns "preset/tb"
+        every { host.activeSplit1BookById(0) } returns split1Book
+        every { host.selectedVersesSplit0_1 } returns ints(3)
+        every { host.selectedVersesSplit1_1 } returns ints(3)
+        every { host.dataSplit1 } returns makeData("", "", "", "Pada mulanya Allah menciptakan langit dan bumi.")
+
+        stubShareUrlMake()
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+        controller.onActionItemClicked(mode, menu.findItem(R.id.menuCopySplit1))
+
+        verify(exactly = 1) {
+            ShareUrl.make(
+                activity = any(),
+                immediatelyCancel = any(),
+                verseText = any(),
+                ari_bc = Ari.encode(2, 1, 0),
+                selectedVerses_1 = any(),
+                reference = any(),
+                version = split1Version,
+                preset_name = "tb",
+                callback = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `clicking Share Split1 passes split1 version, preset_name, and ari_bc to ShareUrl make (not split0 as before)`() {
+        val split0Book = makeBook("Gen").apply { bookId = 0 }
+        val split1Book = makeBook("Kej").apply { bookId = 2 }
+        val split1Version = mockk<Version>(relaxed = true) { every { shortName } returns "TB" }
+
+        every { host.activeSplit0Book } returns split0Book
+        every { host.activeSplit0Version } returns mockk(relaxed = true) { every { shortName } returns "KJV" }
+        every { host.activeSplit0VersionId } returns "internal"
+        every { host.activeSplit1Version } returns split1Version
+        every { host.activeSplit1VersionId } returns "preset/tb"
+        every { host.activeSplit1BookById(0) } returns split1Book
+        every { host.selectedVersesSplit0_1 } returns ints(3)
+        every { host.selectedVersesSplit1_1 } returns ints(3)
+        every { host.dataSplit1 } returns makeData("", "", "", "Pada mulanya Allah menciptakan langit dan bumi.")
+
+        stubShareUrlMake()
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+        controller.onActionItemClicked(mode, menu.findItem(R.id.menuShareSplit1))
+
+        verify(exactly = 1) {
+            ShareUrl.make(
+                activity = any(),
+                immediatelyCancel = any(),
+                verseText = any(),
+                ari_bc = Ari.encode(2, 1, 0),
+                selectedVerses_1 = any(),
+                reference = any(),
+                version = split1Version,
+                preset_name = "tb",
+                callback = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `clicking Share Split0 with a split view active still uses split0 metadata for ShareUrl make (regression guard so the easy case keeps working)`() {
+        val split0Book = makeBook("Gen").apply { bookId = 0 }
+        val split1Book = makeBook("Kej").apply { bookId = 2 }
+        val split0Version = mockk<Version>(relaxed = true) { every { shortName } returns "KJV" }
+        val split1Version = mockk<Version>(relaxed = true) { every { shortName } returns "TB" }
+
+        every { host.activeSplit0Book } returns split0Book
+        every { host.activeSplit0Version } returns split0Version
+        every { host.activeSplit0VersionId } returns "preset/kjv"
+        every { host.activeSplit1Version } returns split1Version
+        every { host.activeSplit1VersionId } returns "preset/tb"
+        every { host.activeSplit1BookById(0) } returns split1Book
+        every { host.selectedVersesSplit0_1 } returns ints(3)
+        every { host.selectedVersesSplit1_1 } returns ints(3)
+
+        stubShareUrlMake()
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+        controller.onActionItemClicked(mode, menu.findItem(R.id.menuShareSplit0))
+
+        verify(exactly = 1) {
+            ShareUrl.make(
+                activity = any(),
+                immediatelyCancel = any(),
+                verseText = any(),
+                ari_bc = Ari.encode(0, 1, 0),
+                selectedVerses_1 = any(),
+                reference = any(),
+                version = split0Version,
+                preset_name = "kjv",
+                callback = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `clicking Share with no split active uses split0 metadata for ShareUrl make (regression guard for the non-split code path)`() {
+        val split0Book = makeBook("Gen").apply { bookId = 0 }
+        val split0Version = mockk<Version>(relaxed = true) { every { shortName } returns "KJV" }
+
+        every { host.activeSplit0Book } returns split0Book
+        every { host.activeSplit0Version } returns split0Version
+        every { host.activeSplit0VersionId } returns "internal"
+        every { host.activeSplit1Version } returns null
+        every { host.activeSplit1VersionId } returns null
+        every { host.selectedVersesSplit0_1 } returns ints(3)
+
+        stubShareUrlMake()
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+        controller.onActionItemClicked(mode, menu.findItem(R.id.menuShare))
+
+        // preset_name is null because versionId = "internal" is not a preset.
+        verify(exactly = 1) {
+            ShareUrl.make(
+                activity = any(),
+                immediatelyCancel = any(),
+                verseText = any(),
+                ari_bc = Ari.encode(0, 1, 0),
+                selectedVerses_1 = any(),
+                reference = any(),
+                version = split0Version,
+                preset_name = null,
+                callback = any(),
+            )
+        }
+    }
+
+    /**
+     * Stubs `ShareUrl.make` to a no-op so tests can verify the arguments without triggering the
+     * real network/dialog flow. `mockkObject` is undone by `unmockkAll()` in @After.
+     */
+    private fun stubShareUrlMake() {
+        mockkObject(ShareUrl)
+        every {
+            ShareUrl.make(
+                activity = any(),
+                immediatelyCancel = any(),
+                verseText = any(),
+                ari_bc = any(),
+                selectedVerses_1 = any(),
+                reference = any(),
+                version = any(),
+                preset_name = any(),
+                callback = any(),
+            )
+        } just Runs
     }
 
     // ----- helpers -----


### PR DESCRIPTION
## Summary

- Fixes a bug where picking "Copy Split1" or "Share Split1" in the verse-selection action mode built text from split1 but passed split0-anchored metadata (`version`, `preset_name`, `ari_bc`) to `ShareUrl.make`, so the resulting share URL pointed back at the wrong version.
- Adds unit tests that cover the fix and guard against regression of the easy split0/no-split cases.

## What changed

**Production** — [VerseActionModeController.kt](Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt): both the copy branch and the share branch now compute `shareUrlBookId`, `shareUrlVersion`, and `shareUrlVersionId` up front, routing through split1 only when the clicked item is `menuCopySplit1`/`menuShareSplit1` and a split1 version is active. Comments explain that `BothSplits` intentionally keeps split0 as the primary anchor.

**Interface** — [VerseActionModeHost.kt](Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeHost.kt): adds `val activeSplit1VersionId: String?`.

**IsiActivity** — [IsiActivity.kt](Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt): overrides `activeSplit1VersionId` as `activeSplit1?.versionId`.

## Why

The bug existed verbatim in `IsiActivity.actionMode_callback` before the REM-07 refactor (#135) and was preserved by design for behavior-preserving extraction. Now that `VerseActionModeControllerTest` exists with mockk + Robolectric infrastructure, the fix can be tested surgically.

## Tests

Four new tests in [VerseActionModeControllerTest.kt](Alkitab/src/test/java/yuku/alkitab/base/actionmode/VerseActionModeControllerTest.kt):

- `clicking Copy Split1 passes split1 version, preset_name, and ari_bc to ShareUrl make (not split0 as before)` — fix coverage
- `clicking Share Split1 passes split1 version, preset_name, and ari_bc to ShareUrl make (not split0 as before)` — fix coverage
- `clicking Share Split0 with a split view active still uses split0 metadata for ShareUrl make (regression guard so the easy case keeps working)` — regression guard
- `clicking Share with no split active uses split0 metadata for ShareUrl make (regression guard for the non-split code path)` — regression guard, covers the null-preset path

Implementation uses `mockkObject(ShareUrl)` + `verify { ShareUrl.make(...) }` with concrete expected values (e.g. `Ari.encode(2, 1, 0)`, `"tb"`, `split1Version`). Verified the tests actually catch the bug by temporarily reverting the fix — both Split1 tests fail with clear diagnostics:

```
[3] argument: 256, matcher: eq(131328), result: -     # ari_bc wrong (split0's)
[6] argument: Version(#274), matcher: eq(Version(#273)), result: -   # version wrong
[7] argument: null, matcher: eq(tb), result: -        # preset_name wrong
```

## Test plan

- [x] `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest assemblePlainDebug` — all pass
- [x] 19 tests in `VerseActionModeControllerTest` (15 existing + 4 new), all green
- [ ] Manual smoke test in a split view: Copy Split1 / Share Split1 / Copy Split0 / Share Split0 / Copy BothSplits / Share BothSplits produce share URLs that match the chosen version

🤖 Generated with [Claude Code](https://claude.com/claude-code)