### PR TITLE
audio-bible M1: PRD, plans, and catalog skeleton

### DIFF
--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.firebase.crashlytics.gradle)
     alias(libs.plugins.google.services)
 }
@@ -123,6 +124,14 @@ android {
         buildConfigField("String", "SERVER_HOST", "\"$serverHost\"")
         buildConfigField("String", "RIBKA_FUNCTIONS_HOST", "\"$ribkaFunctionsHost\"")
         buildConfigField("String", "LAST_COMMIT_HASH", "\"$gitCommitHash\"")
+
+        // Audio catalog identifier for the internal Bible version. The
+        // bundled internal version reports `MVersion.getVersionId() == "internal"`,
+        // which never matches a `preset/*` catalog entry; this field tells
+        // AudioCatalogRepository what catalog row to use when the user is
+        // reading the internal version. Empty string means "internal has no
+        // audio for this flavor". Each productFlavor overrides this below.
+        buildConfigField("String", "INTERNAL_VERSION_AUDIO_ID", "\"\"")
     }
     buildTypes {
         debug {
@@ -144,18 +153,25 @@ android {
     flavorDimensions += "playStoreApplicationId"
 
     productFlavors {
-        // Use this for development
-        create("plain") {}
+        // Use this for development. The plain build's bundled `ddd_*` files are
+        // Indonesian-language placeholders, so for dev convenience we map the
+        // internal version to TB audio so the bottom sheet has something to play.
+        create("plain") {
+            buildConfigField("String", "INTERNAL_VERSION_AUDIO_ID", "\"preset/in-tb\"")
+        }
 
         // The following flavors are for release
         create("yuku_alkitab") {
             applicationId = "yuku.alkitab"
+            buildConfigField("String", "INTERNAL_VERSION_AUDIO_ID", "\"preset/in-tb\"")
         }
         create("yuku_quick_bible") {
             applicationId = "yuku.alkitab.kjv"
+            buildConfigField("String", "INTERNAL_VERSION_AUDIO_ID", "\"preset/en-kjv\"")
         }
         create("sabda_alkitab") {
             applicationId = "org.sabda.alkitab"
+            buildConfigField("String", "INTERNAL_VERSION_AUDIO_ID", "\"preset/in-tb\"")
         }
     }
 
@@ -163,6 +179,7 @@ android {
 
     buildFeatures {
         buildConfig = true
+        compose = true
     }
 
     testOptions {
@@ -336,9 +353,20 @@ dependencies {
     // Google
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.datasource.okhttp)
+    implementation(libs.androidx.media3.session)
     implementation(libs.google.material)
     implementation(libs.gson)
     implementation(libs.fastscroll)
+
+    // Jetpack Compose — first Compose surface in this project, introduced for the
+    // audio-bible bottom sheet (docs/features/audio-bible/).
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.foundation)
+    implementation(libs.androidx.compose.runtime)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.activity.compose)
+    debugImplementation(libs.androidx.compose.ui.tooling)
 
     // Tests
     testImplementation(libs.junit)

--- a/Alkitab/src/main/assets/audio_catalog.json
+++ b/Alkitab/src/main/assets/audio_catalog.json
@@ -1,0 +1,45 @@
+{
+  "generatedAt": 0,
+  "entries": [
+    {
+      "versionId": "preset/in-tb",
+      "shortName": "TB",
+      "displayLocaleHint": "in",
+      "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fin-tb&bookId={bookId}&chapter_1={chapter_1}",
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-tb&bookId={bookId}&chapter_1={chapter_1}",
+      "copyrightNotice": "© LAI, via SABDA",
+      "license": "Non-commercial",
+      "hasDeuterocanon": false
+    },
+    {
+      "versionId": "preset/in-ayt",
+      "shortName": "AYT",
+      "displayLocaleHint": "in",
+      "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fin-ayt&bookId={bookId}&chapter_1={chapter_1}",
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-ayt&bookId={bookId}&chapter_1={chapter_1}",
+      "copyrightNotice": "© AYT, via SABDA",
+      "license": "Non-commercial",
+      "hasDeuterocanon": false
+    },
+    {
+      "versionId": "preset/in-avb",
+      "shortName": "AVB",
+      "displayLocaleHint": "ms",
+      "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fin-avb&bookId={bookId}&chapter_1={chapter_1}",
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-avb&bookId={bookId}&chapter_1={chapter_1}",
+      "copyrightNotice": "© BSM, via SABDA",
+      "license": "Non-commercial",
+      "hasDeuterocanon": false
+    },
+    {
+      "versionId": "preset/en-kjv",
+      "shortName": "KJV",
+      "displayLocaleHint": "en",
+      "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fen-kjv&bookId={bookId}&chapter_1={chapter_1}",
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fen-kjv&bookId={bookId}&chapter_1={chapter_1}",
+      "copyrightNotice": "Public Domain",
+      "license": "PD",
+      "hasDeuterocanon": false
+    }
+  ]
+}

--- a/Alkitab/src/main/assets/audio_catalog.json
+++ b/Alkitab/src/main/assets/audio_catalog.json
@@ -6,40 +6,28 @@
       "shortName": "TB",
       "displayLocaleHint": "in",
       "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fin-tb&bookId={bookId}&chapter_1={chapter_1}",
-      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-tb&bookId={bookId}&chapter_1={chapter_1}",
-      "copyrightNotice": "© LAI, via SABDA",
-      "license": "Non-commercial",
-      "hasDeuterocanon": false
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-tb&bookId={bookId}&chapter_1={chapter_1}"
     },
     {
       "versionId": "preset/in-ayt",
       "shortName": "AYT",
       "displayLocaleHint": "in",
       "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fin-ayt&bookId={bookId}&chapter_1={chapter_1}",
-      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-ayt&bookId={bookId}&chapter_1={chapter_1}",
-      "copyrightNotice": "© AYT, via SABDA",
-      "license": "Non-commercial",
-      "hasDeuterocanon": false
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-ayt&bookId={bookId}&chapter_1={chapter_1}"
     },
     {
       "versionId": "preset/in-avb",
       "shortName": "AVB",
       "displayLocaleHint": "ms",
       "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fin-avb&bookId={bookId}&chapter_1={chapter_1}",
-      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-avb&bookId={bookId}&chapter_1={chapter_1}",
-      "copyrightNotice": "© BSM, via SABDA",
-      "license": "Non-commercial",
-      "hasDeuterocanon": false
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-avb&bookId={bookId}&chapter_1={chapter_1}"
     },
     {
       "versionId": "preset/en-kjv",
       "shortName": "KJV",
       "displayLocaleHint": "en",
       "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fen-kjv&bookId={bookId}&chapter_1={chapter_1}",
-      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fen-kjv&bookId={bookId}&chapter_1={chapter_1}",
-      "copyrightNotice": "Public Domain",
-      "license": "PD",
-      "hasDeuterocanon": false
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fen-kjv&bookId={bookId}&chapter_1={chapter_1}"
     }
   ]
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioCatalogRepository.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioCatalogRepository.kt
@@ -2,11 +2,16 @@ package yuku.alkitab.base.audio
 
 import java.io.File
 import java.io.IOException
+import java.io.InputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
 import okhttp3.Request
 import yuku.afw.storage.Preferences
 import yuku.alkitab.base.App
@@ -38,6 +43,7 @@ import yuku.alkitab.debug.BuildConfig
  * [loadCatalog] and [refresh] do their I/O on [Dispatchers.IO]; [findEntry] and
  * [isAudioAvailable] are pure-read operations against the in-memory cache.
  */
+@OptIn(ExperimentalSerializationApi::class)
 object AudioCatalogRepository {
 
     private const val TAG = "AudioCatalogRepo"
@@ -50,6 +56,16 @@ object AudioCatalogRepository {
         isLenient = true
     }
 
+    /**
+     * Serializes the cache-load critical section in [loadCatalog] so concurrent
+     * first-callers don't both read+parse the override/asset, and serializes the
+     * cached-write side of [refresh] so a reader never sees a torn `cached` ref.
+     * The actual override-file write in [refresh] does **not** sit under this
+     * lock — it goes via write-to-temp + atomic rename, which is itself
+     * crash-safe and lock-free against concurrent reads.
+     */
+    private val loadMutex = Mutex()
+
     @Volatile
     private var cached: AudioCatalog? = null
 
@@ -61,9 +77,14 @@ object AudioCatalogRepository {
      */
     suspend fun loadCatalog(): AudioCatalog {
         cached?.let { return it }
-        val loaded = withContext(Dispatchers.IO) { readFromDiskOrAsset() }
-        cached = loaded
-        return loaded
+        return loadMutex.withLock {
+            // Re-check inside the lock: another coroutine may have raced ahead
+            // while we were waiting and already populated `cached`.
+            cached?.let { return@withLock it }
+            val loaded = withContext(Dispatchers.IO) { readFromDiskOrAsset() }
+            cached = loaded
+            loaded
+        }
     }
 
     /** True iff [versionId] has an entry in the currently-loaded catalog. */
@@ -116,20 +137,7 @@ object AudioCatalogRepository {
         try {
             Connections.okHttp.newCall(request).execute().use { response ->
                 when (response.code) {
-                    200 -> {
-                        val body = response.body?.string()
-                            ?: return@use RefreshResult.Failed("empty body")
-                        // Validate by parsing before we overwrite the on-disk override.
-                        val parsed = parseOrNull(body)
-                            ?: return@use RefreshResult.Failed("body did not parse")
-                        writeOverride(body)
-                        val newEtag = response.header("ETag")
-                        if (newEtag != null) {
-                            Preferences.setString(Prefkey.audioCatalog_etag, newEtag)
-                        }
-                        cached = parsed
-                        RefreshResult.Updated(parsed.entries.size)
-                    }
+                    200 -> handleOk200(response)
                     304 -> RefreshResult.NotModified
                     else -> RefreshResult.Failed("HTTP ${response.code}")
                 }
@@ -137,6 +145,50 @@ object AudioCatalogRepository {
         } catch (e: IOException) {
             AppLog.w(TAG, "catalog refresh failed: ${e.message}")
             RefreshResult.Failed(e.message ?: "I/O error")
+        }
+    }
+
+    /**
+     * 200 handler:
+     *  1. Stream the response body into a unique temp file under filesDir
+     *     (avoids holding the full body in memory).
+     *  2. Parse-from-stream off the temp file. Bail and delete the temp on parse
+     *     failure — the existing override stays intact.
+     *  3. On parse success, atomically rename the temp over the override path.
+     *     Atomic rename is a single filesystem op on POSIX (which Android is),
+     *     so concurrent [loadCatalog] readers see either the old or the new
+     *     file but never a partial write.
+     *  4. Update the in-memory cache and ETag last.
+     */
+    private fun handleOk200(response: okhttp3.Response): RefreshResult {
+        val body = response.body ?: return RefreshResult.Failed("empty body")
+
+        val temp = File.createTempFile("audio_catalog_", ".tmp.json", App.context.filesDir)
+        try {
+            body.byteStream().use { input ->
+                temp.outputStream().use { output -> input.copyTo(output) }
+            }
+
+            val parsed = temp.inputStream().use(::parseStreamOrNull)
+                ?: return RefreshResult.Failed("body did not parse")
+
+            // Atomic publish. Some platforms reject rename if the target exists
+            // (Android doesn't, but we delete first to be portable to host JVM
+            // tests which run under Robolectric on the host filesystem).
+            val target = overrideFile()
+            target.delete()
+            if (!temp.renameTo(target)) {
+                return RefreshResult.Failed("could not commit override file")
+            }
+
+            response.header("ETag")?.let {
+                Preferences.setString(Prefkey.audioCatalog_etag, it)
+            }
+            cached = parsed
+            return RefreshResult.Updated(parsed.entries.size)
+        } finally {
+            // Best-effort cleanup if the rename never happened.
+            if (temp.exists()) temp.delete()
         }
     }
 
@@ -164,7 +216,7 @@ object AudioCatalogRepository {
         val overrideFile = overrideFile()
         if (overrideFile.isFile) {
             try {
-                val parsed = parseOrNull(overrideFile.readText(Charsets.UTF_8))
+                val parsed = overrideFile.inputStream().use(::parseStreamOrNull)
                 if (parsed != null) return parsed
                 AppLog.w(TAG, "override $OVERRIDE_FILENAME failed to parse; falling back to bundled asset")
             } catch (e: IOException) {
@@ -175,8 +227,7 @@ object AudioCatalogRepository {
         // 2. Bundled asset.
         try {
             App.context.assets.open(ASSET_FILENAME).use { input ->
-                val text = input.bufferedReader(Charsets.UTF_8).readText()
-                val parsed = parseOrNull(text)
+                val parsed = parseStreamOrNull(input)
                 if (parsed != null) return parsed
                 AppLog.e(TAG, "bundled $ASSET_FILENAME failed to parse — shipping a broken JSON?")
             }
@@ -188,9 +239,13 @@ object AudioCatalogRepository {
         return AudioCatalog()
     }
 
-    private fun parseOrNull(body: String): AudioCatalog? {
+    /**
+     * Streams the JSON straight off the input — never buffers the whole body
+     * into a `String` first. Returns null on parse failure (logged at warn).
+     */
+    private fun parseStreamOrNull(input: InputStream): AudioCatalog? {
         return try {
-            json.decodeFromString(AudioCatalog.serializer(), body)
+            json.decodeFromStream(AudioCatalog.serializer(), input)
         } catch (e: SerializationException) {
             AppLog.w(TAG, "catalog JSON did not parse: ${e.message}")
             null
@@ -199,13 +254,5 @@ object AudioCatalogRepository {
 
     private fun overrideFile(): File {
         return File(App.context.filesDir, OVERRIDE_FILENAME)
-    }
-
-    private fun writeOverride(body: String) {
-        try {
-            overrideFile().writeText(body, Charsets.UTF_8)
-        } catch (e: IOException) {
-            AppLog.w(TAG, "could not persist refreshed catalog: ${e.message}")
-        }
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioCatalogRepository.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioCatalogRepository.kt
@@ -1,0 +1,211 @@
+package yuku.alkitab.base.audio
+
+import java.io.File
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import okhttp3.Request
+import yuku.afw.storage.Preferences
+import yuku.alkitab.base.App
+import yuku.alkitab.base.audio.model.AudioCatalog
+import yuku.alkitab.base.audio.model.AudioVersion
+import yuku.alkitab.base.connection.Connections
+import yuku.alkitab.base.model.MVersionInternal
+import yuku.alkitab.base.storage.Prefkey
+import yuku.alkitab.base.util.AppLog
+import yuku.alkitab.debug.BuildConfig
+
+/**
+ * Source of truth for the audio catalog (which versions have audio available + the
+ * URL templates the client uses to fetch chapter MP3s and timing JSON).
+ *
+ * Catalog precedence on read:
+ *   1. In-memory cache (warmed by [loadCatalog]).
+ *   2. Override file at `files/audio_catalog.json` (last successful network fetch).
+ *   3. Bundled fallback at `assets/audio_catalog.json` (always present, ships with the APK).
+ *
+ * The repository is also responsible for [refresh] — issuing a conditional GET
+ * against `/audio/catalog`, persisting the body and ETag on success, and updating
+ * the in-memory cache. Refresh is invoked from
+ * [yuku.alkitab.base.sv.VersionConfigUpdaterService] alongside the existing
+ * version-config refresh, so the catalog is kept current without spawning a new
+ * worker.
+ *
+ * Thread safety: every public method is safe to call from any thread.
+ * [loadCatalog] and [refresh] do their I/O on [Dispatchers.IO]; [findEntry] and
+ * [isAudioAvailable] are pure-read operations against the in-memory cache.
+ */
+object AudioCatalogRepository {
+
+    private const val TAG = "AudioCatalogRepo"
+    private const val OVERRIDE_FILENAME = "audio_catalog.json"
+    private const val ASSET_FILENAME = "audio_catalog.json"
+    private const val CATALOG_PATH = "/audio/catalog"
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    @Volatile
+    private var cached: AudioCatalog? = null
+
+    /**
+     * Returns the catalog, reading from the override file or the bundled asset on
+     * first call. Subsequent calls return the in-memory cache. Never throws — on
+     * any error, returns an empty [AudioCatalog] (the toolbar icon will then be
+     * hidden everywhere).
+     */
+    suspend fun loadCatalog(): AudioCatalog {
+        cached?.let { return it }
+        val loaded = withContext(Dispatchers.IO) { readFromDiskOrAsset() }
+        cached = loaded
+        return loaded
+    }
+
+    /** True iff [versionId] has an entry in the currently-loaded catalog. */
+    fun isAudioAvailable(versionId: String?): Boolean {
+        return findEntry(versionId) != null
+    }
+
+    /**
+     * Returns the catalog entry for [versionId], or null if the catalog hasn't
+     * been loaded yet or the version isn't covered.
+     *
+     * If [versionId] is the internal Bible version (`"internal"`, see
+     * [MVersionInternal.getVersionInternalId]), the lookup is redirected to the
+     * flavor-specific audio identifier from `BuildConfig.INTERNAL_VERSION_AUDIO_ID`
+     * — e.g. `yuku_alkitab` and `sabda_alkitab` map to `preset/in-tb`,
+     * `yuku_quick_bible` maps to `preset/en-kjv`. This lets users get audio for
+     * the bundled internal version even though it doesn't ship under a
+     * preset versionId of its own.
+     */
+    fun findEntry(versionId: String?): AudioVersion? {
+        val effective = effectiveVersionId(versionId) ?: return null
+        return cached?.entries?.firstOrNull { it.versionId == effective }
+    }
+
+    private fun effectiveVersionId(versionId: String?): String? {
+        if (versionId.isNullOrEmpty()) return null
+        if (versionId != MVersionInternal.getVersionInternalId()) return versionId
+        val mapped = BuildConfig.INTERNAL_VERSION_AUDIO_ID
+        return if (mapped.isEmpty()) null else mapped
+    }
+
+    /**
+     * Issues `GET /audio/catalog` with `If-None-Match` set to the cached ETag (if
+     * any). On 200, persists the body to `files/audio_catalog.json` and stores the
+     * new ETag. On 304, leaves the on-disk override untouched. On any other
+     * outcome (network error, parse failure, non-2xx, non-304), the override
+     * stays as-is.
+     *
+     * Either way, the in-memory cache is invalidated so the next [loadCatalog]
+     * picks up whatever is now on disk.
+     */
+    suspend fun refresh(): RefreshResult = withContext(Dispatchers.IO) {
+        val url = BuildConfig.SERVER_HOST + CATALOG_PATH + "?" + App.getAppIdentifierParamsEncoded()
+        val etag = Preferences.getString(Prefkey.audioCatalog_etag, null)
+        val request = Request.Builder()
+            .url(url)
+            .apply { if (!etag.isNullOrEmpty()) header("If-None-Match", etag) }
+            .build()
+
+        try {
+            Connections.okHttp.newCall(request).execute().use { response ->
+                when (response.code) {
+                    200 -> {
+                        val body = response.body?.string()
+                            ?: return@use RefreshResult.Failed("empty body")
+                        // Validate by parsing before we overwrite the on-disk override.
+                        val parsed = parseOrNull(body)
+                            ?: return@use RefreshResult.Failed("body did not parse")
+                        writeOverride(body)
+                        val newEtag = response.header("ETag")
+                        if (newEtag != null) {
+                            Preferences.setString(Prefkey.audioCatalog_etag, newEtag)
+                        }
+                        cached = parsed
+                        RefreshResult.Updated(parsed.entries.size)
+                    }
+                    304 -> RefreshResult.NotModified
+                    else -> RefreshResult.Failed("HTTP ${response.code}")
+                }
+            }
+        } catch (e: IOException) {
+            AppLog.w(TAG, "catalog refresh failed: ${e.message}")
+            RefreshResult.Failed(e.message ?: "I/O error")
+        }
+    }
+
+    sealed class RefreshResult {
+        data class Updated(val entryCount: Int) : RefreshResult()
+        data object NotModified : RefreshResult()
+        data class Failed(val reason: String) : RefreshResult()
+    }
+
+    /**
+     * Synchronous bridge for Java callers (e.g.
+     * [yuku.alkitab.base.sv.VersionConfigUpdaterService]). Blocks the calling
+     * thread; intended for use from existing IntentService-style worker threads.
+     * Not for use on the main thread.
+     */
+    @JvmStatic
+    fun refreshBlocking(): RefreshResult = runBlocking { refresh() }
+
+    // ---------------------------------------------------------------------------
+    // Internals
+    // ---------------------------------------------------------------------------
+
+    private fun readFromDiskOrAsset(): AudioCatalog {
+        // 1. Override file from a previous network refresh.
+        val overrideFile = overrideFile()
+        if (overrideFile.isFile) {
+            try {
+                val parsed = parseOrNull(overrideFile.readText(Charsets.UTF_8))
+                if (parsed != null) return parsed
+                AppLog.w(TAG, "override $OVERRIDE_FILENAME failed to parse; falling back to bundled asset")
+            } catch (e: IOException) {
+                AppLog.w(TAG, "could not read override $OVERRIDE_FILENAME: ${e.message}")
+            }
+        }
+
+        // 2. Bundled asset.
+        try {
+            App.context.assets.open(ASSET_FILENAME).use { input ->
+                val text = input.bufferedReader(Charsets.UTF_8).readText()
+                val parsed = parseOrNull(text)
+                if (parsed != null) return parsed
+                AppLog.e(TAG, "bundled $ASSET_FILENAME failed to parse — shipping a broken JSON?")
+            }
+        } catch (e: IOException) {
+            AppLog.e(TAG, "could not read bundled $ASSET_FILENAME: ${e.message}")
+        }
+
+        // 3. Empty catalog — every toolbar audio icon will be hidden.
+        return AudioCatalog()
+    }
+
+    private fun parseOrNull(body: String): AudioCatalog? {
+        return try {
+            json.decodeFromString(AudioCatalog.serializer(), body)
+        } catch (e: SerializationException) {
+            AppLog.w(TAG, "catalog JSON did not parse: ${e.message}")
+            null
+        }
+    }
+
+    private fun overrideFile(): File {
+        return File(App.context.filesDir, OVERRIDE_FILENAME)
+    }
+
+    private fun writeOverride(body: String) {
+        try {
+            overrideFile().writeText(body, Charsets.UTF_8)
+        } catch (e: IOException) {
+            AppLog.w(TAG, "could not persist refreshed catalog: ${e.message}")
+        }
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/model/AudioCatalog.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/model/AudioCatalog.kt
@@ -1,0 +1,14 @@
+package yuku.alkitab.base.audio.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Top-level catalog returned by the backend's `GET /audio/catalog`, also the shape
+ * stored in `files/audio_catalog.json` (overrides) and `assets/audio_catalog.json`
+ * (bundled fallback).
+ */
+@Serializable
+data class AudioCatalog(
+    val generatedAt: Long = 0L,
+    val entries: List<AudioVersion> = emptyList(),
+)

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/model/AudioVersion.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/model/AudioVersion.kt
@@ -1,0 +1,24 @@
+package yuku.alkitab.base.audio.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One entry in the audio catalog: a version that has audio available, plus the
+ * URL templates the client uses to fetch chapter MP3s and timing JSON. Both
+ * templates are relative paths on the backend (`BuildConfig.SERVER_HOST`); the
+ * client expands `{bookId}` and `{chapter_1}` via literal string replace.
+ *
+ * `versionId` matches the client's [yuku.alkitab.base.model.MVersion.getVersionId]
+ * format — typically `"preset/<preset_name>"` (e.g. `preset/in-tb`).
+ */
+@Serializable
+data class AudioVersion(
+    val versionId: String,
+    val shortName: String,
+    val displayLocaleHint: String? = null,
+    val chapterUrlTemplate: String,
+    val timingUrlTemplate: String? = null,
+    val copyrightNotice: String? = null,
+    val license: String? = null,
+    val hasDeuterocanon: Boolean = false,
+)

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/model/AudioVersion.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/model/AudioVersion.kt
@@ -18,7 +18,4 @@ data class AudioVersion(
     val displayLocaleHint: String? = null,
     val chapterUrlTemplate: String,
     val timingUrlTemplate: String? = null,
-    val copyrightNotice: String? = null,
-    val license: String? = null,
-    val hasDeuterocanon: Boolean = false,
 )

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/model/ChapterTiming.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/model/ChapterTiming.kt
@@ -1,0 +1,23 @@
+package yuku.alkitab.base.audio.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Verse timing for a single chapter. Mirrors the JSON returned by the backend's
+ * `GET /audio/timing` endpoint (see docs/features/audio-bible/backend-plan.md §4.2).
+ *
+ * `durationMs` is informational — `ExoPlayer.duration` after preparing the MP3 is
+ * the source of truth for the scrubber max. `verses` may be empty when the chapter
+ * has audio but no upstream timing; the client renders audio without highlight in
+ * that case.
+ */
+@Serializable
+data class ChapterTiming(
+    val schema: Int = 1,
+    val versionId: String,
+    val bookId: Int,
+    val chapter_1: Int,
+    val durationMs: Long = 0L,
+    val verses: List<VerseTiming> = emptyList(),
+    val generatedAt: Long = 0L,
+)

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/model/VerseTiming.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/model/VerseTiming.kt
@@ -1,0 +1,10 @@
+package yuku.alkitab.base.audio.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VerseTiming(
+    val verse_1: Int,
+    val startMs: Long,
+    val endMs: Long,
+)

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/Prefkey.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/Prefkey.kt
@@ -125,4 +125,15 @@ enum class Prefkey {
 
     /** Option to ask for verse number in goto screen  */
     gotoAskForVerse,
+
+    /**
+     * Audio bible: ETag of the most recently fetched `/audio/catalog` response.
+     * Sent as `If-None-Match` on subsequent fetches for 304 short-circuit.
+     */
+    audioCatalog_etag,
+
+    /**
+     * Audio bible: playback speed (float, 0.5–2.0). Default 1.0.
+     */
+    audioPlaybackSpeed,
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/sv/VersionConfigUpdaterService.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/sv/VersionConfigUpdaterService.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.Date;
 import yuku.afw.storage.Preferences;
 import yuku.alkitab.base.App;
+import yuku.alkitab.base.audio.AudioCatalogRepository;
 import yuku.alkitab.base.config.VersionConfig;
 import yuku.alkitab.base.connection.Connections;
 import yuku.alkitab.base.events.AppEvents;
@@ -66,6 +67,13 @@ public class VersionConfigUpdaterService extends IntentService {
 			} finally {
 				AppEvents.emitVersionListRefreshingStatus(false);
 			}
+
+			// Piggyback the audio catalog refresh on the same worker so we don't
+			// spawn a separate background service (see docs/features/audio-bible/).
+			// Failures are non-fatal — the catalog falls back to the previously
+			// stored override or the bundled assets/audio_catalog.json.
+			final AudioCatalogRepository.RefreshResult result = AudioCatalogRepository.refreshBlocking();
+			AppLog.d(TAG, "audio catalog refresh: " + result);
 		}
 	}
 

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioCatalogRepositoryTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioCatalogRepositoryTest.kt
@@ -1,0 +1,174 @@
+package yuku.alkitab.base.audio
+
+import android.app.Application
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import yuku.alkitab.debug.BuildConfig
+
+/**
+ * Robolectric tests for [AudioCatalogRepository] — Robolectric is required so
+ * that `App.context.assets.open(...)` can read the bundled
+ * `assets/audio_catalog.json` from the test classpath.
+ *
+ * The repository is a Kotlin `object` and therefore holds process-global state
+ * across tests. We reset it via reflection in [tearDown].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class AudioCatalogRepositoryTest {
+
+    @Before
+    fun setUp() {
+        val app = RuntimeEnvironment.getApplication()
+        yuku.afw.App.context = app
+        resetCachedField()
+        // Make sure no override file from a previous test leaks in.
+        overrideFile(app).delete()
+    }
+
+    @After
+    fun tearDown() {
+        resetCachedField()
+        overrideFile(RuntimeEnvironment.getApplication()).delete()
+    }
+
+    @Test
+    fun `bundled fallback exposes the four SABDA versions when no override exists`() {
+        val catalog = runBlocking { AudioCatalogRepository.loadCatalog() }
+        val ids = catalog.entries.map { it.versionId }
+        assertEquals(
+            "the bundled assets/audio_catalog.json should ship with TB, AYT, AVB, KJV",
+            listOf("preset/in-tb", "preset/in-ayt", "preset/in-avb", "preset/en-kjv"),
+            ids,
+        )
+    }
+
+    @Test
+    fun `findEntry returns the entry whose versionId matches`() {
+        runBlocking { AudioCatalogRepository.loadCatalog() }
+        val tb = AudioCatalogRepository.findEntry("preset/in-tb")
+        assertNotNull(tb)
+        assertEquals("TB", tb!!.shortName)
+        assertTrue(tb.chapterUrlTemplate.contains("{bookId}"))
+        assertTrue(tb.chapterUrlTemplate.contains("{chapter_1}"))
+    }
+
+    @Test
+    fun `findEntry returns null for an unknown versionId`() {
+        runBlocking { AudioCatalogRepository.loadCatalog() }
+        assertNull(AudioCatalogRepository.findEntry("preset/zz-nonsense"))
+        assertNull(AudioCatalogRepository.findEntry(null))
+    }
+
+    @Test
+    fun `isAudioAvailable is true for catalog versions and false for everything else`() {
+        runBlocking { AudioCatalogRepository.loadCatalog() }
+        assertTrue(AudioCatalogRepository.isAudioAvailable("preset/in-tb"))
+        assertTrue(AudioCatalogRepository.isAudioAvailable("preset/en-kjv"))
+        assertFalse(AudioCatalogRepository.isAudioAvailable("preset/zz-nonsense"))
+        assertFalse(AudioCatalogRepository.isAudioAvailable(null))
+    }
+
+    @Test
+    fun `override file is preferred over the bundled asset`() {
+        val app = RuntimeEnvironment.getApplication()
+        // A two-entry override that does NOT include any of the four SABDA presets,
+        // so we can tell which source loadCatalog() drew from.
+        overrideFile(app).writeText(
+            """
+            {
+              "generatedAt": 1700000000,
+              "entries": [
+                {
+                  "versionId": "preset/test-only",
+                  "shortName": "TST",
+                  "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Ftest-only&bookId={bookId}&chapter_1={chapter_1}"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+        resetCachedField()  // force a re-read
+
+        val catalog = runBlocking { AudioCatalogRepository.loadCatalog() }
+        assertEquals(1, catalog.entries.size)
+        assertEquals("preset/test-only", catalog.entries.single().versionId)
+        assertFalse(
+            "loading the override should have shadowed the bundled SABDA entries",
+            catalog.entries.any { it.versionId == "preset/in-tb" },
+        )
+    }
+
+    @Test
+    fun `internal versionId is mapped via BuildConfig INTERNAL_VERSION_AUDIO_ID`() {
+        // Sanity: this test runs under the `plain` flavor, which maps internal -> preset/in-tb.
+        // Other production flavors override INTERNAL_VERSION_AUDIO_ID in their build.gradle.kts.
+        assertEquals("preset/in-tb", BuildConfig.INTERNAL_VERSION_AUDIO_ID)
+
+        runBlocking { AudioCatalogRepository.loadCatalog() }
+
+        val entry = AudioCatalogRepository.findEntry("internal")
+        assertNotNull(
+            "the internal version should resolve to the flavor's mapped audio entry",
+            entry,
+        )
+        assertEquals("preset/in-tb", entry!!.versionId)
+        assertTrue(AudioCatalogRepository.isAudioAvailable("internal"))
+    }
+
+    @Test
+    fun `findEntry passes preset versionIds through unchanged (no mapping for non-internal)`() {
+        runBlocking { AudioCatalogRepository.loadCatalog() }
+        // The mapping override only applies to "internal"; presets resolve directly.
+        assertEquals(
+            "preset/en-kjv",
+            AudioCatalogRepository.findEntry("preset/en-kjv")?.versionId,
+        )
+    }
+
+    @Test
+    fun `unparseable override falls back to the bundled asset`() {
+        val app = RuntimeEnvironment.getApplication()
+        overrideFile(app).writeText("{ this is not json")
+        resetCachedField()
+
+        val catalog = runBlocking { AudioCatalogRepository.loadCatalog() }
+        assertEquals(
+            "should have fallen back to the four bundled entries",
+            4,
+            catalog.entries.size,
+        )
+        assertTrue(catalog.entries.any { it.versionId == "preset/in-tb" })
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private fun overrideFile(app: Application): File {
+        return File(app.filesDir, "audio_catalog.json")
+    }
+
+    /**
+     * The repository caches the parsed catalog in a `@Volatile` field. Reset it
+     * between tests so the bundled-vs-override switch isn't confounded by carryover
+     * state. Using reflection avoids exposing test-only API on the object itself.
+     */
+    private fun resetCachedField() {
+        val field = AudioCatalogRepository.javaClass.getDeclaredField("cached")
+        field.isAccessible = true
+        field.set(AudioCatalogRepository, null)
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioCatalogRepositoryTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioCatalogRepositoryTest.kt
@@ -2,7 +2,11 @@ package yuku.alkitab.base.audio
 
 import android.app.Application
 import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -136,6 +140,27 @@ class AudioCatalogRepositoryTest {
             "preset/en-kjv",
             AudioCatalogRepository.findEntry("preset/en-kjv")?.versionId,
         )
+    }
+
+    @Test
+    fun `concurrent first-callers of loadCatalog return the same instance and don't tear`() = runBlocking {
+        // 32 coroutines fan out from the same starting line. With the loadMutex
+        // in place, only one of them does the actual disk read; the rest take
+        // the cached reference. Either way, every caller must observe the same
+        // AudioCatalog object — *not* just a structurally-equal one — to prove
+        // the cache write is correctly published.
+        resetCachedField()
+        val catalogs = withContext(Dispatchers.Default) {
+            (1..32).map { async { AudioCatalogRepository.loadCatalog() } }.awaitAll()
+        }
+        val first = catalogs.first()
+        for ((i, c) in catalogs.withIndex()) {
+            assertTrue(
+                "caller #$i got a different AudioCatalog instance than caller #0",
+                c === first,
+            )
+        }
+        assertEquals(4, first.entries.size)
     }
 
     @Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.crashlytics.gradle) apply false
 }

--- a/docs/features/audio-bible/backend-plan.md
+++ b/docs/features/audio-bible/backend-plan.md
@@ -4,7 +4,19 @@
 **Client counterpart:** see [client-plan.md](client-plan.md) and [prd.md](prd.md).
 **Estimated effort:** ~1 sprint-week for one engineer (v1 endpoints + caching + monitoring).
 
-> ⚠️ I was not able to read `alkitab-host` from this environment (the GitHub MCP scope is restricted to `yukuku/androidbible`). This plan is therefore framed against the conventions visible from the client: a RESTful JSON API at `https://api.alkitab.app`, existing endpoints such as `/devotion/get`, `/sync/api/sync`, `/versions/get_yes`, `/addon/audio/exists`, and the Firebase-adjacent hosting described in `docs/backend-communication.md`. Before implementation, confirm the stack and adjust the handler language/framework sections accordingly.
+## 0. Stack (confirmed against `alkitab-host`)
+
+The backend is **Python 3.12 / Flask on Google App Engine Standard**, deployed as the `web-py3` service (see `alkitab-host/CLAUDE.md`, `alkitab-host/web/flask_app.py`, `alkitab-host/dispatch.yaml`).
+
+- **Routing.** `dispatch.yaml` sends `*/sync/*`, `*/cloud*`, `*/deferred_yuku/*`, `*/sync_cleanup/*` to the `sync-py3` service; everything else (including the new `/audio/*` paths) falls through to the `*/*` catch-all on `web-py3`. **No `dispatch.yaml` change needed.**
+- **Path namespace.** `/addon/audio/*` is already taken by **song** audio (`alkitab-host/addon/flask_app.py:161-187`, used by Kidung MP3/MID files keyed on song books like KJ/KPRI). New Bible audio endpoints **must not collide with that prefix** — use top-level `/audio/*`.
+- **Module shape.** Each feature is a Flask blueprint under its own top-level package (`addon/`, `versions/`, `devotion/`, `rp/`, `v/`, `announce/`). Blueprints are registered in `web/flask_app.py`. We will follow the same pattern: a new `audio/` package with `audio/__init__.py` and `audio/flask_app.py`.
+- **Storage.** The backend uses **Cloud Datastore via `google-cloud-ndb`** for persistent records (see `addon.AddonDownloadCounter`, `versions.AndroidBibleVersionDownloadCounter`, dozens of `Sync*` kinds). For per-instance hot caches, `web/cache.py` is a small TTL-bound LRU. **No Postgres, no Firestore, no GCS for app data** — the timing cache will be one new NDB kind plus the in-memory LRU.
+- **Admin auth.** Admin routes use the `@require_staff` decorator (Google OAuth2 staff login, `web/auth.py`), e.g. `addon.addon_admin_counter_stats`. **Not** a token. We follow the same convention for `/audio/admin/reload`.
+- **Upstream fetches.** Synchronous `requests` calls with a timeout, caching via `web.cache.set/get` (TTL-bound, per-instance). `addon.audio_file_exists` is the canonical example.
+- **Outbound CDN handoffs.** Existing addon endpoints redirect (`Flask.redirect`, 302) to either `https://boafiles.kejut.com/addon/...` or version-specific hosts. Bible audio will redirect to `https://media.sabda.org/...`.
+
+This plan is now grounded in the actual codebase. Implementation specifics below reference real files.
 
 ---
 
@@ -22,8 +34,8 @@
 |---|---|---|---|
 | `GET` | `/audio/catalog` | none | List of versions with audio + URL templates |
 | `GET` | `/audio/timing?versionId={versionId}&bookId={bookId}&chapter_1={chapter_1}` | none | Verse-timing JSON, normalized |
-| `GET` | `/audio/chapter?versionId={versionId}&bookId={bookId}&chapter_1={chapter_1}` | none | 302 redirect to the chapter MP3 on the CDN |
-| `POST` | `/audio/admin/reload` | admin token | Invalidate in-memory catalog; for manual rollouts |
+| `GET` | `/audio/chapter?versionId={versionId}&bookId={bookId}&chapter_1={chapter_1}` | none | 302 redirect to the chapter MP3 on the SABDA CDN |
+| `POST` | `/audio/admin/reload` | `@require_staff` | Invalidate in-memory catalog + timing LRU; for manual rollouts |
 
 `versionId` is the exact string the client's `MVersion.getVersionId()` returns (e.g. `preset/in-tb`). It is carried as a **query parameter** rather than a path segment so the `/` it contains doesn't need to be URL-encoded into a path component, which many routers (Nginx, Spring MVC's default mapping, Go's `http.ServeMux`) reject or pre-decode in surprising ways. Keeping `versionId` identical on client and backend means no translation layer on either side — the catalog entry's identifier, the `matchVersionId` the client looks up locally, and the query param sent to `/audio/timing`/`/audio/chapter` are all the same string.
 
@@ -108,7 +120,22 @@ Content-Type: application/json
 
 ### 3.3 Data source
 
-The catalog is a small hand-maintained config file (JSON or TOML) in the backend repo — effectively the same shape as `version_config.json` today, but narrower. No database; loaded once at boot, reloadable via `/audio/admin/reload`. Each deploy can change the list.
+The catalog is a Python module-level dict in `audio/flask_app.py`, in the same style as `BOOKS_WITH_MP3` in `addon/flask_app.py`. Hand-edited; one deploy = one update. No database, no JSON file on disk to keep in sync.
+
+```python
+# audio/flask_app.py
+CATALOG = {
+    "preset/in-tb":  {"shortName": "TB",  "displayLocaleHint": "in", "copyrightNotice": "© LAI, via SABDA",  "license": "Non-commercial", "hasDeuterocanon": False},
+    "preset/in-ayt": {"shortName": "AYT", "displayLocaleHint": "in", "copyrightNotice": "© AYT, via SABDA", "license": "Non-commercial", "hasDeuterocanon": False},
+    "preset/in-avb": {"shortName": "AVB", "displayLocaleHint": "ms", "copyrightNotice": "© BSM, via SABDA", "license": "Non-commercial", "hasDeuterocanon": False},
+    "preset/en-kjv": {"shortName": "KJV", "displayLocaleHint": "en", "copyrightNotice": "Public Domain",     "license": "PD",              "hasDeuterocanon": False},
+}
+
+# At request time, the handler synthesises chapterUrlTemplate / timingUrlTemplate
+# from the dict's keys plus the static path shape — see the JSON in §3.2.
+```
+
+The ETag is derived from a `sha1` of `json.dumps(CATALOG, sort_keys=True)`. It changes only when the dict changes (i.e. when a deploy ships a new entry). `/audio/admin/reload` is a no-op for the catalog itself today (the dict reloads when the App Engine instance restarts), but we keep the endpoint to bust the timing LRU and as a hook for any future dynamic catalog source.
 
 ### 3.4 Notes
 
@@ -162,35 +189,67 @@ ETag: "<sha1>"
 
 ### 4.3 Implementation
 
-Backend maintains a storage bucket (Firestore, GCS, or a Postgres table — whichever is already in alkitab-host) with the normalized timing for every (versionId, bookId, chapter_1) that a client has ever requested. On request:
+Two-tier cache: per-instance in-memory LRU (microsecond hits, evicted on instance restart) backed by a single new NDB kind for cross-instance persistence.
 
-1. Cache hit → serve from storage (microseconds).
-2. Cache miss → fetch from `karaoke.sabda.org/api/timming.php?book=<timingName>&chapter=<chapter_1>&version=<timingVersionParam>`, normalize, store, serve.
-3. Upstream failure on cache miss → `503` with `Retry-After: 30`. Never serve stale data we've never verified.
-4. Upstream failure on cache hit → serve the stored copy anyway — the long `max-age` keeps clients from re-fetching in the interim.
+**NDB model** (defined in `audio/flask_app.py`, alongside the existing counter-style models in `addon/` and `versions/`):
 
-The SABDA-specific translation tables (versionId → `timingVersionParam`, book ID → `timingName`) live here, not in the client. Shape:
-
+```python
+class BibleAudioTimingCache(ndb.Model):
+    # key name format: "<versionId>|<bookId>|<chapter_1>", e.g. "preset/in-tb|41|3"
+    payload   = ndb.JsonProperty(required=False)  # the normalized response body, or None for negative-cached entries
+    not_found = ndb.BooleanProperty(default=False)  # True if upstream returned 404 / known-missing chapter
+    fetched_at = ndb.IntegerProperty(required=True)  # epoch seconds, for TTL re-validation
 ```
+
+Why NDB and not GCS:
+- Total dataset is ~5000 chapters × ~5 KB = ~25 MB. Datastore handles this easily; entity size limit is 1 MB so a chapter's timing fits with room to spare.
+- Datastore reads are cheap (~$0.06 per 100k reads) and most chapters won't get more than a handful of cold-instance fetches per day.
+- Operationally the project already lives in NDB; introducing GCS would add another auth surface and another deploy step.
+
+Why not just `web/cache.py`:
+- That LRU is per-instance and per-warm-window. With F1 instance class auto-scaling 0-3, each scale-up serves a cold cache. NDB makes the cache survive scale events.
+
+**Request flow** (`GET /audio/timing`):
+
+1. **In-memory hit** (`web.cache.get(key)`) → serve.
+2. **NDB hit** with `not_found=False` and `fetched_at` within TTL → populate in-memory cache, serve.
+3. **NDB hit** with `not_found=True` and within negative TTL → serve `200` with `verses: []` (clients render audio without highlight). We do **not** propagate 404 here because the chapter exists in the Bible — it just lacks timing.
+4. **Cold miss** → `requests.get(karaoke.sabda.org/api/timming.php?book=<timingName>&chapter=<chapter_1>&version=<timingVersionParam>, timeout=15)`.
+   - Successful parse → normalize, store with `not_found=False`, populate LRU, serve.
+   - Upstream `404` → store with `not_found=True` (TTL ~7 days), serve `200` with empty `verses`.
+   - Upstream `5xx` / timeout / parse error → return `503 Retry-After: 30`. **Do not** poison the cache.
+5. **Stale NDB hit** (older than TTL) → kick off a refresh in the background (Cloud Tasks queue or an `ndb.tasklets.toplevel`-wrapped fire-and-forget) and serve the stored copy synchronously. Keeps p99 latency flat.
+
+**TTLs:**
+- Positive cache: 30 days (timing data is essentially immutable for a given recording).
+- Negative cache: **1 day** (short window so SABDA gap-fixes propagate quickly; the cost of the occasional re-fetch storm is negligible vs. user surprise).
+- In-memory LRU: 1 hour bound (matches the `audio_file_exists` precedent in `addon/flask_app.py:105`).
+
+**No pre-warm.** The cache fills lazily on the first user request per (version, book, chapter). The first hit on each chapter is slower (one upstream call to SABDA), but the upper bound is acceptable: ~200–500 ms added on a cold chapter. With a 30-day positive TTL, the second user — even days later — sees a hot hit.
+
+**Adapter tables** live in `audio/adapters.py` and are lifted verbatim from PR #127's `BibleAudioRepository.kt` (the values below are the actual constants from `Alkitab/src/main/java/yuku/alkitab/base/util/BibleAudioRepository.kt` in that PR — they are the result of real experimentation against sabda.org and we should not reinvent them):
+
+```python
+# audio/adapters.py
 AUDIO_ADAPTERS = {
-  "preset/in-tb": {
-    sabda_timing_version: "tbsuara",
-    sabda_audio_folder: "tb_alkitabsuara",
-  },
-  "preset/in-ayt": {
-    sabda_timing_version: "ayt",
-    sabda_audio_folder: "ayt-ai-v2",
-  },
-  ...
+    "preset/in-tb":  {"timing_version": "tbsuara", "audio_folder": "tb_alkitabsuara"},
+    "preset/in-ayt": {"timing_version": "ayt",     "audio_folder": "ayt-ai-v2"},
+    "preset/in-avb": {"timing_version": "avb",     "audio_folder": "avb"},
+    "preset/en-kjv": {"timing_version": "kjv",     "audio_folder": "kjv"},
 }
 
+# Indexed by 0-based bookId. timing_name is Indonesian even for KJV — that's
+# what karaoke.sabda.org/api/timming.php expects, regardless of audio version.
 BOOK_META = [
-  { bookId: 0, sabda_folder: "kejadian", sabda_abbr: "kej", sabda_timing_name: "Kejadian" },
-  ...
+    # ("folder",       "abbr", "timing_name")
+    ("kejadian",       "kej",  "Kejadian"),         # 0  Genesis
+    ("keluaran",       "kel",  "Keluaran"),         # 1  Exodus
+    # … all 66 books …
+    ("wahyu",          "wah",  "Wahyu"),            # 65 Revelation
 ]
 ```
 
-(Lift these tables verbatim from `BibleAudioRepository.kt` in PR #127 — they're the result of real experimentation against sabda.org.)
+The full table (~66 entries) is in PR #127's `BibleAudioRepository.kt` `BOOK_INFO` array. Copy it across into the Python module on backend implementation.
 
 ### 4.4 Why normalize instead of proxy passthrough?
 
@@ -234,7 +293,15 @@ url = "$base/$folder/$subdir/${prefix}_${shortDir}/${prefix}_${abbr}${chapterStr
 
 ## 6. `POST /audio/admin/reload`
 
-Simple admin endpoint protected by the same mechanism that today protects the existing `/versions/get_yes` etc. backoffice (reuse, don't invent). Body: empty. Response: `{ "reloadedAt": <ts>, "catalogEntries": <count> }`. Bumps the catalog's ETag so all clients refetch within a day.
+Protected by the project's standard `@require_staff` decorator (`alkitab-host/web/auth.py`) — the same mechanism that today guards `addon_admin_counter_stats`, `versions/admin/*`, etc.
+
+Body empty. Clears the per-instance `web.cache` LRU for `audio/timing/*` keys (catalog included). Does **not** touch the NDB cache — that survives across reloads, since the timing data is essentially immutable. To force a re-fetch of NDB-cached entries, an admin can delete rows directly via the Datastore console; we don't expose a programmatic flush in v1 because we never expect to need one.
+
+Response:
+
+```json
+{ "reloadedAt": 1713456000000, "evictedKeys": 184 }
+```
 
 ## 7. Monitoring
 
@@ -245,8 +312,8 @@ Simple admin endpoint protected by the same mechanism that today protects the ex
 
 ## 8. Rollout
 
-1. Implement the three read endpoints (catalog, timing, chapter) and `/audio/admin/reload`. Deploy to production — no flag, the endpoints are either live or they aren't.
-2. Pre-warm the timing cache for the whole Bible (~1188 chapters × 4 versions ≈ 4750 fetches) by running a one-off script against the deployed instance. Takes a few minutes and guarantees the first user never hits a cold cache.
+1. Land the new `audio/` package and register the blueprint in `web/flask_app.py`. Deploy via `cd deploy/web-py3 && bash deploy.sh`. No `dispatch.yaml` change is needed — the existing `*/*` catch-all routes `/audio/*` to `web-py3`.
+2. **No pre-warm.** Cache fills on demand. First user on a given chapter will incur ~200–500 ms of additional latency; subsequent users hit the NDB cache for 30 days.
 3. Verify the client (shipped with a bundled `assets/audio_catalog.json` mirroring the same four versions) continues to work if the backend is temporarily unreachable, so there is no hard coupling between app and backend releases.
 
 ## 9. Test plan
@@ -259,9 +326,10 @@ Simple admin endpoint protected by the same mechanism that today protects the ex
 
 ## 10. Security & abuse
 
-- No auth on read endpoints (by design — devotion and version endpoints are the same shape).
-- Rate-limit per client IP: 100 req/min per endpoint is plenty (a phone will make one catalog + ~10 timing requests per session).
-- Reject any `versionId` not in the catalog's key set (prevents arbitrary strings from reaching the sabda.org upstream).
+- No auth on read endpoints (by design — `/devotion/get`, `/versions/*`, `/addon/audio/exists`, etc. are all the same shape).
+- The existing endpoints have **no per-IP rate limiting** beyond App Engine's quotas. We will not add Flask-level rate limiting in v1 to stay consistent. A phone will issue one `/audio/catalog` per session plus ~10 `/audio/timing` and ~10 `/audio/chapter` per chapter played; load will be bounded by the install base. Revisit only if SABDA's CDN starts complaining.
+- Reject any `versionId` not in `CATALOG.keys()` with `404` (prevents arbitrary strings from reaching the sabda.org upstream).
+- Validate `bookId` is `0..65` and `chapter_1` is `1..150` at the handler boundary; reject otherwise with `400`.
 
 ## 11. Coordination with client
 
@@ -275,9 +343,14 @@ Simple admin endpoint protected by the same mechanism that today protects the ex
 - **Timing regeneration** when a version updates — add a `timingGeneration` field to force client refresh per version.
 - **HLS / DASH** for per-verse byte-range requests if pre-download or fine-grained scrubbing becomes a priority.
 
-## 13. Open questions (for the backend owner)
+## 13. Open questions (resolved)
 
-1. Which datastore does `alkitab-host` already use? (Timing cache should ride on an existing Postgres/Firestore/KV, not introduce a new one.)
-2. Is there already a scheduled job framework for pre-warming? (If not, a one-off script is fine.)
-3. What's the current admin-auth scheme for existing backoffice endpoints? Reuse it for `/audio/admin/reload`.
-4. Licensing: SABDA permits free distribution of audio, but do we need a formal attribution line beyond the `copyrightNotice` field in the catalog?
+| Question | Answer found in the codebase |
+|---|---|
+| Datastore? | `google-cloud-ndb` (Cloud Datastore) — same as `addon`, `versions`, `sync`. New kind: `BibleAudioTimingCache`. |
+| Scheduled jobs / pre-warming? | `cron.yaml` is currently empty. We add `POST /audio/admin/prewarm` as a one-shot admin endpoint instead of a cron entry; it can be re-hit manually after each deploy. |
+| Admin auth? | `@require_staff` decorator from `web/auth.py` (Google OAuth2). Reused. |
+
+The only question left for the **product** owner, not the engineering owner:
+
+1. **Licensing attribution.** SABDA permits free distribution of audio, but should the in-app "About this audio" sheet display a longer attribution string than the per-version `copyrightNotice` field? If so, what text? (Default for v1: just the per-version line.)

--- a/docs/features/audio-bible/backend-plan.md
+++ b/docs/features/audio-bible/backend-plan.md
@@ -64,40 +64,28 @@ Accept: application/json
       "shortName": "TB",
       "displayLocaleHint": "in",
       "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fin-tb&bookId={bookId}&chapter_1={chapter_1}",
-      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-tb&bookId={bookId}&chapter_1={chapter_1}",
-      "copyrightNotice": "© LAI, via SABDA",
-      "license": "Non-commercial",
-      "hasDeuterocanon": false
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-tb&bookId={bookId}&chapter_1={chapter_1}"
     },
     {
       "versionId": "preset/in-ayt",
       "shortName": "AYT",
       "displayLocaleHint": "in",
       "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fin-ayt&bookId={bookId}&chapter_1={chapter_1}",
-      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-ayt&bookId={bookId}&chapter_1={chapter_1}",
-      "copyrightNotice": "© AYT, via SABDA",
-      "license": "Non-commercial",
-      "hasDeuterocanon": false
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-ayt&bookId={bookId}&chapter_1={chapter_1}"
     },
     {
       "versionId": "preset/in-avb",
       "shortName": "AVB",
       "displayLocaleHint": "ms",
       "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fin-avb&bookId={bookId}&chapter_1={chapter_1}",
-      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-avb&bookId={bookId}&chapter_1={chapter_1}",
-      "copyrightNotice": "© BSM, via SABDA",
-      "license": "Non-commercial",
-      "hasDeuterocanon": false
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fin-avb&bookId={bookId}&chapter_1={chapter_1}"
     },
     {
       "versionId": "preset/en-kjv",
       "shortName": "KJV",
       "displayLocaleHint": "en",
       "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fen-kjv&bookId={bookId}&chapter_1={chapter_1}",
-      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fen-kjv&bookId={bookId}&chapter_1={chapter_1}",
-      "copyrightNotice": "Public Domain",
-      "license": "PD",
-      "hasDeuterocanon": false
+      "timingUrlTemplate": "/audio/timing?versionId=preset%2Fen-kjv&bookId={bookId}&chapter_1={chapter_1}"
     }
   ]
 }
@@ -125,10 +113,10 @@ The catalog is a Python module-level dict in `audio/flask_app.py`, in the same s
 ```python
 # audio/flask_app.py
 CATALOG = {
-    "preset/in-tb":  {"shortName": "TB",  "displayLocaleHint": "in", "copyrightNotice": "© LAI, via SABDA",  "license": "Non-commercial", "hasDeuterocanon": False},
-    "preset/in-ayt": {"shortName": "AYT", "displayLocaleHint": "in", "copyrightNotice": "© AYT, via SABDA", "license": "Non-commercial", "hasDeuterocanon": False},
-    "preset/in-avb": {"shortName": "AVB", "displayLocaleHint": "ms", "copyrightNotice": "© BSM, via SABDA", "license": "Non-commercial", "hasDeuterocanon": False},
-    "preset/en-kjv": {"shortName": "KJV", "displayLocaleHint": "en", "copyrightNotice": "Public Domain",     "license": "PD",              "hasDeuterocanon": False},
+    "preset/in-tb":  {"shortName": "TB",  "displayLocaleHint": "in"},
+    "preset/in-ayt": {"shortName": "AYT", "displayLocaleHint": "in"},
+    "preset/in-avb": {"shortName": "AVB", "displayLocaleHint": "ms"},
+    "preset/en-kjv": {"shortName": "KJV", "displayLocaleHint": "en"},
 }
 
 # At request time, the handler synthesises chapterUrlTemplate / timingUrlTemplate
@@ -140,7 +128,7 @@ The ETag is derived from a `sha1` of `json.dumps(CATALOG, sort_keys=True)`. It c
 ### 3.4 Notes
 
 - `versionId` must exactly match the client's `MVersion.getVersionId()` format (`"preset/<preset_name>"`). See `Alkitab/src/main/java/yuku/alkitab/base/model/MVersionPreset.java:18-20`. Getting this wrong means the toolbar icon never shows up.
-- `hasDeuterocanon` is advisory so the client can disable Next-chapter at the Protestant canon boundary for those who want it; v1 can ignore.
+- We assume **all books and all chapters have audio** when a version is in the catalog. If the upstream is missing a particular chapter, the client renders a "Audio not available for this chapter" snackbar (PRD §4.6) — there is no advance signal of coverage gaps in the catalog.
 
 ## 4. `GET /audio/timing?versionId=…&bookId=…&chapter_1=…`
 
@@ -351,6 +339,4 @@ Response:
 | Scheduled jobs / pre-warming? | `cron.yaml` is currently empty. We add `POST /audio/admin/prewarm` as a one-shot admin endpoint instead of a cron entry; it can be re-hit manually after each deploy. |
 | Admin auth? | `@require_staff` decorator from `web/auth.py` (Google OAuth2). Reused. |
 
-The only question left for the **product** owner, not the engineering owner:
-
-1. **Licensing attribution.** SABDA permits free distribution of audio, but should the in-app "About this audio" sheet display a longer attribution string than the per-version `copyrightNotice` field? If so, what text? (Default for v1: just the per-version line.)
+No open product questions for v1.

--- a/docs/features/audio-bible/client-plan.md
+++ b/docs/features/audio-bible/client-plan.md
@@ -91,40 +91,31 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 **Exit criteria:** A throwaway button in a debug-only screen starts the service, plays a chapter, updates a text view with the active verse. No UI polish yet.
 
-### M3 — UI surface (Compose, ≈ 4 days)
+### M3 — UI surface (Compose, ≈ 3 days)
 
-**Goal:** the feature is wired into `IsiActivity` and matches the mock in PRD §4.2 — peek bottom-sheet that swipes up into a full mini-player. Implemented entirely in Compose 1.11.0; this is the project's first Compose surface.
+**Goal:** the feature is wired into `IsiActivity` and matches the mock in PRD §4.2 — a fixed-height Material 3 audio bar at the bottom of the screen. Implemented entirely in Compose 1.11.0; this is the project's first Compose surface.
 
 #### 3.1 Compose host
 
-- [ ] Add a `<androidx.compose.ui.platform.ComposeView android:id="@+id/audio_bottom_sheet" />` to `activity_isi.xml` at the bottom of the root layout (`android:layout_gravity="bottom"`). The sheet handles its own peek/expand behavior; no XML siblings move.
+- [ ] Add a `<androidx.compose.ui.platform.ComposeView android:id="@+id/audio_bar" />` to `activity_isi.xml` at the bottom of the root layout (`android:layout_gravity="bottom"`).
 - [ ] `AudioBarController.kt` (in `audio/`) — Kotlin glue between the View-based `IsiActivity` and the Compose UI:
     - Owns a `MutableStateFlow<AudioBarUiState>`.
-    - `attach(activity: IsiActivity, composeView: ComposeView)` — `composeView.setContent { AudioBottomSheet(state, onCommand) }`.
+    - `attach(activity: IsiActivity, composeView: ComposeView)` — `composeView.setContent { AudioBar(state, onCommand) }`.
     - Exposes `fun show()` / `fun hide()` / `fun isAvailable: Boolean` for `IsiActivity` to call.
     - Forwards play/pause/seek/speed/chapter-nav commands to the `BibleAudioService` (M2) via the binder.
     - Forwards chapter-navigation events back to `IsiActivity.display(book, chapter_1, 0)`.
 
 #### 3.2 Composable surface
 
-- [ ] `audio/ui/AudioTheme.kt` — wraps Compose `MaterialTheme` and bridges the project's existing `?attr/colorSurface*` etc. into Compose `ColorScheme` so dark mode works without a separate Compose theme. Uses `MaterialTheme.colorScheme.surfaceContainerHigh` for the sheet background.
-- [ ] `audio/ui/AudioBottomSheet.kt` — top-level `@Composable`:
-    - `BottomSheetScaffold` from `androidx.compose.material3` with `sheetPeekHeight = 96.dp`, `sheetSwipeEnabled = true`, `sheetDragHandle = { BottomSheetDefaults.DragHandle() }`, `sheetContainerColor = colorScheme.surfaceContainerHigh`, `sheetTonalElevation = 6.dp`, `sheetShape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)`.
-    - `sheetContent = { AudioBarExpanded(...) }` (the full mini-player).
-    - The peek row (`AudioBarPeek`) is the part of `sheetContent` rendered above the fold within `sheetPeekHeight`.
-- [ ] `audio/ui/AudioBarPeek.kt` — peek row matching PRD §4.2.1:
-    - Row: prev-chapter (icon + label) | prev-verse | play/pause FAB | next-verse | next-chapter (icon + label) | speed | close.
-    - Slider below the row.
+- [ ] `audio/ui/AudioTheme.kt` — wraps Compose `MaterialTheme` and bridges the project's existing `?attr/colorSurface*` etc. into Compose `ColorScheme` so dark mode works without a separate Compose theme. Uses `MaterialTheme.colorScheme.surfaceContainerHigh` for the bar background.
+- [ ] `audio/ui/AudioBar.kt` — top-level `@Composable`. A fixed-height (≈96dp) `Surface` anchored to the bottom of the host `ComposeView`. Visibility (show/hide on close) is animated via `AnimatedVisibility(enter = slideInVertically(initialOffsetY = { it }), exit = slideOutVertically(targetOffsetY = { it }))` so the bar slides in/out instead of popping.
+    - Layout: top row of controls + Slider below.
+    - Top row, left-to-right: prev-chapter (icon + label) | prev-verse | play/pause FAB | next-verse | next-chapter (icon + label) | speed | close.
     - Slider uses Material 3 `Slider` with a custom `SliderState` and a label rendered above the thumb: `"${formatMmSs(snappedMs)} · v.${verse_1}"`. Snap-to-verse on `onValueChangeFinished`.
     - Play/pause button uses `AnimatedContent` to crossfade between `Icons.Filled.PlayArrow` and `Icons.Filled.Pause` — Compose's idiomatic equivalent of the AVD morph.
     - On preparing state: render a `CircularProgressIndicator` overlay around the play/pause button.
     - Chapter-nav button labels (`Jn 4`) drawn with `Modifier.alpha(if (target != null) 1f else 0f)` — invisible-not-gone, layout doesn't reflow at Bible boundaries.
     - Haptics: `LocalHapticFeedback.current.performHapticFeedback(HapticFeedbackType.LongPress)` on speed change, `HapticFeedbackType.TextHandleMove` on play/pause.
-- [ ] `audio/ui/AudioBarExpanded.kt` — expanded state matching PRD §4.2.2:
-    - Big chapter art (square, 240dp) — for v1, the app icon over a tinted background.
-    - Title row (`John 3 · KJV`) in `MaterialTheme.typography.headlineSmall`.
-    - Same scrubber, larger transport row, speed + verse counter chips.
-    - **"Up next" `LazyColumn`** of upcoming verses' first 80 chars; tap to seek.
 - [ ] `audio/ui/SpeedBottomSheet.kt` — `ModalBottomSheet` with a `FilterChip` row for `0.5×, 0.8×, 1.0×, 1.25×, 1.5×, 1.75×, 2.0×`. Single-selection. Persisted via `Prefkey.audioPlaybackSpeed`.
 - [ ] `audio/ui/AudioHighlightColor.kt` — pure-function logic:
     ```kotlin
@@ -158,10 +149,10 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 #### 3.5 Tests
 
 - [ ] `AudioHighlightColorTest` — pure-function unit tests covering yellow/black/white selection across light, sepia, and dark reading backgrounds. Assert ≥4.5 contrast.
-- [ ] Compose preview functions for `AudioBarPeek`, `AudioBarExpanded`, `SpeedBottomSheet` — for visual review in Android Studio. (Previews don't replace device testing but are cheap insurance.)
-- [ ] Instrumented test (`connectedCheck`): open chapter → tap audio → verify the bottom sheet appears in peek state → swipe up via Compose `performTouchInput` → assert the expanded state is rendered.
+- [ ] Compose preview functions for `AudioBar`, `SpeedBottomSheet` — for visual review in Android Studio. (Previews don't replace device testing but are cheap insurance.)
+- [ ] Instrumented test (`connectedCheck`): open chapter → tap audio → verify the audio bar slides in → tap close → verify it slides out and the service stops.
 
-**Exit criteria:** End-to-end demo of §1–§6 of the PRD's must-haves (screen-on usage); the bottom sheet swipes smoothly between peek and expanded; verse highlight uses yellow on light themes and the contrast-fallback color on dark themes.
+**Exit criteria:** End-to-end demo of §1–§6 of the PRD's must-haves (screen-on usage); the audio bar slides in/out smoothly; verse highlight uses yellow on light themes and the contrast-fallback color on dark themes.
 
 ### M4 — Lock-screen & background (≈ 2 days)
 
@@ -184,14 +175,14 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 ### M5 — Behavior polish & design review (≈ 2 days)
 
-The visual scaffolding (Compose `BottomSheetScaffold`, Material 3 theming, `AnimatedContent` icon crossfades, smooth verse-scroll, `LocalHapticFeedback`) is already baked into M3. M5 is the behavior polish:
+The visual scaffolding (Compose audio bar with `AnimatedVisibility` slide-in, Material 3 theming, `AnimatedContent` icon crossfades, smooth verse-scroll, `LocalHapticFeedback`) is already baked into M3. M5 is the behavior polish:
 
 - [ ] Speed persistence: `Prefkey.audioPlaybackSpeed` (enum default `1.0f`). Read on service start, write on each change.
 - [ ] Auto-advance: on `onEnded`, navigate to the next chapter. Centralise the cross-book logic in a new `BibleNavigationUtil.kt` (it's useful outside audio too). No repeat toggle in v1.
 - [ ] Snackbar error handling (§4.6 of PRD). Snackbars come from `IsiActivity` (host), not the Compose layer, since they need to overlay the toolbar.
 - [ ] Split-view source dialog (§4.5 of PRD). On play-tap when split view is active and both visible versions have audio, render a Compose `AlertDialog` with the two version short names and a Cancel. The state is held in `AudioBarController` via `MutableStateFlow`; reset to `null` whenever split view toggles, either visible version changes, or the audio bar is closed.
 - [ ] **Design review pass.** Walk the bottom sheet against this checklist before tagging M5 done:
-    - Peek-to-expanded swipe is smooth on a low-end device (Pixel 4a / API 30 emulator OK).
+    - Slide-in / slide-out animation is smooth on a low-end device (Pixel 4a / API 30 emulator OK).
     - Highlight overlay fades, doesn't strobe, at 1.0× speed.
     - Play/pause icon crossfades (no swap).
     - Toolbar icon crossfades into the spinner (no swap).

--- a/docs/features/audio-bible/client-plan.md
+++ b/docs/features/audio-bible/client-plan.md
@@ -6,35 +6,52 @@
 
 This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-plan.md) lands (at least catalog + timing endpoints) before milestone M3.
 
+**Backend status:** the [backend plan](backend-plan.md) is now grounded in the real `alkitab-host` stack (Python 3.12 / Flask on App Engine Standard, NDB Datastore for the timing cache, `web.cache` LRU for in-memory hits, top-level `/audio/*` namespace served by the `web-py3` service). No `dispatch.yaml` change is required — the catch-all already routes `/audio/*` to web-py3. The client is therefore unblocked: we ship with the bundled fallback catalog and the feature works end-to-end against `media.sabda.org` even if the backend deploy slips.
+
 ---
 
 ## 0. Prerequisites
 
 - [ ] Read the PRD in `prd.md` and the backend plan in `backend-plan.md`.
-- [ ] Skim PR #127 — it is the template for the player/repository layer and most of its code carries over.
+- [ ] **Do not cherry-pick from PR #127 or PR #124.** Both PRs will be closed unmerged once this work lands. They are useful as inspiration only — the SABDA timing-API tables in PR #127 have moved to the backend, the activity-scoped player from both PRs is replaced by a `MediaSessionService`, and the entire UI surface is rewritten in Compose. Re-write the player wrapper (`BibleAudioPlayer`), the repository (`BibleAudioRepository`), the highlight tracker, and the verse-overlay code from scratch with the conventions called out in this plan.
 - [ ] Confirm `androidx.media3:media3-session` is not yet in the build; add it in M1.
-- [ ] Access to the backend staging environment (base URL + simple-token, same as sync).
+- [ ] Confirm Jetpack Compose is not yet in the build (it isn't — this feature is the project's first Compose surface); add the dependency family + Kotlin Compose Compiler plugin in M1.
+- [ ] Access to the backend staging environment (base URL is `BuildConfig.SERVER_HOST`).
 
 ---
 
 ## 1. Milestones
 
-### M1 — Skeleton & catalog (≈ 2 days)
+### M1 — Skeleton, deps, & catalog (≈ 3 days, +1 for the Compose bootstrap)
 
-**Goal:** app builds with a stubbed AudioBar; catalog loads from backend.
+**Goal:** app builds with the new dependency family wired in (media3-session, Compose 1.11.0, Compose Compiler plugin); catalog loads from backend with a bundled fallback.
 
-- [ ] Add `androidx.media3:media3-session:<same-version-as-exoplayer>` to `Alkitab/build.gradle` (match the existing media3 version used by `ExoplayerController.kt:8-17`).
+- [ ] Add `androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "androidxMedia3" }` to `gradle/libs.versions.toml` and `implementation(libs.androidx.media3.session)` in `Alkitab/build.gradle.kts`.
+- [ ] Add Compose 1.11.0 to the project as **the first Compose surface in the codebase**:
+    - In `gradle/libs.versions.toml`:
+        ```toml
+        androidxComposeUi = "1.11.0"
+        androidxComposeMaterial3 = "1.4.0"   # paired with compose-ui 1.11 per Compose BOM 2026.04.01
+        ```
+        Plus library entries for `androidx-compose-ui`, `androidx-compose-foundation`, `androidx-compose-runtime`, `androidx-compose-material3`, `androidx-compose-ui-tooling-preview`, `androidx-compose-ui-tooling`, `androidx-activity-compose`.
+    - In `Alkitab/build.gradle.kts`:
+        - Apply the `org.jetbrains.kotlin.plugin.compose` plugin (Kotlin 2.x ships the Compose compiler as a separate plugin; matches the project's `kotlin = "2.2.0"`).
+        - Add `buildFeatures { compose = true }` to the `android {}` block.
+        - Add the `implementation(libs.androidx.compose.ui)` etc. dependencies.
+    - Add `id("org.jetbrains.kotlin.plugin.compose") apply false` to the root `build.gradle.kts` plugin list (root project alias).
+- [ ] Verify `./gradlew assemblePlainDebug` succeeds with the new deps in place. If `compose-material3:1.5.0` is not yet published, bump to the most recent stable that pairs with `compose-ui:1.11.0`.
 - [ ] Create package `yuku.alkitab.base.audio` and skeleton files per PRD §5.7.
 - [ ] Model classes: `AudioVersion.kt`, `ChapterTiming.kt`, `VerseTiming.kt`, `AudioCatalog.kt`.
 - [ ] `AudioCatalogRepository`:
-    - Uses `Connections.okHttp` and `BuildConfig.SERVER_HOST`.
-    - `GET /audio/catalog?appIdentifier=...` with conditional `If-None-Match` when we have an ETag.
+    - Uses `Connections.okHttp` and `BuildConfig.SERVER_HOST` (defined at `Alkitab/build.gradle.kts:123`; resolves to `https://alkitab.app` for production flavors).
+    - `GET ${SERVER_HOST}/audio/catalog?${App.getAppIdentifierParamsEncoded()}` with conditional `If-None-Match` when we have an ETag. Mirror the `appIdentifier`/`packageName`/`versionCode` query-param style used by `VersionConfigUpdaterService` (`Alkitab/src/main/java/yuku/alkitab/base/sv/VersionConfigUpdaterService.java:93`) and `DevotionDownloader` (`DevotionDownloader.java:51`).
     - 200 → parse JSON, persist to `files/audio_catalog.json`, store ETag in `Prefkey.audioCatalog_etag`.
     - 304 → keep current cache.
-    - Non-2xx → fall back to bundled `assets/audio_catalog.json` (checked in with the known SABDA versions, so the feature degrades to the #127 behavior if backend is down).
+    - Non-2xx → fall back to bundled `Alkitab/src/main/assets/audio_catalog.json` (checked in with the four known SABDA versions; same shape as the live `/audio/catalog` response). The feature works end-to-end on the bundled fallback alone, so client and backend can ship independently.
     - `suspend fun loadCatalog(): AudioCatalog` returns the cached+merged view.
     - `fun isAudioAvailable(versionId: String): Boolean` for the toolbar icon visibility.
-- [ ] Add a Prefkey entry `audioCatalog_etag` in `Prefkey.kt`.
+- [ ] Add a Prefkey entry `audioCatalog_etag` (and `audioPlaybackSpeed` for M5) in `Prefkey.kt`.
+- [ ] Per-flavor `BuildConfig.INTERNAL_VERSION_AUDIO_ID` in `Alkitab/build.gradle.kts` (see PRD §5.4.1). Default `""` in `defaultConfig`; override `"preset/in-tb"` for `plain`/`yuku_alkitab`/`sabda_alkitab` and `"preset/en-kjv"` for `yuku_quick_bible`. Wire the substitution into `AudioCatalogRepository.findEntry` so `MVersion.getVersionId() == "internal"` resolves to the correct catalog row.
 - [ ] Background refresh: piggyback on the existing `VersionConfigUpdaterService` (see `docs/backend-communication.md:39-41`) — add a parallel catalog fetch so we don't spawn a new worker.
 - [ ] Unit tests (`Alkitab/src/test/java/.../audio/AudioCatalogRepositoryTest.kt`): parsing, ETag handling, cache fallback.
 
@@ -44,11 +61,11 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 **Goal:** single-stream audio plays end-to-end for the active chapter; verses highlight and scroll.
 
-- [ ] `BibleAudioPlayer.kt` — port from PR #127 verbatim (the file is already clean). Single-responsibility wrapper around ExoPlayer with a `Listener` (`onReady`, `onEnded`, `onError`). Main-thread-only API.
-- [ ] `BibleAudioRepository.kt` — replaces the sabda-hard-coded repository from PR #127:
-    - `suspend fun buildChapterUrl(versionId, bookId, chapter_1): String?` — expands the catalog's `chapterUrlTemplate`.
-    - `suspend fun fetchTiming(versionId, bookId, chapter_1): ChapterTiming?` — GET via `Connections.okHttp`; parses new JSON schema (see backend plan §4); returns `null` on network/parse failure. OkHttp's 50MB disk cache supplies implicit per-URL caching via `Cache-Control` headers set by the backend.
-    - All book-code / filename construction moves to the backend.
+- [ ] `BibleAudioPlayer.kt` — write from scratch. Single-responsibility wrapper around media3 ExoPlayer with a `Listener` (`onReady`, `onEnded`, `onError`). Main-thread-only API. Use the OkHttp `DataSource.Factory` pattern from `yuku.alkitab.songs.ExoplayerController.kt:8-17` (same project convention, same dependency).
+- [ ] `BibleAudioRepository.kt` — written from scratch, lives at `yuku.alkitab.base.audio.BibleAudioRepository`. Surface:
+    - `suspend fun buildChapterUrl(versionId, bookId, chapter_1): String?` — expands the catalog's `chapterUrlTemplate` against `${SERVER_HOST}` (the backend issues a 302 to the real CDN).
+    - `suspend fun fetchTiming(versionId, bookId, chapter_1): ChapterTiming?` — `GET ${SERVER_HOST}/audio/timing?...` via `Connections.okHttp`; parses the v1 JSON schema (see backend plan §4); returns `null` on network/parse failure, an empty `verses` list when the backend signals "no timing for this chapter". OkHttp's 50MB disk cache supplies implicit per-URL caching via the `Cache-Control` headers set by the backend.
+    - **No SABDA URLs** in the client. All book-code / filename / SABDA-folder construction lives on the backend (`audio/adapters.py`). Verify with `grep -r "sabda" Alkitab/src/main` after the PR is up: zero hits expected.
 - [ ] `HighlightTracker.kt` — a small class that owns a `StateFlow<Int>` of currently-active `verse_1`. Input: `positionMs` + timing list. Internal: a last-index hint so we don't re-binary-search every tick. 100ms poll interval (same as PR #127).
 - [ ] `BibleAudioService.kt` — `androidx.media3.session.MediaSessionService`:
     - Owns a `BibleAudioPlayer`.
@@ -74,31 +91,77 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 **Exit criteria:** A throwaway button in a debug-only screen starts the service, plays a chapter, updates a text view with the active verse. No UI polish yet.
 
-### M3 — UI surface (≈ 3 days)
+### M3 — UI surface (Compose, ≈ 4 days)
 
-**Goal:** the feature is wired into `IsiActivity` and looks like the mock in PRD §4.2.
+**Goal:** the feature is wired into `IsiActivity` and matches the mock in PRD §4.2 — peek bottom-sheet that swipes up into a full mini-player. Implemented entirely in Compose 1.11.0; this is the project's first Compose surface.
 
-- [ ] `layout/audio_bar.xml` — the bar from PRD §4.2 (close → scrubber → controls). Include a `SeekBar` and `TextView` for time labels. Use Material 3 theming attributes so it respects dark mode (`?attr/colorSurface`, etc.) — PR #127's hard-coded `#455A64` and `#FFFFFF` do not. The prev-chapter and next-chapter controls are `LinearLayout` button-likes (icon + `TextView`) so the label (e.g. `Jn 4`) sits next to the icon; the label is driven by a `StateFlow<ChapterTarget?>` from the ViewModel and set to empty when the target is out of range (Bible boundary). Prev/next verse are plain icon buttons with no label.
-- [ ] `drawable/ic_audio*.xml` — carry over the SVG assets from PR #127 (they are generic Material icons).
-- [ ] `AudioBarView.kt` — a `LinearLayout` subclass that inflates `audio_bar.xml` and binds to a `AudioBarViewModel`.
-- [ ] `AudioBarViewModel.kt`:
-    - Collects the service's `StateFlow<PlaybackState>` (exposed through the binder).
-    - Exposes `LiveData` or `StateFlow` for the view.
-    - Commands: `togglePlayPause()`, `seekTo(ms)`, `seekToVerse(verse_1)`, `nextVerse()`, `prevVerse()`, `nextChapter()`, `prevChapter()`, `setSpeed(f)`.
-    - Scrubber preview: exposes `fun previewAtPosition(ms: Long): ScrubPreview` returning `{ snappedMs, verse_1 }` derived from the current chapter's timing, so the view can update the drag bubble without touching the player.
-    - Navigates by firing an event flow; `IsiActivity` observes and calls its existing chapter-navigation methods.
-- [ ] Menu item: edit `res/menu/activity_isi.xml` to add `<item android:id="@+id/menuAudio" app:showAsAction="always" android:icon="@drawable/ic_audio" android:title="@string/menu_audio" />` — matches the existing `menuSearch` entry's `always` treatment so it never spills into overflow. Wire in `IsiActivity.buildMenu`/`onOptionsItemSelected` (see `IsiActivity.kt:1368-1399`).
-- [ ] Toolbar icon visibility — observe the catalog. Set `menuItem.isVisible = repo.isAudioAvailable(visibleVersionId0) || repo.isAudioAvailable(visibleVersionId1)`. Refresh on active-version change and on split-view enter/exit. Hiding (not disabling) is intentional — a permanently-greyed icon is more confusing than no icon.
-- [ ] Preparing-state spinner: clone the Kidung pattern (`SongViewActivity.kt:178, 443-449, 1088-1090`). Add a `circular_progress` view to the toolbar layout in `activity_isi.xml`, initially `GONE`. In `onPrepareOptionsMenu`, when `audioBinder.isPreparing`, set `menuAudio.isVisible = false` and `circular_progress.visibility = VISIBLE`; otherwise the inverse. Tapping during preparing is a no-op — the menu item is gone and the spinner is not clickable. Trigger `invalidateOptionsMenu()` from the state collector whenever `PlaybackState.preparing` flips.
-- [ ] Verse highlight:
-    - Add `var audioHighlighted: Boolean` on `VerseItem.kt` (PR #127's diff transfers directly). Uses `?attr/colorPrimaryContainer` at 20% alpha, not the hard-coded `#334FC3F7`.
-    - Add `fun setAudioHighlight(verse_1: Int)` on `VersesController` / `VersesControllerImpl`. `verse_1 = 0` clears.
-    - On each `PlaybackState.verse_1` change, call `setAudioHighlight` on the active split's controller and `scrollToVerse(verse_1, prop = 0.33f)` (using existing `scrollToVerse(verse_1, prop)` from `VersesController.kt:86`).
-- [ ] Close button hides the bar and stops the service.
-- [ ] Accessibility: all buttons have `contentDescription`; the scrubber announces "verse X of Y"; the "currently playing" highlight adds `contentDescription` suffix.
-- [ ] Instrumented test (`connectedCheck`) for: open chapter → tap audio → verify service starts → tap pause → verify state flows back.
+#### 3.1 Compose host
 
-**Exit criteria:** End-to-end demo of §1–§6 of the PRD's must-haves (screen-on usage).
+- [ ] Add a `<androidx.compose.ui.platform.ComposeView android:id="@+id/audio_bottom_sheet" />` to `activity_isi.xml` at the bottom of the root layout (`android:layout_gravity="bottom"`). The sheet handles its own peek/expand behavior; no XML siblings move.
+- [ ] `AudioBarController.kt` (in `audio/`) — Kotlin glue between the View-based `IsiActivity` and the Compose UI:
+    - Owns a `MutableStateFlow<AudioBarUiState>`.
+    - `attach(activity: IsiActivity, composeView: ComposeView)` — `composeView.setContent { AudioBottomSheet(state, onCommand) }`.
+    - Exposes `fun show()` / `fun hide()` / `fun isAvailable: Boolean` for `IsiActivity` to call.
+    - Forwards play/pause/seek/speed/chapter-nav commands to the `BibleAudioService` (M2) via the binder.
+    - Forwards chapter-navigation events back to `IsiActivity.display(book, chapter_1, 0)`.
+
+#### 3.2 Composable surface
+
+- [ ] `audio/ui/AudioTheme.kt` — wraps Compose `MaterialTheme` and bridges the project's existing `?attr/colorSurface*` etc. into Compose `ColorScheme` so dark mode works without a separate Compose theme. Uses `MaterialTheme.colorScheme.surfaceContainerHigh` for the sheet background.
+- [ ] `audio/ui/AudioBottomSheet.kt` — top-level `@Composable`:
+    - `BottomSheetScaffold` from `androidx.compose.material3` with `sheetPeekHeight = 96.dp`, `sheetSwipeEnabled = true`, `sheetDragHandle = { BottomSheetDefaults.DragHandle() }`, `sheetContainerColor = colorScheme.surfaceContainerHigh`, `sheetTonalElevation = 6.dp`, `sheetShape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)`.
+    - `sheetContent = { AudioBarExpanded(...) }` (the full mini-player).
+    - The peek row (`AudioBarPeek`) is the part of `sheetContent` rendered above the fold within `sheetPeekHeight`.
+- [ ] `audio/ui/AudioBarPeek.kt` — peek row matching PRD §4.2.1:
+    - Row: prev-chapter (icon + label) | prev-verse | play/pause FAB | next-verse | next-chapter (icon + label) | speed | close.
+    - Slider below the row.
+    - Slider uses Material 3 `Slider` with a custom `SliderState` and a label rendered above the thumb: `"${formatMmSs(snappedMs)} · v.${verse_1}"`. Snap-to-verse on `onValueChangeFinished`.
+    - Play/pause button uses `AnimatedContent` to crossfade between `Icons.Filled.PlayArrow` and `Icons.Filled.Pause` — Compose's idiomatic equivalent of the AVD morph.
+    - On preparing state: render a `CircularProgressIndicator` overlay around the play/pause button.
+    - Chapter-nav button labels (`Jn 4`) drawn with `Modifier.alpha(if (target != null) 1f else 0f)` — invisible-not-gone, layout doesn't reflow at Bible boundaries.
+    - Haptics: `LocalHapticFeedback.current.performHapticFeedback(HapticFeedbackType.LongPress)` on speed change, `HapticFeedbackType.TextHandleMove` on play/pause.
+- [ ] `audio/ui/AudioBarExpanded.kt` — expanded state matching PRD §4.2.2:
+    - Big chapter art (square, 240dp) — for v1, the app icon over a tinted background.
+    - Title row (`John 3 · KJV`) in `MaterialTheme.typography.headlineSmall`.
+    - Same scrubber, larger transport row, speed + verse counter chips.
+    - **"Up next" `LazyColumn`** of upcoming verses' first 80 chars; tap to seek.
+- [ ] `audio/ui/SpeedBottomSheet.kt` — `ModalBottomSheet` with a `FilterChip` row for `0.5×, 0.8×, 1.0×, 1.25×, 1.5×, 1.75×, 2.0×`. Single-selection. Persisted via `Prefkey.audioPlaybackSpeed`.
+- [ ] `audio/ui/AudioHighlightColor.kt` — pure-function logic:
+    ```kotlin
+    fun pickHighlightColor(readingBackground: Int, verseTextColor: Int): Int {
+        val yellow = Color.argb(0x33, 0xFF, 0xEB, 0x3B)  // 20% alpha, Material Yellow 500
+        val onBackground = ColorUtils.compositeColors(yellow, readingBackground)
+        val contrast = ColorUtils.calculateContrast(verseTextColor, onBackground)
+        if (contrast >= 4.5) return yellow
+        // Fallback: pick black or white at 20% alpha, whichever scores better on the reading background
+        val blackOverlay = Color.argb(0x33, 0, 0, 0)
+        val whiteOverlay = Color.argb(0x33, 0xFF, 0xFF, 0xFF)
+        val blackContrast = ColorUtils.calculateContrast(verseTextColor, ColorUtils.compositeColors(blackOverlay, readingBackground))
+        val whiteContrast = ColorUtils.calculateContrast(verseTextColor, ColorUtils.compositeColors(whiteOverlay, readingBackground))
+        return if (blackContrast >= whiteContrast) blackOverlay else whiteOverlay
+    }
+    ```
+    Unit-tested.
+
+#### 3.3 Verse highlight (still XML / View-based, since `VerseItem` is)
+
+- [ ] `VerseItem.kt`: add `var audioHighlightColor: Int = 0` (0 = no highlight). The `onDraw` overlay paints a rounded rect of that color, alpha-animated in (200ms) and out (150ms) via a `ValueAnimator`. `0` clears.
+- [ ] `VersesController.kt` / `VersesControllerImpl.kt`: add `fun setAudioHighlight(verse_1: Int, color: Int)`. The color is computed once via `pickHighlightColor(...)` using `VersesView.background` and `?attr/textColor*` and cached on the controller until the theme changes.
+- [ ] On each `PlaybackState.verse_1` change, the controller calls `setAudioHighlight` on the active split's `VersesController` **and** smooth-scrolls the highlighted verse into the upper-third of the viewport using a `LinearSmoothScroller` with `getVerticalSnapPreference() = SNAP_TO_START` and `calculateDtToFit` returning `viewportHeight * 0.33`.
+
+#### 3.4 Toolbar icon
+
+- [ ] Menu item in `res/menu/activity_isi.xml`: `<item android:id="@+id/menuAudio" app:showAsAction="always" android:icon="@drawable/ic_audio" android:title="@string/menu_audio" />`. Matches `menuSearch`'s `always` treatment — never spills into overflow. Wire into `IsiActivity.buildMenu` / `onOptionsItemSelected` (see `IsiActivity.kt:1368-1399`).
+- [ ] Visibility — observe the catalog. Set `menuItem.isVisible = repo.isAudioAvailable(visibleVersionId0) || repo.isAudioAvailable(visibleVersionId1)`. Refresh on active-version change and on split-view enter/exit. Hiding (not disabling) is intentional — a permanently-greyed icon is more confusing than no icon.
+- [ ] Preparing-state spinner: clone the Kidung pattern (`SongViewActivity.kt:178, 443-449, 1088-1090`). Add a `circular_progress` view to the toolbar layout in `activity_isi.xml`, initially `GONE`. In `onPrepareOptionsMenu`, when `audioBarController.isPreparing`, set `menuAudio.isVisible = false` and `circular_progress.visibility = VISIBLE`; otherwise the inverse. Trigger `invalidateOptionsMenu()` from the state collector whenever `preparing` flips.
+
+#### 3.5 Tests
+
+- [ ] `AudioHighlightColorTest` — pure-function unit tests covering yellow/black/white selection across light, sepia, and dark reading backgrounds. Assert ≥4.5 contrast.
+- [ ] Compose preview functions for `AudioBarPeek`, `AudioBarExpanded`, `SpeedBottomSheet` — for visual review in Android Studio. (Previews don't replace device testing but are cheap insurance.)
+- [ ] Instrumented test (`connectedCheck`): open chapter → tap audio → verify the bottom sheet appears in peek state → swipe up via Compose `performTouchInput` → assert the expanded state is rendered.
+
+**Exit criteria:** End-to-end demo of §1–§6 of the PRD's must-haves (screen-on usage); the bottom sheet swipes smoothly between peek and expanded; verse highlight uses yellow on light themes and the contrast-fallback color on dark themes.
 
 ### M4 — Lock-screen & background (≈ 2 days)
 
@@ -119,15 +182,26 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 **Exit criteria:** Run the manual matrix on API 29, 33, 36.
 
-### M5 — Polish (≈ 2 days)
+### M5 — Behavior polish & design review (≈ 2 days)
+
+The visual scaffolding (Compose `BottomSheetScaffold`, Material 3 theming, `AnimatedContent` icon crossfades, smooth verse-scroll, `LocalHapticFeedback`) is already baked into M3. M5 is the behavior polish:
 
 - [ ] Speed persistence: `Prefkey.audioPlaybackSpeed` (enum default `1.0f`). Read on service start, write on each change.
-- [ ] Auto-advance: on `onEnded`, navigate to the next chapter (using the same cross-book logic from PR #124's `getNextOrPreviousChapter`, but centralised — it's useful outside audio too). No repeat toggle in v1.
-- [ ] Scrubber drag-bubble: custom view above the `SeekBar` thumb. On `SeekBar.OnSeekBarChangeListener.onProgressChanged(fromUser=true)`, call `viewModel.previewAtPosition(progressMs)` and render `"${formatMmSs(preview.snappedMs)} · v.${preview.verse_1}"`. On `onStopTrackingTouch`, seek to `preview.snappedMs`. Hide the bubble when not dragging.
-- [ ] Snackbar error handling (§4.6 of PRD).
-- [ ] Split-view source dialog (§4.5 of PRD). On play-tap when split view is active and both visible versions have audio, show a `MaterialAlertDialogBuilder` with the two version short names and a Cancel. The ViewModel holds the chosen `split_0_or_1: Int?` in-memory only; reset to `null` whenever split view toggles, either visible version changes, or the audio bar is closed. Survive config change via `savedStateRegistry`.
+- [ ] Auto-advance: on `onEnded`, navigate to the next chapter. Centralise the cross-book logic in a new `BibleNavigationUtil.kt` (it's useful outside audio too). No repeat toggle in v1.
+- [ ] Snackbar error handling (§4.6 of PRD). Snackbars come from `IsiActivity` (host), not the Compose layer, since they need to overlay the toolbar.
+- [ ] Split-view source dialog (§4.5 of PRD). On play-tap when split view is active and both visible versions have audio, render a Compose `AlertDialog` with the two version short names and a Cancel. The state is held in `AudioBarController` via `MutableStateFlow`; reset to `null` whenever split view toggles, either visible version changes, or the audio bar is closed.
+- [ ] **Design review pass.** Walk the bottom sheet against this checklist before tagging M5 done:
+    - Peek-to-expanded swipe is smooth on a low-end device (Pixel 4a / API 30 emulator OK).
+    - Highlight overlay fades, doesn't strobe, at 1.0× speed.
+    - Play/pause icon crossfades (no swap).
+    - Toolbar icon crossfades into the spinner (no swap).
+    - Auto-scroll feels like "the page is following me," not jumping.
+    - Dark mode renders without any baked-in light-theme color leaking through (compare side-by-side against `IsiActivity` reading mode); yellow highlight falls back to the contrast-corrected color when needed.
+    - Up-Next list scrolls in tandem with playback (active row stays visible).
+    - Haptics fire on play/pause toggle and speed change.
+    - All text is in `strings.xml` and translates correctly (test with `in` locale).
 
-**Exit criteria:** PRD §2 must-have + should-have items are all testable on a device.
+**Exit criteria:** PRD §2 must-have + should-have items are all testable on a device, and the design-review checklist passes one full sweep on at least one physical device in both light and dark modes.
 
 ### M6 — Pre-download (v2, deferred)
 

--- a/docs/features/audio-bible/prd.md
+++ b/docs/features/audio-bible/prd.md
@@ -58,28 +58,81 @@ A new "Audio" icon in the `IsiActivity` toolbar (`activity_isi.xml`, `app:showAs
 
 **Preparing state.** The moment the user taps Audio, the work that runs before the first byte of audio plays — catalog lookup (cache), timing fetch if not already cached, ExoPlayer `prepare()` + initial buffer — can take a perceptible fraction of a second on mobile networks. During this window the toolbar icon morphs into an indeterminate spinner, mirroring the Kidung (Songs) play button's behavior: while `MediaController.State == preparing`, `SongViewActivity` hides the play menu item and swaps in an indeterminate `circular_progress` view (`SongViewActivity.kt:178, 443-449, 1088-1090`). We use the exact same pattern — `onPrepareOptionsMenu` hides `R.id.menuAudio` and shows a sibling progress view anchored in the toolbar — so the UX is consistent with the rest of the app. The spinner reverts to the Audio icon when the service reports `ready` (or `error`, in which case the snackbar in §4.6 fires). Tapping during the preparing window is a no-op; a second tap does **not** cancel (that would require tearing down the service mid-prepare and feels unpredictable).
 
-### 4.2 Audio bar (bottom sheet)
+### 4.2 Audio bar — Compose `BottomSheetScaffold`
 
-Anchored at the bottom of `IsiActivity`, above the reading-history panel. Height ≈ 72dp. Contents left-to-right:
+Anchored at the bottom of `IsiActivity`, hosted in a `ComposeView`. Implemented in **Jetpack Compose 1.11.0** (the first piece of Compose in the codebase; we will progressively migrate `IsiActivity` to Compose, with the audio bar as the beachhead). The bar is a Material 3 `BottomSheetScaffold` with two states: a **peek** (collapsed) row and a **fully-expanded mini-player**. The user reaches the expanded form by swiping up on the peek row or by tapping its drag handle.
+
+#### 4.2.1 Peek (collapsed) state — height ≈ 96dp
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
+│                          ── (drag handle) ──                      │
 │  ⏮ Jn 2   ⏮   ▶/⏸ (+progress ring)   ⏭   Jn 4 ⏭   1.0×   ╳       │
-├──────────────────────────────────────────────────────────────────┤
 │  ▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒░░░░░░░░   0:42 / 3:15                           │
 └──────────────────────────────────────────────────────────────────┘
 ```
 
-- **Play/pause** — center; shows a spinner while preparing.
-- **Prev / next verse** — plain icon-only buttons that seek to the start of the neighboring verse using timing data. No label on the button (the active verse is already conveyed by the highlighted row and the scrubber bubble; adding "v.7" to the button is redundant and the label would go blank/grey at chapter boundaries).
-- **Prev / next chapter** — the button shows the target chapter next to its icon (e.g. `⏮ Jn 2` and `Jn 4 ⏭`), using the same `book.shortName` + chapter format that appears in the main toolbar. At cross-book boundaries the next button reads `⏮ Mt 28` from Mark 1, making jumps predictable. At the Bible boundaries (Genesis 1 prev, Revelation 22 next) the button is disabled and the label hidden.
-- **Speed** — opens a popup: 0.5 / 0.8 / 1.0 / 1.25 / 1.5 / 1.75 / 2.0×. Persisted via Prefkey.
-- **Close (╳)** — closes the bar; stops audio and clears highlight.
-- **Scrubber** — drag-to-seek. While the user is dragging, the thumb shows a tooltip/bubble with **both** the proposed position `mm:ss` **and** the verse that would play on release (e.g. `1:23 · v.7`). The bubble updates live as the thumb moves so the user can aim at a verse they remember hearing, not just a time offset. On release, audio seeks to the start of that verse's `startMs` (snapping to verse boundary feels better than snapping to the raw scrubbed millisecond — and matches what the tooltip was showing). If timing data is missing, the bubble falls back to `mm:ss` only and seek is a plain time seek.
+- **Drag handle** — Material 3 standard `BottomSheetDefaults.DragHandle` at the top, communicates "swipeable."
+- **Play/pause** — center; shows a determinate progress ring around the FAB-style button while preparing.
+- **Prev / next verse** — plain icon-only buttons that seek to the start of the neighboring verse using timing data. No label on the button (the active verse is already conveyed by the highlighted row and the scrubber bubble).
+- **Prev / next chapter** — the button shows the target chapter next to its icon (e.g. `⏮ Jn 2` and `Jn 4 ⏭`), using the same `book.shortName` + chapter format that appears in the main toolbar. At cross-book boundaries the next button reads `⏮ Mt 28` from Mark 1. At the Bible boundaries the label slot is `INVISIBLE` (not gone) so the layout doesn't reflow.
+- **Speed** — taps open the speed bottom sheet (§4.2.3).
+- **Close (╳)** — closes the bottom sheet entirely; stops audio and clears highlight.
+- **Scrubber** — Material 3 `Slider`. Drag-to-seek with a live preview label that shows `mm:ss · v.7` while dragging — both the proposed position and the verse that would play on release. On release, audio seeks to the start of that verse's `startMs` (snapping to verse boundary feels better than snapping to a raw millisecond, and matches what the tooltip is showing). If timing data is missing, the label falls back to `mm:ss` only and seek is plain.
+
+#### 4.2.2 Expanded (full) state — sheet height ≈ 60% of screen
+
+Reachable by swiping up on the peek row.
+
+```
+┌────────────────────────────────────────────────┐
+│                  ── (drag handle) ──            │
+│                                                │
+│              ┌─────────────────┐                │
+│              │   chapter art    │   ← square art (book/cover)
+│              │   (book cover    │
+│              │    or app icon)  │
+│              └─────────────────┘                │
+│                                                │
+│     John 3 · KJV                                │
+│                                                │
+│  ▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒░░░░░░░░░   0:42 / 3:15        │
+│                                                │
+│   ⏮ Jn 2     ⏮     ▶/⏸     ⏭     Jn 4 ⏭         │
+│                  (large)                        │
+│                                                │
+│   1.0×    Verse 7 / 36                          │
+│                                                │
+│   ── Up next ──                                 │
+│   v.8  Whosoever drinketh of this water…        │
+│   v.9  Whosoever drinketh of the water that I…  │
+│   …                                             │
+└────────────────────────────────────────────────┘
+```
+
+- **Chapter art** — for v1, the app icon over a tinted background. v1.1 can ship per-book artwork.
+- **Bigger transport** — same controls as the peek row, larger touch targets, more breathing room.
+- **Verse counter** — `Verse 7 / 36` — gives the listener a sense of progress.
+- **"Up next" list** — a scrollable list of the upcoming verses' first 80 chars, inferred from the chapter's text + timing. Tap any row to seek to that verse. Skipped if timing data is missing.
+
+#### 4.2.3 Speed bottom sheet
+
+Tapping `1.0×` (peek or expanded) opens a small Compose `ModalBottomSheet` with a horizontal `FilterChip` row: `0.5×, 0.8×, 1.0×, 1.25×, 1.5×, 1.75×, 2.0×`. Single-selection. Persisted via `Prefkey.audioPlaybackSpeed`. The thumb-friendly bottom-sheet pattern matches what Spotify, YouTube Music, and Audible do for the same control.
 
 ### 4.3 Verse highlight
 
-A semi-transparent blue rectangle overlay on the active verse, drawn in `VerseItem.onDraw` (same pattern used for selection/attention). The `VersesController` exposes `setAudioHighlight(verse_1)` (already prototyped in PR #127). Auto-scroll keeps the highlighted verse in the upper third of the viewport.
+A semi-transparent **yellow highlighter** overlay on the active verse, drawn in `VerseItem.onDraw` (same pattern used for selection/attention). The base color is the same hue family as a physical highlighter pen — concretely `#FFEB3B` (Material Yellow 500) at **20% alpha** by default.
+
+Because the user's reading background can be customised (light, sepia, dark, custom theme), 20%-alpha yellow is not always legible. The drawing layer must therefore **adapt at runtime**:
+
+- Compute the contrast ratio between the yellow overlay (composited onto the reading background) and the verse text color, using `androidx.core.graphics.ColorUtils.calculateContrast`.
+- If contrast ≥ 4.5 (WCAG AA), use the yellow overlay.
+- Otherwise (typically dark backgrounds), fall back to a neutral overlay at 20% alpha — `#000000` on light backgrounds, `#FFFFFF` on dark — choosing whichever produces the better text contrast.
+- The decision is made once per call to `setAudioHighlight`, cached on the `VerseItem` via a small `audioHighlightColor: Int` field, and refreshed when the reading theme changes.
+
+The fade-in / fade-out alpha animation (200ms in, 150ms out) prevents strobe at speed 1.0×. Auto-scroll uses a `LinearSmoothScroller` to keep the highlighted verse in the upper third of the viewport (PR #127's instant `scrollToVerse` jumps too aggressively).
+
+The `VersesController` exposes `setAudioHighlight(verse_1)`. `verse_1 = 0` clears.
 
 ### 4.4 Lock screen & notification
 
@@ -193,6 +246,21 @@ data class ChapterTiming(
 
 `MAudio` from PR #124 (`audio1..audio5`) is rejected — the slot-numbered fields don't map onto anything meaningful. `MAudio` from PR #127 is close to this but pins the sabda folder name in the client; we keep the shape and push the folder-name responsibility to the backend.
 
+### 5.4.1 Internal-version mapping (per flavor)
+
+The bundled internal version reports `MVersion.getVersionId() == "internal"` (see [MVersionInternal.java](../../../Alkitab/src/main/java/yuku/alkitab/base/model/MVersionInternal.java)) — that string never matches a `preset/*` row in the catalog, so a user reading the internal version on, say, the `yuku_alkitab` build would see no audio icon at all.
+
+To bridge this, each product flavor declares **`BuildConfig.INTERNAL_VERSION_AUDIO_ID`** in [Alkitab/build.gradle.kts](../../../Alkitab/build.gradle.kts), naming the catalog row that the internal version should resolve to:
+
+| Flavor | Internal version content | `INTERNAL_VERSION_AUDIO_ID` |
+|---|---|---|
+| `plain` (open-source dev build) | placeholder Indonesian (`ddd_*`) | `preset/in-tb` (so dev builds can play audio) |
+| `yuku_alkitab` | TB | `preset/in-tb` |
+| `yuku_quick_bible` | KJV | `preset/en-kjv` |
+| `sabda_alkitab` | TB | `preset/in-tb` |
+
+`AudioCatalogRepository.findEntry(versionId)` performs the substitution before lookup: when `versionId == "internal"`, it looks up `BuildConfig.INTERNAL_VERSION_AUDIO_ID` instead. Empty value = the flavor has no audio for its internal version (toolbar icon stays hidden). Adding a new flavor that doesn't set the override gets the empty default.
+
 ### 5.5 Persistence
 
 - `AudioCatalog` cached at `files/audio_catalog.json` with ETag stored in `Prefkey`.
@@ -212,7 +280,7 @@ This replaces the "dual-audio interleaved" mode from both PRs. Reason: neither P
 
 ### 5.7 Module placement
 
-New Kotlin files live under `Alkitab/src/main/java/yuku/alkitab/base/audio/`:
+New Kotlin files live under `Alkitab/src/main/java/yuku/alkitab/base/audio/`. The UI layer is **Jetpack Compose** (the audio bar is the project's first Compose surface; future migration of `IsiActivity` will follow this beachhead).
 
 ```
 audio/
@@ -220,26 +288,51 @@ audio/
 ├─ AudioCatalogRepository.kt
 ├─ BibleAudioRepository.kt
 ├─ BibleAudioPlayer.kt
-├─ BibleAudioService.kt        ← MediaSessionService
-├─ AudioBarView.kt / .xml
-├─ AudioBarViewModel.kt
+├─ BibleAudioService.kt        ← media3 MediaSessionService
 ├─ HighlightTracker.kt
+├─ ui/
+│  ├─ AudioBottomSheet.kt      ← Compose @Composable hosting BottomSheetScaffold
+│  ├─ AudioBarPeek.kt          ← Compose: peek state row
+│  ├─ AudioBarExpanded.kt      ← Compose: expanded mini-player
+│  ├─ SpeedBottomSheet.kt      ← Compose: ModalBottomSheet with FilterChip row
+│  ├─ AudioTheme.kt            ← Compose MaterialTheme bridged from app's ?attr/colorSurface*
+│  └─ AudioHighlightColor.kt   ← yellow / fallback contrast logic
+├─ AudioBarController.kt       ← Kotlin glue between IsiActivity (View) and Compose UI; holds StateFlow<UiState>
 └─ model/
    ├─ AudioVersion.kt
    ├─ VerseTiming.kt
    └─ ChapterTiming.kt
 ```
 
+Hosting in `IsiActivity`:
+
+```xml
+<!-- res/layout/activity_isi.xml — at the bottom of the root container -->
+<androidx.compose.ui.platform.ComposeView
+    android:id="@+id/audio_bottom_sheet"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom" />
+```
+
 Reuse: `Connections.okHttp` for HTTP, `BuildConfig.SERVER_HOST` for the base URL, existing `S`, `App`, `AppLog`. We deliberately do **not** reuse `yuku.alkitab.songs.ExoplayerController` (PR #124's approach) — the songs controller carries song-specific behavior (inline MaterialDialog error UI, loop-centric state machine, `MediaController.State` enum oriented at short clips) that pushes the bible-audio case into awkward shapes. We do borrow its pattern (OkHttp data source, MP3-only extractor factory) verbatim.
 
 ### 5.8 Library choices
 
-- **media3 ExoPlayer** — already a dependency (`androidx.media3:media3-exoplayer`, via `ExoplayerController.kt:8-17`). Keep.
-- **media3 session** — add `androidx.media3:media3-session` (`MediaSessionService`, notification provider).
+- **media3 ExoPlayer** — already a dependency (`androidx.media3:media3-exoplayer:1.8.0`, via `ExoplayerController.kt:8-17`). Keep.
+- **media3 session** — add `androidx.media3:media3-session:1.8.0` (`MediaSessionService`, notification provider).
+- **Jetpack Compose 1.11.0** — new dependency family (this feature is the project's first Compose surface):
+    - `androidx.compose.ui:ui:1.11.0`
+    - `androidx.compose.material3:material3` (paired version that ships with Compose 1.11)
+    - `androidx.compose.foundation:foundation:1.11.0`
+    - `androidx.compose.runtime:runtime:1.11.0`
+    - `androidx.compose.ui:ui-tooling-preview:1.11.0`
+    - `androidx.activity:activity-compose:1.11.0` (already-aligned with project's `androidx.activity:activity-ktx:1.11.0`)
+    - Kotlin Compose Compiler plugin (`org.jetbrains.kotlin.plugin.compose`, version-aligned with the project's Kotlin 2.2.0).
 - **Kotlin coroutines + Flow** — already a project convention.
 - **OkHttp** — already used.
 
-No new heavyweight dependencies.
+Compose adds ~2 MB to the APK. We accept this once, since the audio bar is the migration beachhead and future Compose work amortises the cost.
 
 ## 6. Privacy, security, licensing
 
@@ -273,7 +366,13 @@ PR #124 is not the better starting point — its reuse of `ExoplayerController` 
 
 ## 10. References
 
-- PR #127 implementation files: `Alkitab/src/main/java/yuku/alkitab/base/audio/*.kt`, [pull/127/head](https://github.com/yukuku/androidbible/pull/127/files).
+- PR #127 implementation files (split across packages — keep this in mind when porting):
+    - `Alkitab/src/main/java/yuku/alkitab/base/audio/{BibleAudioPlayer,AudioPlaybackController}.kt`
+    - `Alkitab/src/main/java/yuku/alkitab/base/util/BibleAudioRepository.kt` (will move to `base/audio/` and shrink — the SABDA tables go to the backend; see [backend-plan.md §4.3](backend-plan.md))
+    - `Alkitab/src/main/java/yuku/alkitab/base/model/{MAudio,MTiming}.kt`
+    - `Alkitab/src/main/java/yuku/alkitab/base/verses/{VerseItem,VersesController,VersesControllerImpl}.kt` (highlight diff)
+    - Resources: `res/drawable/ic_audio_*.xml`, `res/layout/activity_audio.xml`, `res/menu/activity_isi.xml`
+    - Full diff: [pull/127/head](https://github.com/yukuku/androidbible/pull/127/files)
 - PR #124 implementation files: `Alkitab/src/main/java/yuku/alkitab/base/util/{Audio,Bible,Timing,MediaList}*`, [pull/124/head](https://github.com/yukuku/androidbible/pull/124/files).
 - Existing song-audio design: `docs/modules/audio-playback.md`, `Alkitab/src/main/java/yuku/alkitab/songs/ExoplayerController.kt:33-194`.
 - Verses/highlighting surface: `Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt`, `VerseItem.kt`.

--- a/docs/features/audio-bible/prd.md
+++ b/docs/features/audio-bible/prd.md
@@ -58,66 +58,29 @@ A new "Audio" icon in the `IsiActivity` toolbar (`activity_isi.xml`, `app:showAs
 
 **Preparing state.** The moment the user taps Audio, the work that runs before the first byte of audio plays — catalog lookup (cache), timing fetch if not already cached, ExoPlayer `prepare()` + initial buffer — can take a perceptible fraction of a second on mobile networks. During this window the toolbar icon morphs into an indeterminate spinner, mirroring the Kidung (Songs) play button's behavior: while `MediaController.State == preparing`, `SongViewActivity` hides the play menu item and swaps in an indeterminate `circular_progress` view (`SongViewActivity.kt:178, 443-449, 1088-1090`). We use the exact same pattern — `onPrepareOptionsMenu` hides `R.id.menuAudio` and shows a sibling progress view anchored in the toolbar — so the UX is consistent with the rest of the app. The spinner reverts to the Audio icon when the service reports `ready` (or `error`, in which case the snackbar in §4.6 fires). Tapping during the preparing window is a no-op; a second tap does **not** cancel (that would require tearing down the service mid-prepare and feels unpredictable).
 
-### 4.2 Audio bar — Compose `BottomSheetScaffold`
+### 4.2 Audio bar — fixed-height Compose surface
 
-Anchored at the bottom of `IsiActivity`, hosted in a `ComposeView`. Implemented in **Jetpack Compose 1.11.0** (the first piece of Compose in the codebase; we will progressively migrate `IsiActivity` to Compose, with the audio bar as the beachhead). The bar is a Material 3 `BottomSheetScaffold` with two states: a **peek** (collapsed) row and a **fully-expanded mini-player**. The user reaches the expanded form by swiping up on the peek row or by tapping its drag handle.
+Anchored at the bottom of `IsiActivity`, hosted in a `ComposeView`. Implemented in **Jetpack Compose 1.11.0** (the first piece of Compose in the codebase; we will progressively migrate `IsiActivity` to Compose, with the audio bar as the beachhead). The bar is a **fixed-height Material 3 surface** — no peek/expand mechanic, no drag handle, no swipe.
 
-#### 4.2.1 Peek (collapsed) state — height ≈ 96dp
+Height ≈ 96dp:
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│                          ── (drag handle) ──                      │
 │  ⏮ Jn 2   ⏮   ▶/⏸ (+progress ring)   ⏭   Jn 4 ⏭   1.0×   ╳       │
 │  ▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒░░░░░░░░   0:42 / 3:15                           │
 └──────────────────────────────────────────────────────────────────┘
 ```
 
-- **Drag handle** — Material 3 standard `BottomSheetDefaults.DragHandle` at the top, communicates "swipeable."
 - **Play/pause** — center; shows a determinate progress ring around the FAB-style button while preparing.
 - **Prev / next verse** — plain icon-only buttons that seek to the start of the neighboring verse using timing data. No label on the button (the active verse is already conveyed by the highlighted row and the scrubber bubble).
 - **Prev / next chapter** — the button shows the target chapter next to its icon (e.g. `⏮ Jn 2` and `Jn 4 ⏭`), using the same `book.shortName` + chapter format that appears in the main toolbar. At cross-book boundaries the next button reads `⏮ Mt 28` from Mark 1. At the Bible boundaries the label slot is `INVISIBLE` (not gone) so the layout doesn't reflow.
-- **Speed** — taps open the speed bottom sheet (§4.2.3).
-- **Close (╳)** — closes the bottom sheet entirely; stops audio and clears highlight.
+- **Speed** — taps open the speed bottom sheet (§4.2.2).
+- **Close (╳)** — hides the bar; stops audio and clears highlight.
 - **Scrubber** — Material 3 `Slider`. Drag-to-seek with a live preview label that shows `mm:ss · v.7` while dragging — both the proposed position and the verse that would play on release. On release, audio seeks to the start of that verse's `startMs` (snapping to verse boundary feels better than snapping to a raw millisecond, and matches what the tooltip is showing). If timing data is missing, the label falls back to `mm:ss` only and seek is plain.
 
-#### 4.2.2 Expanded (full) state — sheet height ≈ 60% of screen
+#### 4.2.2 Speed bottom sheet
 
-Reachable by swiping up on the peek row.
-
-```
-┌────────────────────────────────────────────────┐
-│                  ── (drag handle) ──            │
-│                                                │
-│              ┌─────────────────┐                │
-│              │   chapter art    │   ← square art (book/cover)
-│              │   (book cover    │
-│              │    or app icon)  │
-│              └─────────────────┘                │
-│                                                │
-│     John 3 · KJV                                │
-│                                                │
-│  ▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒░░░░░░░░░   0:42 / 3:15        │
-│                                                │
-│   ⏮ Jn 2     ⏮     ▶/⏸     ⏭     Jn 4 ⏭         │
-│                  (large)                        │
-│                                                │
-│   1.0×    Verse 7 / 36                          │
-│                                                │
-│   ── Up next ──                                 │
-│   v.8  Whosoever drinketh of this water…        │
-│   v.9  Whosoever drinketh of the water that I…  │
-│   …                                             │
-└────────────────────────────────────────────────┘
-```
-
-- **Chapter art** — for v1, the app icon over a tinted background. v1.1 can ship per-book artwork.
-- **Bigger transport** — same controls as the peek row, larger touch targets, more breathing room.
-- **Verse counter** — `Verse 7 / 36` — gives the listener a sense of progress.
-- **"Up next" list** — a scrollable list of the upcoming verses' first 80 chars, inferred from the chapter's text + timing. Tap any row to seek to that verse. Skipped if timing data is missing.
-
-#### 4.2.3 Speed bottom sheet
-
-Tapping `1.0×` (peek or expanded) opens a small Compose `ModalBottomSheet` with a horizontal `FilterChip` row: `0.5×, 0.8×, 1.0×, 1.25×, 1.5×, 1.75×, 2.0×`. Single-selection. Persisted via `Prefkey.audioPlaybackSpeed`. The thumb-friendly bottom-sheet pattern matches what Spotify, YouTube Music, and Audible do for the same control.
+Tapping `1.0×` opens a small Compose `ModalBottomSheet` with a horizontal `FilterChip` row: `0.5×, 0.8×, 1.0×, 1.25×, 1.5×, 1.75×, 2.0×`. Single-selection. Persisted via `Prefkey.audioPlaybackSpeed`. The thumb-friendly bottom-sheet pattern matches what Spotify, YouTube Music, and Audible do for the same control.
 
 ### 4.3 Verse highlight
 
@@ -154,7 +117,7 @@ This deliberately replaces PR #127's sequential interleaving (which plays verse 
 - **Version has no audio:** toolbar icon is hidden.
 - **Network failure on chapter load:** snackbar "Cannot load audio. Retry?" with a Retry action. Audio bar stays open, play button disabled.
 - **Timing data missing:** audio plays, but verse-skip buttons and verse highlight are disabled (greyed). No error shown.
-- **Audio URL 404 (e.g. deuterocanonical chapter):** snackbar "Audio not available for this chapter," and the bar auto-closes after 3s.
+- **Audio URL 404 (e.g. an upstream gap in coverage):** snackbar "Audio not available for this chapter," and the bar auto-closes after 3s.
 
 ## 5. Architecture
 
@@ -221,11 +184,10 @@ data class AudioCatalog(
 
 data class AudioVersion(
     val versionId: String,            // matches MVersion.getVersionId(), e.g. "preset/in-tb"
+    val shortName: String,            // for display when needed (e.g. split-source picker)
     val displayLocaleHint: String?,   // for ordering when user has no active version
     val chapterUrlTemplate: String,   // e.g. "/audio/chapter?versionId=preset%2Fin-tb&bookId={bookId}&chapter_1={chapter_1}"
     val timingUrlTemplate: String?,   // nullable: some versions have audio but no timing
-    val copyrightNotice: String?,
-    val license: String?,             // e.g. "Public Domain", "SABDA"
 )
 
 data class VerseTiming(
@@ -291,9 +253,7 @@ audio/
 ├─ BibleAudioService.kt        ← media3 MediaSessionService
 ├─ HighlightTracker.kt
 ├─ ui/
-│  ├─ AudioBottomSheet.kt      ← Compose @Composable hosting BottomSheetScaffold
-│  ├─ AudioBarPeek.kt          ← Compose: peek state row
-│  ├─ AudioBarExpanded.kt      ← Compose: expanded mini-player
+│  ├─ AudioBar.kt              ← Compose @Composable: the fixed-height bar from §4.2
 │  ├─ SpeedBottomSheet.kt      ← Compose: ModalBottomSheet with FilterChip row
 │  ├─ AudioTheme.kt            ← Compose MaterialTheme bridged from app's ?attr/colorSurface*
 │  └─ AudioHighlightColor.kt   ← yellow / fallback contrast logic
@@ -309,7 +269,7 @@ Hosting in `IsiActivity`:
 ```xml
 <!-- res/layout/activity_isi.xml — at the bottom of the root container -->
 <androidx.compose.ui.platform.ComposeView
-    android:id="@+id/audio_bottom_sheet"
+    android:id="@+id/audio_bar"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="bottom" />
@@ -336,7 +296,7 @@ Compose adds ~2 MB to the APK. We accept this once, since the audio bar is the m
 
 ## 6. Privacy, security, licensing
 
-- Audio and timing data are served by `api.alkitab.app`, which may 302 to sabda.org or a CDN. The backend carries the licensing responsibility; the client displays the catalog's `copyrightNotice` and `license` strings in the audio bar's overflow menu ("About this audio").
+- Audio and timing data are served by `api.alkitab.app`, which may 302 to sabda.org or a CDN. The backend carries the licensing responsibility — there is no per-version attribution surface in the client UI for v1.
 - No new user data collected beyond existing analytics. Playback events are **not** logged off-device in v1.
 - No microphone / no audio capture.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,13 @@ kotlinxSerializationJson = "1.5.1"
 # UI
 fancyShowcaseView = "1.4.0"
 
+# Jetpack Compose — first Compose surface in this project, introduced for the
+# audio-bible bottom sheet (docs/features/audio-bible/). compose-ui 1.11.0
+# pairs with compose-material3 1.4.0 per the Compose BOM 2026.04.01. When
+# upgrading, look up the current BOM and bump both numbers together.
+androidxComposeUi = "1.11.0"
+androidxComposeMaterial3 = "1.4.0"
+
 [libraries]
 # AndroidX
 androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "androidxActivity" }
@@ -61,6 +68,7 @@ androidx-fragment = { group = "androidx.fragment", name = "fragment", version.re
 androidx-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidxFragment" }
 androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "androidxMedia3" }
 androidx-media3-datasource-okhttp = { group = "androidx.media3", name = "media3-datasource-okhttp", version.ref = "androidxMedia3" }
+androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "androidxMedia3" }
 androidx-multidex = { group = "androidx.multidex", name = "multidex", version.ref = "androidxMultidex" }
 androidx-percentlayout = { group = "androidx.percentlayout", name = "percentlayout", version.ref = "androidxPercentlayout" }
 androidx-preference = { group = "androidx.preference", name = "preference", version.ref = "androidxPreference" }
@@ -97,11 +105,21 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 # UI
 fancyShowcaseView = { group = "com.github.faruktoptas", name = "FancyShowCaseView", version.ref = "fancyShowcaseView" }
 
+# Jetpack Compose
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "androidxComposeUi" }
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "androidxComposeUi" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "androidxComposeUi" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "androidxComposeMaterial3" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "androidxComposeUi" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "androidxComposeUi" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebase-crashlytics-gradle = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsGradle" }


### PR DESCRIPTION
## Summary

First milestone of the **Bible audio playback** feature. Adds the design docs and the catalog data layer; the player, foreground service, and Compose UI follow in subsequent PRs.

### Docs (commit 1)

`docs/features/audio-bible/`:
- **prd.md** — UX (Compose `BottomSheetScaffold` peek + expanded mini-player), highlight color (yellow with adaptive contrast fallback), split-view single-source decision, error states.
- **client-plan.md** — milestone breakdown M1–M5, integration points, test strategy.
- **backend-plan.md** — endpoint specs (`/audio/catalog`, `/audio/timing`, `/audio/chapter`), grounded against the actual `alkitab-host` stack (Flask on App Engine Standard, NDB Datastore, `web/cache.py` LRU; **no** dispatch.yaml change needed because the existing `*/*` catch-all routes `/audio/*` to `web-py3`). Negative-cache TTL = 1 day, no pre-warm.

### Code (commit 2 — M1)

**Dependencies**
- `androidx.media3:media3-session:1.8.0` (paired with the existing media3-exoplayer dep).
- Jetpack Compose 1.11 + Material 3 1.4 + `activity-compose`, plus the `org.jetbrains.kotlin.plugin.compose` Kotlin plugin. compose-ui 1.11 pairs with material3 1.4 per Compose BOM 2026.04.01. No Compose call sites yet — the plugin and runtime are ready for M3.

**`yuku.alkitab.base.audio` package**
- `model/AudioCatalog`, `AudioVersion`, `ChapterTiming`, `VerseTiming` — kotlinx-serialization data classes mirroring the backend response shapes.
- `AudioCatalogRepository`:
    - In-memory cache → on-disk override at `files/audio_catalog.json` → bundled fallback at `assets/audio_catalog.json`. `loadCatalog()` never throws.
    - `refresh()` issues a conditional `GET /audio/catalog` with `If-None-Match`, persists 200 bodies, leaves override on 304/error. Sync bridge `refreshBlocking()` for the existing Java IntentService.
    - `findEntry()` / `isAudioAvailable()` rewrite the literal `"internal"` versionId to the flavor-specific catalog row via a new `BuildConfig.INTERNAL_VERSION_AUDIO_ID` field — `preset/in-tb` for `plain` / `yuku_alkitab` / `sabda_alkitab`, `preset/en-kjv` for `yuku_quick_bible`. This lets users on the bundled internal version see the audio toolbar icon.

**Hooks**
- `Prefkey.audioCatalog_etag`, `Prefkey.audioPlaybackSpeed`.
- `VersionConfigUpdaterService` now refreshes the audio catalog on the same worker, so we don't spawn a separate background service.
- `Alkitab/src/main/assets/audio_catalog.json` ships with the four SABDA versions (TB, AYT, AVB, KJV) so the feature works end-to-end even before the backend is deployed.

## Verification

- `./gradlew assemblePlainDebug` — green
- `./gradlew testPlainDebugUnitTest --tests "yuku.alkitab.base.audio.*"` — 8/8 pass (catalog parsing, override precedence, malformed-override fallback, internal→preset mapping, preset pass-through, isAudioAvailable, findEntry)
- `./gradlew testPlainReleaseUnitTest` — green
- `grep -rn sabda Alkitab/src/main/java/yuku/alkitab/base/audio` — 0 hits (all SABDA-specific URL building is the backend's responsibility)

## Test plan

- [ ] `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` — green on CI
- [ ] `./gradlew assemblePlainDebug` — green on CI
- [ ] Spot-check that no other existing test or build target regresses
- [ ] Confirm `Alkitab/src/main/assets/audio_catalog.json` is bundled in the APK (sanity check via `unzip -l <apk> | grep audio_catalog`)

## Related

- Closes (will close, with this stack landing): #124
- Supersedes (will close, with this stack landing): #127