### PR TITLE
Update docs: mark REM-07/18a/18b completed, fix TD-01/02/13, add README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,35 @@ Run the unit tests used in CI:
 
     ./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest
 
+Developer Documentation
+-----------------------
+
+For working with the codebase, see [CLAUDE.md](CLAUDE.md) (architecture overview, module structure, ARI encoding, code conventions, and build instructions) and the `docs/` folder:
+
+**Architecture & infrastructure**
+- [Architecture Deep Dive](docs/architecture.md) — singleton patterns, data flow, module dependencies
+- [Build System](docs/build-system.md) — flavors, signing, CI/CD, release process
+- [Storage & Database](docs/storage.md) — SQLite schema, preferences, file storage
+- [Backend Communication](docs/backend-communication.md) — API endpoints, download flows
+- [Text Rendering](docs/text-rendering.md) — verse formatting pipeline and codes
+- [Binary Formats](docs/binary-formats.md) — YES2, Bintex, RPB file format specs
+
+**Feature modules**
+- [Songs](docs/modules/songs.md) — song book browsing, search, audio playback
+- [Reading Plans](docs/modules/reading-plans.md) — RPB binary format, daily progress tracking
+- [Versions](docs/modules/versions.md) — Bible version management, download, YES2 format
+- [Markers](docs/modules/markers.md) — bookmarks, notes, highlights system
+- [Sync](docs/modules/sync.md) — cloud sync protocol and FCM push
+- [Devotions](docs/modules/devotions.md) — daily devotional articles
+- [Audio Playback](docs/modules/audio-playback.md) — ExoPlayer/MIDI controllers
+- [Search](docs/modules/search.md) — full-text verse search engine
+- [Daily Verse Widget](docs/modules/daily-verse-widget.md) — home screen widget
+- [Data Transfer](docs/modules/data-transfer.md) — JSON export/import of user data
+
+**Tech debt**
+- [Tech Debt & Known Issues](docs/tech-debt.md) — known problems with file/line references
+- [Tech Debt Remediation Plan](docs/tech-debt-remediation.md) — prioritized fixes with BRICE scores
+
 Notes
 -----
 

--- a/docs/tech-debt-remediation.md
+++ b/docs/tech-debt-remediation.md
@@ -133,17 +133,22 @@ This document provides a prioritized remediation plan for each tech debt item id
 
 ---
 
-### REM-07: Extract IsiActivity Action Mode
+### REM-07: Extract IsiActivity Action Mode ✅ COMPLETED
 **Addresses:** TD-01 (action mode cluster)  
 **Module:** Main reader  
 **BRICE:** B=4 R=3 I=3 C=3 E=4 → **3.4**
 
-**Steps:**
-1. Create `VerseActionModeController.kt` implementing `ActionMode.Callback`
-2. Move the `actionMode_callback` object (lines 524-1023 in `IsiActivity.kt`, ~500 lines) into this new class — includes `onCreateActionMode`, `onPrepareActionMode`, `onActionItemClicked`, `appendSplitTextForCopyShare`, and `onDestroyActionMode`
-3. Define a `VerseActionModeCallback` interface for actions that need Activity context (navigate, share, etc.)
-4. Inject dependencies: `selectedVerses`, `activeVersion`, `ClipboardManager`
-5. Handle extension menu items via delegate pattern
+**Completed in:** `89a1894e` (REM-07 refactor) + `716eb1ce` (follow-up split-1 fix, 2026-04-16)
+
+**What was done:**
+1. ✅ Created `VerseActionModeController.kt` (~593 lines) implementing `ActionMode.Callback`. Moved the entire ~500-line `actionMode_callback` object from `IsiActivity.kt` into this class.
+2. ✅ Defined two interfaces: `VerseActionModeHost` (queries activity state — selected verses, versions, book data, chapter) and `VerseActionModeActions` (callbacks back into the activity — navigate, show toasts, etc.)
+3. ✅ Extracted pure text-building logic into `VerseTextFormatter` (no Android dependencies, purely testable under plain JUnit)
+4. ✅ Moved `RibkaEligibility` to a standalone top-level file `RibkaEligibility.kt`
+5. ✅ Added `mockk` to the test classpath. Added 26 unit tests: 11 pure-JUnit tests for `VerseTextFormatterTest`, 15 Robolectric tests for `VerseActionModeControllerTest` (menu visibility rules, click routing)
+6. ✅ Follow-up PR `716eb1ce` fixed the split-1 share URL metadata bug (PB-08) that had been preserved verbatim in the REM-07 refactor. Four regression tests added for copy/share split-0/1 metadata routing.
+
+**Result:** `IsiActivity.kt` shrank from 2894 → 2320 lines (−574 lines). Action mode is now independently testable without instantiating the Activity.
 
 **Difficulty:** Medium (6-8 hours). Risk: action mode references many Activity-level fields and methods.
 
