### PR TITLE
REM-06: Extract IsiActivity gesture handling

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -71,6 +71,9 @@ import yuku.alkitab.base.dialog.TypeBookmarkDialog
 import yuku.alkitab.base.dialog.VersesDialog
 import yuku.alkitab.base.dialog.XrefDialog
 import yuku.alkitab.base.events.AppEvents
+import yuku.alkitab.base.gesture.ReaderGestureActions
+import yuku.alkitab.base.gesture.ReaderGestureHost
+import yuku.alkitab.base.gesture.ReaderGestureHandler
 import yuku.alkitab.base.model.MVersion
 import yuku.alkitab.base.model.MVersionDb
 import yuku.alkitab.base.settings.SettingsActivity
@@ -126,11 +129,12 @@ private const val TAG = "IsiActivity"
 private const val EXTRA_verseUrl = "verseUrl"
 private const val INSTANCE_STATE_ari = "ari"
 
-class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseActionModeHost, VerseActionModeActions {
+class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseActionModeHost, VerseActionModeActions, ReaderGestureHost, ReaderGestureActions {
     override var uncheckVersesWhenActionModeDestroyed = true
     var needsRestart = false // whether this activity needs to be restarted
 
     private val actionModeController by lazy { VerseActionModeController(this, this) }
+    private val gestureHandler by lazy { ReaderGestureHandler(this, this) }
 
     // --- VerseActionModeHost overrides ---
     // Thin read-only accessors so the controller can reach the Activity's state
@@ -151,103 +155,14 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     override fun uncheckAllVersesSplit0() { lsSplit0.uncheckAllVerses(true) }
     override fun onActionModeDestroyed() { actionMode = null }
 
-    private val bGoto_floaterDrag = object : GotoButton.FloaterDragListener {
-        val floaterLocationOnScreen = intArrayOf(0, 0)
-
-        override fun onFloaterDragStart(screenX: Float, screenY: Float) {
-            floater.show(activeSplit0.book.bookId, chapter_1)
-            floater.onDragStart(activeSplit0.version.consecutiveBooks)
-        }
-
-        override fun onFloaterDragMove(screenX: Float, screenY: Float) {
-            floater.getLocationOnScreen(floaterLocationOnScreen)
-            floater.onDragMove(screenX - floaterLocationOnScreen[0], screenY - floaterLocationOnScreen[1])
-        }
-
-        override fun onFloaterDragComplete(screenX: Float, screenY: Float) {
-            floater.hide()
-            floater.onDragComplete(screenX - floaterLocationOnScreen[0], screenY - floaterLocationOnScreen[1])
-        }
-    }
-
-    private val floater_listener = Floater.Listener { ari ->
-        jumpToAri(ari)
-    }
-
-    private val splitRoot_listener = object : TwofingerLinearLayout.Listener {
-        var startFontSize = 0f
-        var startDx = Float.MIN_VALUE
-        var chapterSwipeCellWidth = 0f // initted later
-        var moreSwipeYAllowed = true // to prevent setting and unsetting fullscreen many times within one gesture
-
-        override fun onOnefingerLeft() {
-            bRight_click()
-        }
-
-        override fun onOnefingerRight() {
-            bLeft_click()
-        }
-
-        override fun onTwofingerStart() {
-            chapterSwipeCellWidth = 24f * resources.displayMetrics.density
-            startFontSize = Preferences.getFloat(Prefkey.ukuranHuruf2, resources.getInteger(R.integer.pref_ukuranHuruf2_default).toFloat())
-        }
-
-        override fun onTwofingerScale(scale: Float) {
-            var nowFontSize = startFontSize * scale
-
-            if (nowFontSize < 2f) nowFontSize = 2f
-            if (nowFontSize > 42f) nowFontSize = 42f
-
-            Preferences.setFloat(Prefkey.ukuranHuruf2, nowFontSize)
-
-            applyPreferences()
-
-            textAppearancePanel?.displayValues()
-        }
-
-        override fun onTwofingerDragX(dx: Float) {
-            if (startDx == Float.MIN_VALUE) { // just started
-                startDx = dx
-
-                if (dx < 0) {
-                    bRight_click()
-                } else {
-                    bLeft_click()
-                }
-            } else { // more
-                // more to the left
-                while (dx < startDx - chapterSwipeCellWidth) {
-                    startDx -= chapterSwipeCellWidth
-                    bRight_click()
-                }
-
-                while (dx > startDx + chapterSwipeCellWidth) {
-                    startDx += chapterSwipeCellWidth
-                    bLeft_click()
-                }
-            }
-        }
-
-        override fun onTwofingerDragY(dy: Float) {
-            if (!moreSwipeYAllowed) return
-
-            if (dy < 0) {
-                setFullScreen(true)
-                leftDrawer.handle.setFullScreen(true)
-            } else {
-                setFullScreen(false)
-                leftDrawer.handle.setFullScreen(false)
-            }
-
-            moreSwipeYAllowed = false
-        }
-
-        override fun onTwofingerEnd(mode: TwofingerLinearLayout.Mode?) {
-            startFontSize = 0f
-            startDx = Float.MIN_VALUE
-            moreSwipeYAllowed = true
-        }
+    // --- ReaderGestureHost / ReaderGestureActions overrides ---
+    // Host state `activeSplit0Book`, `activeSplit0Version`, `chapter_1`, and
+    // `activity` are already exposed by the VerseActionMode overrides above;
+    // `floater` and `textAppearancePanel` satisfy the Host contract as
+    // `override`s on their existing declarations below.
+    override fun onGestureFullScreenToggle(fullScreen: Boolean) {
+        setFullScreen(fullScreen)
+        leftDrawer.handle.setFullScreen(fullScreen)
     }
 
     private lateinit var drawerLayout: DrawerLayout
@@ -265,7 +180,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     private lateinit var bLeft: ImageButton
     private lateinit var bRight: ImageButton
     private lateinit var bVersion: TextView
-    lateinit var floater: Floater
+    override lateinit var floater: Floater
     private lateinit var backForwardListController: BackForwardListController<ImageButton, ImageButton>
     private var fullscreenReferenceToast: Toast? = null
 
@@ -300,7 +215,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
     var actionMode: ActionMode? = null
     private var dictionaryMode = false
-    var textAppearancePanel: TextAppearancePanel? = null
+    override var textAppearancePanel: TextAppearancePanel? = null
 
     /**
      * The following "esvsbasal" thing is a personal thing by yuku that doesn't matter to anyone else.
@@ -634,20 +549,20 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
         updateToolbarLocation()
 
-        splitRoot.setListener(splitRoot_listener)
+        splitRoot.setListener(gestureHandler.twofingerListener)
 
         bGoto.setOnClickListener { bGoto_click() }
         bGoto.setOnLongClickListener {
             bGoto_longClick()
             true
         }
-        bGoto.setFloaterDragListener(bGoto_floaterDrag)
+        bGoto.setFloaterDragListener(gestureHandler.floaterDragListener)
 
         bLeft.setOnClickListener { bLeft_click() }
         bRight.setOnClickListener { bRight_click() }
         bVersion.setOnClickListener { openVersionsDialog() }
 
-        floater.setListener(floater_listener)
+        floater.setListener(gestureHandler.floaterListener)
 
         // listeners
         lsSplit0 = VersesControllerImpl(
@@ -1097,6 +1012,11 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
      *
      * If successful, the destination will be added to history.
      */
+    /** Single-arg form that satisfies [ReaderGestureActions.jumpToAri]; delegates with defaults. */
+    override fun jumpToAri(ari: Int) {
+        jumpToAri(ari = ari, updateBackForwardListCurrentEntryWithSource = true, addHistoryEntry = true, callAttention = true)
+    }
+
     fun jumpToAri(
         ari: Int,
         updateBackForwardListCurrentEntryWithSource: Boolean = true,
@@ -1132,7 +1052,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
     }
 
-    fun applyPreferences() {
+    override fun applyPreferences() {
         // make sure S applied variables are set first
         S.recalculateAppliedValuesBasedOnPreferences()
 
@@ -1810,7 +1730,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         return leftDrawer
     }
 
-    fun bLeft_click() {
+    override fun bLeft_click() {
         val currentBook = activeSplit0.book
         if (chapter_1 == 1) {
             // we are in the beginning of the book, so go to prev book
@@ -1832,7 +1752,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
     }
 
-    fun bRight_click() {
+    override fun bRight_click() {
         val currentBook = activeSplit0.book
         if (chapter_1 >= currentBook.chapter_count) {
             val maxBookId = activeSplit0.version.maxBookIdPlusOne

--- a/Alkitab/src/main/java/yuku/alkitab/base/gesture/ReaderGestureActions.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/gesture/ReaderGestureActions.kt
@@ -1,0 +1,19 @@
+package yuku.alkitab.base.gesture
+
+/**
+ * Write-side surface that [ReaderGestureHandler] invokes to trigger reader
+ * operations in response to gestures. Implemented by the hosting Activity.
+ */
+interface ReaderGestureActions {
+    fun bLeft_click()
+    fun bRight_click()
+    fun applyPreferences()
+
+    /**
+     * Toggles fullscreen mode; the implementer is expected to also propagate
+     * the state to the left-drawer handle so its own chrome stays in sync.
+     */
+    fun onGestureFullScreenToggle(fullScreen: Boolean)
+
+    fun jumpToAri(ari: Int)
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/gesture/ReaderGestureHandler.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/gesture/ReaderGestureHandler.kt
@@ -1,0 +1,120 @@
+package yuku.alkitab.base.gesture
+
+import yuku.afw.storage.Preferences
+import yuku.alkitab.base.storage.Prefkey
+import yuku.alkitab.base.widget.Floater
+import yuku.alkitab.base.widget.GotoButton
+import yuku.alkitab.base.widget.TwofingerLinearLayout
+import yuku.alkitab.debug.R
+
+/**
+ * Bundles together the three gesture-driven listeners that used to live directly
+ * on `IsiActivity`:
+ *
+ * - [twofingerListener]: one-finger horizontal swipes for chapter navigation,
+ *   two-finger scale for font size, two-finger vertical drag for fullscreen toggle.
+ * - [floaterDragListener]: drag the "goto" floater to pick a book/chapter.
+ * - [floaterListener]: jump to the ARI the floater reports on drop.
+ *
+ * Mutable gesture-local state (start positions, swipe cell width, etc.) is kept
+ * here rather than on the Activity so gesture scratch doesn't leak into the
+ * Activity's field set.
+ */
+class ReaderGestureHandler(
+    private val host: ReaderGestureHost,
+    private val actions: ReaderGestureActions,
+) {
+    val floaterDragListener: GotoButton.FloaterDragListener = object : GotoButton.FloaterDragListener {
+        private val floaterLocationOnScreen = intArrayOf(0, 0)
+
+        override fun onFloaterDragStart(screenX: Float, screenY: Float) {
+            host.floater.show(host.activeSplit0Book.bookId, host.chapter_1)
+            host.floater.onDragStart(host.activeSplit0Version.consecutiveBooks)
+        }
+
+        override fun onFloaterDragMove(screenX: Float, screenY: Float) {
+            host.floater.getLocationOnScreen(floaterLocationOnScreen)
+            host.floater.onDragMove(screenX - floaterLocationOnScreen[0], screenY - floaterLocationOnScreen[1])
+        }
+
+        override fun onFloaterDragComplete(screenX: Float, screenY: Float) {
+            host.floater.hide()
+            host.floater.onDragComplete(screenX - floaterLocationOnScreen[0], screenY - floaterLocationOnScreen[1])
+        }
+    }
+
+    val floaterListener: Floater.Listener = Floater.Listener { ari ->
+        actions.jumpToAri(ari)
+    }
+
+    val twofingerListener: TwofingerLinearLayout.Listener = object : TwofingerLinearLayout.Listener {
+        var startFontSize = 0f
+        var startDx = Float.MIN_VALUE
+        var chapterSwipeCellWidth = 0f // initted later
+        var moreSwipeYAllowed = true // to prevent setting and unsetting fullscreen many times within one gesture
+
+        override fun onOnefingerLeft() {
+            actions.bRight_click()
+        }
+
+        override fun onOnefingerRight() {
+            actions.bLeft_click()
+        }
+
+        override fun onTwofingerStart() {
+            val resources = host.activity.resources
+            chapterSwipeCellWidth = 24f * resources.displayMetrics.density
+            startFontSize = Preferences.getFloat(Prefkey.ukuranHuruf2, resources.getInteger(R.integer.pref_ukuranHuruf2_default).toFloat())
+        }
+
+        override fun onTwofingerScale(scale: Float) {
+            var nowFontSize = startFontSize * scale
+
+            if (nowFontSize < 2f) nowFontSize = 2f
+            if (nowFontSize > 42f) nowFontSize = 42f
+
+            Preferences.setFloat(Prefkey.ukuranHuruf2, nowFontSize)
+
+            actions.applyPreferences()
+
+            host.textAppearancePanel?.displayValues()
+        }
+
+        override fun onTwofingerDragX(dx: Float) {
+            if (startDx == Float.MIN_VALUE) { // just started
+                startDx = dx
+
+                if (dx < 0) {
+                    actions.bRight_click()
+                } else {
+                    actions.bLeft_click()
+                }
+            } else { // more
+                // more to the left
+                while (dx < startDx - chapterSwipeCellWidth) {
+                    startDx -= chapterSwipeCellWidth
+                    actions.bRight_click()
+                }
+
+                while (dx > startDx + chapterSwipeCellWidth) {
+                    startDx += chapterSwipeCellWidth
+                    actions.bLeft_click()
+                }
+            }
+        }
+
+        override fun onTwofingerDragY(dy: Float) {
+            if (!moreSwipeYAllowed) return
+
+            actions.onGestureFullScreenToggle(dy < 0)
+
+            moreSwipeYAllowed = false
+        }
+
+        override fun onTwofingerEnd(mode: TwofingerLinearLayout.Mode?) {
+            startFontSize = 0f
+            startDx = Float.MIN_VALUE
+            moreSwipeYAllowed = true
+        }
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/gesture/ReaderGestureHost.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/gesture/ReaderGestureHost.kt
@@ -1,0 +1,20 @@
+package yuku.alkitab.base.gesture
+
+import androidx.appcompat.app.AppCompatActivity
+import yuku.alkitab.base.widget.Floater
+import yuku.alkitab.base.widget.TextAppearancePanel
+import yuku.alkitab.model.Book
+import yuku.alkitab.model.Version
+
+/**
+ * Read-only state surface that [ReaderGestureHandler] reads from to drive
+ * one- and two-finger gestures on the reader. Implemented by the hosting Activity.
+ */
+interface ReaderGestureHost {
+    val activity: AppCompatActivity
+    val chapter_1: Int
+    val activeSplit0Book: Book
+    val activeSplit0Version: Version
+    val floater: Floater
+    val textAppearancePanel: TextAppearancePanel?
+}

--- a/docs/tech-debt-remediation.md
+++ b/docs/tech-debt-remediation.md
@@ -118,18 +118,22 @@ Coroutines and `lifecycleScope` were already on the classpath transitively throu
 
 ## Phase 2: Architecture Improvements (BRICE 3.0–3.9)
 
-### REM-06: Extract IsiActivity Gesture Handling
+### ~~REM-06: Extract IsiActivity Gesture Handling~~ ✅ COMPLETED
 **Addresses:** TD-01 (gesture cluster)  
 **Module:** Main reader  
 **BRICE:** B=4 R=3 I=3 C=3 E=4 → **3.4**
 
-**Steps:**
-1. Create `ReaderGestureHandler.kt` implementing `TwofingerLinearLayout.Listener`
-2. Move the `splitRoot_listener` object (lines 163-237 in `IsiActivity.kt`) and the `bGoto_floaterDrag` / `floater_listener` callbacks (lines 140-161) into `ReaderGestureHandler` (~98 lines of gesture code total)
-3. Pass required callbacks as constructor parameters: `onChapterChange`, `onFontSizeChange`, `onFullscreenToggle`
-4. In `IsiActivity`, instantiate `ReaderGestureHandler` and delegate the listener interface
+**Outcome:** All three gesture listeners (`splitRoot_listener` TwofingerLinearLayout, `bGoto_floaterDrag` GotoButton.FloaterDragListener, `floater_listener` Floater.Listener) moved out of `IsiActivity.kt` into a new `yuku.alkitab.base.gesture` package following the REM-07 host/actions convention.
 
-**Difficulty:** Medium (4-6 hours). Risk: gesture state depends on Activity fields (`chapter_1`, `unchunkedFontSizeDp`).
+**What was done:**
+1. Created `ReaderGestureHandler.kt`, `ReaderGestureHost.kt`, `ReaderGestureActions.kt`. The handler owns mutable gesture-local scratch (`startFontSize`, `startDx`, `chapterSwipeCellWidth`, `moreSwipeYAllowed`, `floaterLocationOnScreen`) so that state no longer leaks into Activity fields.
+2. Host surface exposes `activity`, `chapter_1`, `activeSplit0Book`, `activeSplit0Version`, `floater`, `textAppearancePanel`. Actions surface exposes `bLeft_click`, `bRight_click`, `applyPreferences`, `onGestureFullScreenToggle` (consolidates the paired `setFullScreen` + `leftDrawer.handle.setFullScreen` call), `jumpToAri`.
+3. `IsiActivity` now implements `ReaderGestureHost, ReaderGestureActions`; the three wire-up sites (`splitRoot.setListener`, `bGoto.setFloaterDragListener`, `floater.setListener`) now point at `gestureHandler.twofingerListener`/`.floaterDragListener`/`.floaterListener`.
+4. Added `override` modifiers to the existing `bLeft_click`, `bRight_click`, `applyPreferences`, `floater`, `textAppearancePanel` declarations. Added a 1-arg `override fun jumpToAri(ari: Int)` that delegates to the existing 4-arg defaulted method so the interface contract is satisfied without changing the 4-arg signature (which has many callers).
+
+**Result:** ~97 lines of gesture code moved out of `IsiActivity.kt`; handler + two interfaces total ~155 lines in the new package.
+
+**Verified:** `./gradlew :Alkitab:assemblePlainDebug :Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest` — all tests pass.
 
 ---
 
@@ -664,7 +668,7 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 | REM-05 | ~~Fix DevotionDownloader threading~~ ✅ | **4.0** | 1 |
 | REM-03 | ~~Replace LocalBroadcastManager~~ ✅ | **3.8** | 1 |
 | REM-23 | ~~Port ybuild.sh to Gradle~~ ✅ | **3.8** | 2 |
-| REM-06 | Extract IsiActivity gestures | **3.4** | 2 |
+| REM-06 | ~~Extract IsiActivity gestures~~ ✅ | **3.4** | 2 |
 | REM-07 | ~~Extract IsiActivity action mode~~ ✅ | **3.4** | 2 |
 | REM-09 | Introduce ViewModel | **3.4** | 2 |
 | REM-10 | Room migration (Markers) | **3.4** | 2 |
@@ -686,7 +690,7 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 
 **Sprint 1 (1 week):** ~~REM-01~~✅, ~~REM-02~~✅, ~~REM-04~~✅, ~~REM-05~~✅ — quick safety fixes (all done)  
 **Sprint 2 (1 week):** ~~REM-03~~✅ — LocalBroadcastManager removal (done)  
-**Sprint 3 (2 weeks):** ~~REM-07~~✅, REM-06, REM-08 — IsiActivity decomposition (REM-07 done)  
+**Sprint 3 (2 weeks):** ~~REM-07~~✅, ~~REM-06~~✅, REM-08 — IsiActivity decomposition (REM-07/06 done)  
 **Sprint 4 (1 week):** ~~REM-12~~✅, ~~REM-14~~✅ — deprecated library replacements (done)  
 **Sprint 5 (2 weeks):** REM-10, REM-11 — Room migration for core tables  
 **Sprint 6 (2 weeks):** REM-09, ~~REM-18a-e~~✅ — ViewModel + test coverage (REM-18a/b/c/d/e done)  


### PR DESCRIPTION
## Summary
- Moves the three gesture listeners (`splitRoot_listener` TwofingerLinearLayout, `bGoto_floaterDrag` FloaterDragListener, `floater_listener` Floater.Listener) out of `IsiActivity.kt` into a new `yuku.alkitab.base.gesture` package.
- Follows the Host/Actions interface convention from REM-07 (`VerseActionModeController`). `ReaderGestureHandler` owns gesture-local scratch state (`startFontSize`, `startDx`, `chapterSwipeCellWidth`, `moreSwipeYAllowed`, `floaterLocationOnScreen`) so it no longer leaks into Activity fields.
- The paired `setFullScreen` + `leftDrawer.handle.setFullScreen` call in `onTwofingerDragY` is consolidated behind a single `onGestureFullScreenToggle(fullScreen: Boolean)` action.
- Net: ~97 lines removed from `IsiActivity.kt`; handler + two interfaces total ~155 lines in the new package.

## Test plan
- [x] `./gradlew :Alkitab:assemblePlainDebug`
- [x] `./gradlew :Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest`
- [ ] Manual: verify one-finger horizontal swipes still navigate chapters
- [ ] Manual: verify two-finger pinch still scales the verse font (and the text-appearance panel updates if open)
- [ ] Manual: verify two-finger vertical drag still toggles fullscreen (including the left-drawer handle tracking it)
- [ ] Manual: verify drag-from-Goto-button still shows the floater and jumps to the released ARI