### PR TITLE
Refactor DevotionDownloader to use ExecutorService instead of Thread

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/connection/Connections.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/connection/Connections.kt
@@ -70,10 +70,11 @@ object Connections {
     @JvmStatic
     @Throws(IOException::class)
     fun downloadString(url: String): String {
-        val response = downloadCall(url).execute()
-        if (!response.isSuccessful) throw IOException("response was not successful, code ${response.code}")
-        val body = response.body ?: throw IOException("body is null")
-        return body.string()
+        return downloadCall(url).execute().use { response ->
+            if (!response.isSuccessful) throw IOException("response was not successful, code ${response.code}")
+            val body = response.body ?: throw IOException("body is null")
+            body.string()
+        }
     }
 
     /**
@@ -82,10 +83,11 @@ object Connections {
     @JvmStatic
     @Throws(IOException::class)
     fun downloadBytes(url: String): ByteArray {
-        val response = downloadCall(url).execute()
-        if (!response.isSuccessful) throw IOException("response was not successful, code ${response.code}")
-        val body = response.body ?: throw IOException("body is null")
-        return body.bytes()
+        return downloadCall(url).execute().use { response ->
+            if (!response.isSuccessful) throw IOException("response was not successful, code ${response.code}")
+            val body = response.body ?: throw IOException("body is null")
+            body.bytes()
+        }
     }
 
     @JvmStatic

--- a/Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionDownloader.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionDownloader.java
@@ -1,7 +1,6 @@
 package yuku.alkitab.base.devotion;
 
 import android.content.Intent;
-import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -63,8 +62,8 @@ public class DevotionDownloader {
                     if (!output.startsWith("NG")) {
                         broadcastDownloaded(kind.name, article.getDate());
                     }
-                } catch (IOException e) {
-                    AppLog.d(TAG, "Downloader failed to download", e);
+                } catch (Exception e) {
+                    AppLog.d(TAG, "Downloader failed to process article", e);
                 }
             } catch (InterruptedException e) {
                 AppLog.d(TAG, "Downloader interrupted");

--- a/Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionDownloader.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionDownloader.java
@@ -1,9 +1,10 @@
 package yuku.alkitab.base.devotion;
 
 import android.content.Intent;
-import android.os.SystemClock;
 import java.io.IOException;
-import java.util.LinkedList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
 import yuku.alkitab.base.App;
 import yuku.alkitab.base.S;
 import yuku.alkitab.base.ac.DevotionActivity;
@@ -11,70 +12,44 @@ import yuku.alkitab.base.connection.Connections;
 import yuku.alkitab.base.util.AppLog;
 import yuku.alkitab.debug.BuildConfig;
 
-public class DevotionDownloader extends Thread {
+public class DevotionDownloader {
     private static final String TAG = DevotionDownloader.class.getSimpleName();
 
     public static final String ACTION_DOWNLOADED = DevotionDownloader.class.getName() + ".action.DOWNLOADED";
 
-    private final LinkedList<DevotionArticle> queue_ = new LinkedList<>();
+    private final LinkedBlockingDeque<DevotionArticle> queue_ = new LinkedBlockingDeque<>();
+    private volatile boolean shutdown_ = false;
+    private final ExecutorService executor_ = Executors.newSingleThreadExecutor();
+
+    public DevotionDownloader() {
+        executor_.submit(this::downloadLoop);
+    }
 
     public synchronized boolean add(DevotionArticle article, boolean prioritize) {
+        if (shutdown_) return false;
         if (queue_.contains(article)) return false;
 
         if (prioritize) {
             queue_.addFirst(article);
         } else {
-            queue_.add(article);
+            queue_.addLast(article);
         }
-
-        if (!isAlive()) {
-            start();
-        }
-
-        resumeDownloading();
 
         return true;
     }
 
-    private synchronized DevotionArticle dequeue() {
-        while (true) {
-            if (queue_.isEmpty()) {
-                return null;
-            }
-
-            DevotionArticle article = queue_.getFirst();
-            queue_.removeFirst();
-
-            if (article.getReadyToUse()) {
-                continue;
-            }
-
-            return article;
-        }
+    public void shutdown() {
+        shutdown_ = true;
+        executor_.shutdownNow();
     }
 
-    void resumeDownloading() {
-        synchronized (queue_) {
-            queue_.notify();
-        }
-    }
+    private void downloadLoop() {
+        while (!shutdown_) {
+            try {
+                final DevotionArticle article = queue_.take();
 
-    @Override
-    public void run() {
-        //noinspection InfiniteLoopStatement
-        while (true) {
-            final DevotionArticle article = dequeue();
+                if (article.getReadyToUse()) continue;
 
-            if (article == null) {
-                try {
-                    synchronized (queue_) {
-                        queue_.wait();
-                    }
-                    AppLog.d(TAG, "Downloader is resumed");
-                } catch (InterruptedException e) {
-                    AppLog.d(TAG, "Queue is interrupted");
-                }
-            } else {
                 final DevotionActivity.DevotionKind kind = article.getKind();
                 final String url = BuildConfig.SERVER_HOST + "/devotion/get?name=" + kind.name + "&date=" + article.getDate() + "&" + App.getAppIdentifierParamsEncoded();
 
@@ -82,11 +57,7 @@ public class DevotionDownloader extends Thread {
 
                 try {
                     final String output = Connections.downloadString(url);
-
-                    // success!
                     article.fillIn(output);
-
-                    // let's now store it to db
                     S.getDb().storeArticleToDevotions(article);
 
                     if (!output.startsWith("NG")) {
@@ -95,13 +66,15 @@ public class DevotionDownloader extends Thread {
                 } catch (IOException e) {
                     AppLog.d(TAG, "Downloader failed to download", e);
                 }
+            } catch (InterruptedException e) {
+                AppLog.d(TAG, "Downloader interrupted");
+                Thread.currentThread().interrupt();
+                break;
             }
-
-            SystemClock.sleep(50);
         }
     }
 
-    void broadcastDownloaded(final String name, final String date) {
+    private void broadcastDownloaded(final String name, final String date) {
         final Intent intent = new Intent(ACTION_DOWNLOADED)
             .putExtra("name", name)
             .putExtra("date", date);


### PR DESCRIPTION
## Summary
Refactored the `DevotionDownloader` class to use Java's `ExecutorService` for concurrent task execution instead of extending `Thread`. This improves code maintainability and follows better concurrency patterns. Additionally, improved resource management in the `Connections` class by using try-with-resources for HTTP responses.

## Key Changes

### DevotionDownloader.java
- Changed from extending `Thread` to a regular class that manages an `ExecutorService`
- Replaced `LinkedList` with `LinkedBlockingDeque` for thread-safe queue operations
- Introduced `ExecutorService.newSingleThreadExecutor()` to handle background downloads
- Refactored the main download loop from `run()` method to `downloadLoop()` private method
- Simplified queue management by leveraging `LinkedBlockingDeque.take()` instead of manual synchronization and wait/notify patterns
- Added `shutdown()` method for graceful termination of the executor
- Removed manual sleep calls (`SystemClock.sleep(50)`)
- Changed `broadcastDownloaded()` visibility from package-private to private
- Added shutdown flag to prevent new items from being queued after shutdown

### Connections.kt
- Wrapped HTTP response handling with try-with-resources (`use` block) in both `downloadString()` and `downloadBytes()` methods
- Ensures proper resource cleanup and prevents potential connection leaks
- Improves code readability by reducing variable assignments

## Implementation Details
- The `ExecutorService` is initialized in the constructor and automatically submits the download loop
- Thread-safe queue operations are now handled by `LinkedBlockingDeque` instead of manual synchronization
- The `take()` method blocks until an item is available, eliminating the need for explicit wait/notify logic
- Interruption handling is properly managed with `Thread.currentThread().interrupt()` to preserve interrupt status

https://claude.ai/code/session_0184tpHu2DqfybbsGW2BgMy2