@@ -415,16 +420,17 @@ Use Android Studio's "Convert Java File to Kotlin" as a starting point, then man
 
 **Steps — prioritized by risk coverage:**
 
-**Step 18a: Highlight encoding tests**
-1. Write unit tests for `Highlights.java`: encode/decode, hash verification, partial highlights
-2. Test edge cases: empty highlights, Unicode text, version text changes
-3. Difficulty: Easy (2-3 hours)
+**Step 18a: Highlight encoding tests** ✅ COMPLETED
+**Completed in:** `513961b9` / `1ca73821` (2026-04-16)
+1. ✅ Added 31 unit tests in `HighlightsTest.kt`: encode/decode round-trip, hash verification, partial-highlight guard, alphaMix with ARGB input
+2. ✅ Fixed `Highlights.alphaMix()` ARGB leak: changed `0xa0000000 | colorRgb` to `0xa0000000 | (colorRgb & 0x00ffffff)` so the output alpha is always `0xA0` regardless of what the caller passes
+3. ✅ Added test-scope no-op shadows for `android.util.Log` and `com.google.firebase.crashlytics.FirebaseCrashlytics` — these unblock all future Alkitab module unit tests that touch `AppLog`
 
-**Step 18b: Sync protocol tests**
-1. Create mock server responses for `Sync_Mabel`, `Sync_Pins`, `Sync_Rp`
-2. Test delta application: add, mod, del operations
-3. Test conflict scenarios: concurrent edits, missing GIDs
-4. Difficulty: Medium (1 day)
+**Step 18b: Sync protocol tests** ✅ COMPLETED
+**Completed in:** `b4bce934` (2026-04-16)
+1. ✅ Added 101 unit tests across `SyncDeltaTest.kt`, `Sync_MabelTest.kt`, `Sync_PinsTest.kt`, `Sync_RpTest.kt` — covers `SyncAdapter.patchNoConflict` delta application (add/mod/del, missing GIDs, conflict, idempotency), `Sync.entitiesEqual`, `SyncUtils.findEntity/isSameContent`, `Sync_Mabel.updateMarker/Label/Marker_Label`, and `Content equals/hashCode/toString` for all three sync sets
+2. ✅ Fixed `Sync_Pins.Content.equals()`: was sorting copies but comparing the original unsorted lists — now compares sorted copies. Fixed `hashCode()` to match order-insensitive equals (violations would cause misbehavior inside `HashMap`/`HashSet`)
+3. ✅ Added test-scope stub for `android.util.Pair` so `patchNoConflict` runs without Robolectric
 
 **Step 18c: InternalDb tests (or Room DAO tests)** ✅ COMPLETED
 1. ✅ Added Robolectric (`4.14.1`) as a `testImplementation` dependency and enabled `testOptions.unitTests.includeAndroidResources` in `Alkitab/build.gradle` — Robolectric is required because `InternalDbHelper` extends Android's `SQLiteOpenHelper`
@@ -636,7 +642,7 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 | REM-03 | Replace LocalBroadcastManager | **3.8** | 1 |
 | REM-23 | ~~Port ybuild.sh to Gradle~~ ✅ | **3.8** | 2 |
 | REM-06 | Extract IsiActivity gestures | **3.4** | 2 |
-| REM-07 | Extract IsiActivity action mode | **3.4** | 2 |
+| REM-07 | ~~Extract IsiActivity action mode~~ ✅ | **3.4** | 2 |
 | REM-09 | Introduce ViewModel | **3.4** | 2 |
 | REM-10 | Room migration (Markers) | **3.4** | 2 |
 | REM-12 | ~~Replace DragSortListView~~ ✅ | **3.4** | 2 |
@@ -657,8 +663,8 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 
 **Sprint 1 (1 week):** ~~REM-01~~✅, ~~REM-02~~✅, REM-04, REM-05 — quick safety fixes (REM-01/02 done)  
 **Sprint 2 (1 week):** REM-03 — LocalBroadcastManager removal (touches many files, best done in isolation)  
-**Sprint 3 (2 weeks):** REM-06, REM-07, REM-08 — IsiActivity decomposition  
-**Sprint 4 (1 week):** REM-12, REM-14 — deprecated library replacements  
+**Sprint 3 (2 weeks):** ~~REM-07~~✅, REM-06, REM-08 — IsiActivity decomposition (REM-07 done)  
+**Sprint 4 (1 week):** ~~REM-12~~✅, REM-14 — deprecated library replacements (REM-12 done)  
 **Sprint 5 (2 weeks):** REM-10, REM-11 — Room migration for core tables  
-**Sprint 6 (2 weeks):** REM-09, REM-18a-b — ViewModel + test coverage  
+**Sprint 6 (2 weeks):** REM-09, ~~REM-18a-d~~✅ — ViewModel + test coverage (REM-18a/b/c/d done)  
 **Ongoing:** REM-15, REM-16, REM-17 — modernization work mixed into feature sprints

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -1,19 +1,19 @@
 # Tech Debt, Improvements & Critiques
 
-## TD-01: IsiActivity God Class (2897 lines)
+## TD-01: IsiActivity God Class (~2320 lines)
 
 **File:** `Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt`
 
-The main Bible reader activity is a monolithic class containing 40+ inline lambda callbacks, 2900 lines of mixed concerns. Specific clusters that violate single-responsibility:
+The main Bible reader activity is a monolithic class containing many inline lambda callbacks, ~2320 lines of mixed concerns (down from 2897 after REM-07 extracted action mode). Specific clusters that violate single-responsibility:
 
 - **Gesture handling (lines 143–370):** `onFloaterDragStart/Move/Complete`, `onOnefingerLeft/Right`, `onTwofingerStart/Scale/DragX/DragY/End` — all inline lambdas that implement `TwofingerLinearLayout.Listener`. This is ~230 lines of touch gesture processing embedded in the Activity.
-- **Action mode (lines 530–1014):** `onCreateActionMode`, `onPrepareActionMode`, `onActionItemClicked`, `onDestroyActionMode` — ~480 lines of context menu handling for copy, share, bookmark, highlight, compare, dictionary, extensions.
+- **~~Action mode~~** ✅ **Extracted (REM-07):** The ~500-line `actionMode_callback` object has been moved to `VerseActionModeController.kt` behind two interfaces (`VerseActionModeHost`, `VerseActionModeActions`). Pure text-building logic is in `VerseTextFormatter` (no Android deps). `RibkaEligibility` is a top-level file. 26 unit tests added.
 - **Broadcast receivers (lines 451–519):** Two anonymous `BroadcastReceiver` instances registered inline, one for verse attribute changes and one for version changes.
 - **Verse selection listeners (lines 463–525):** Two `SelectedVersesListener` implementations (`lsSplit0_selectedVerses`, `lsSplit1_selectedVerses`) with partially duplicated logic.
 - **Split view management:** `openSplitDisplay()`, `closeSplitDisplay()`, `displaySplitFollowingMaster()`, `loadSplitVersion()` scattered across the file.
 - **Navigation history:** `BackForwardListController` usage, `jumpToAri()`, `jumpTo(reference)`, `History` tracking.
 
-**Impact:** Any change to one concern risks breaking unrelated functionality. Testing individual behaviors requires instantiating the entire Activity. New developers face a ~3000-line class with no clear entry point.
+**Impact:** Any change to one concern risks breaking unrelated functionality. Testing individual behaviors requires instantiating the entire Activity. New developers face a ~2320-line class with no clear entry point.
 
 ---
 
@@ -52,6 +52,9 @@ Three near-identical `execSQL()` calls to reorder labels with `+1`/`-1` arithmet
 
 ### TODO comment (line 234)
 `TODO this is only called together with putAttributes(), make it private` — indicates known coupling that hasn't been fixed.
+
+### ~~Verse-255 boundary bug (lines 238, 262)~~ ✅ FIXED
+**Fixed in REM-18c** (`ccf0a320`, 2026-04-16). `countMarkersForBookChapter` and `putAttributes` used exclusive upper bound (`ari < ariMax`) when `ariMax = ari_bookchapter | 0xff`, silently dropping any marker on verse 255. Changed to inclusive (`ari <= ariMax`) to match `getHighlightColorRgb`. No real data was affected (no Bible chapter has 255 verses), but the boundary is now correct and locked down by two regression tests.
 
 ---
 
@@ -220,7 +223,18 @@ Newer files (activities, data classes) are Kotlin, creating a mixed codebase whe
 
 ## TD-13: Minimal Test Coverage
 
-14 test files exist across the project:
+22 test files now exist across the project (Alkitab module unit tests unless noted):
+
+**Added in recent sprints:**
+- `HighlightsTest.kt` — highlight encode/decode, alphaMix, partial highlights (REM-18a)
+- `SyncDeltaTest.kt`, `Sync_MabelTest.kt`, `Sync_PinsTest.kt`, `Sync_RpTest.kt` — sync delta application and entity equality (REM-18b)
+- `InternalDbTest.kt` — marker CRUD, label ordering, highlight storage, attribute loading via Robolectric (REM-18c)
+- `SearchEngineTest.kt` — `ReadyTokens`, `satisfiesTokens`, and `searchByGrep` end-to-end via Robolectric (REM-18d)
+- `VerseTextFormatterTest.kt` — pure text-formatting logic extracted from action mode (REM-07)
+- `VerseActionModeControllerTest.kt` — menu visibility rules, click routing, split-1 share URL metadata (REM-07)
+- `SongBookUtilTest.java` — song deserialization safety (REM-01)
+
+**Pre-existing:**
 - `FormattedTextRendererTest.java` — verse formatting codes
 - `QueryTokenizerTest.kt` — search tokenization
 - `TargetDecoderTest.java` — verse reference parsing
@@ -228,14 +242,10 @@ Newer files (activities, data classes) are Kotlin, creating a mixed codebase whe
 - `RemoveSpecialCodesTest.java` — formatting code stripping
 - `JsonFileExportTest.kt` — data transfer export
 - `VersionTest.java`, `GetVersionInitialsTest.java` — version model
-- `OptionalGzipInputStreamTest.java` — I/O utility
-- `UnsignedBinarySearchKtTest.kt` — binary search utility
-- `DesktopVerseFinderTest.java` — desktop verse finder (in tools/AlkitabConverter)
-- `DesktopVerseParserTest.java` — desktop verse parser (in tools/AlkitabConverter)
-- `LauncherTest.java` — integration launcher test (in AlkitabIntegration, androidTest)
-- `VerseProviderTest.java` — verse provider test (in AlkitabIntegration, androidTest)
+- `DesktopVerseFinderTest.java`, `DesktopVerseParserTest.java` — desktop verse finder/parser (in tools/AlkitabConverter)
+- `LauncherTest.java`, `VerseProviderTest.java` — integration tests (in AlkitabIntegration, androidTest)
 
-**Not tested:** Database operations, sync protocol, version loading, search engine, devotion downloading, song management, highlight encoding, content provider, widget logic.
+**Still not tested:** Version loading (YES2 reader/writer round-trip), devotion downloading, song management, content provider, widget logic.
 
 ---
 
@@ -323,3 +333,12 @@ Daily verse widget selects from a predefined list, but if the user's selected Bi
 
 ### ~~PB-07: Preferences hold() Without unhold()~~ ✅ FIXED
 **Fixed in REM-02** (`0b61084a`–`80cd9f34`, 2026-04-10/11). `hold()`/`unhold()` are now private; all external code uses `withTransaction(Runnable)` with try/finally guarantee.
+
+### ~~PB-08: Copy/Share Split1 Uses Split0 Metadata in Share URL~~ ✅ FIXED
+**Fixed in** `716eb1ce` (2026-04-16). When split view was active and the user picked "Copy Split1" or "Share Split1", the clipboard/share text was correctly built from split1, but the share URL metadata (`version`, `preset_name`, `ari_bc`) came from split0 — so the generated URL pointed at the wrong version. The bug existed in `IsiActivity.actionMode_callback` and was preserved verbatim by the REM-07 refactor (intentionally, to keep it a pure refactor). Now `menuCopySplit1`/`menuShareSplit1` route metadata through split1; split0 and BothSplits remain correct. Four regression tests added.
+
+### ~~PB-09: Highlights.alphaMix() ARGB Leak~~ ✅ FIXED
+**Fixed in REM-18a** (`1ca73821`, 2026-04-16). `Highlights.alphaMix()` OR-ed `0xa0000000` without masking the high byte: any caller passing an ARGB value instead of an RGB one would bleed the original alpha into the result. Fixed by masking the input: `0xa0000000 | (colorRgb & 0x00ffffff)`.
+
+### ~~PB-10: Sync_Pins.Content.equals() Compared Unsorted Lists~~ ✅ FIXED
+**Fixed in REM-18b** (`b4bce934`, 2026-04-16). `Sync_Pins.Content.equals()` sorted copies of the pin lists but then compared the original unsorted lists, defeating the intended order-insensitive equality. In practice masked because `getEntitiesFromCurrent()` always builds pins in `preset_id` order, but a deserialized shadow with pins in a different order would incorrectly trigger a spurious "mod" sync op. Fixed to compare the sorted copies; `hashCode()` also fixed to be order-insensitive to satisfy the `equals`/`hashCode` contract.


### PR DESCRIPTION
## Summary

- **tech-debt.md**: Update TD-01 (IsiActivity now ~2320 lines after REM-07); document verse-255 boundary fix in TD-02; expand TD-13 test list from 14→22 files; add three new fixed potential-bug entries (PB-08 split-1 share URL, PB-09 alphaMix ARGB leak, PB-10 Sync_Pins equality bug)
- **tech-debt-remediation.md**: Mark REM-07 ✅ with full detail (VerseActionModeController, VerseTextFormatter, 26 tests, −574 lines in IsiActivity); mark Steps 18a and 18b ✅ with test counts, bug fixes, and test-scope shadow details; update priority summary and sprint plan to reflect current completion state
- **README.md**: Add "Developer Documentation" section linking to CLAUDE.md and all 16 docs in `docs/` (grouped by architecture / feature modules / tech debt)

## What triggered this

Pulled `develop` through `ccf0a320` (REM-18c InternalDb tests + verse-255 fix). Several earlier PRs (#131 REM-18b, #132/#133 REM-18a, #135 REM-07, #136 REM-18d, #138 split-1 fix) had not been reflected in the tech debt docs.

## Test plan

- [ ] Verify all links in README.md resolve to existing files in `docs/`
- [ ] Verify CLAUDE.md link resolves correctly
- [ ] Spot-check line numbers / commit hashes in tech-debt entries against `git log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)