### PR TITLE
audio-bible M2: player + foreground service

### DIFF
--- a/Alkitab/src/main/AndroidManifest.xml
+++ b/Alkitab/src/main/AndroidManifest.xml
@@ -5,6 +5,10 @@
 
 	<uses-permission android:name="android.permission.INTERNET" />
 
+	<!-- Foreground service for Bible audio playback (yuku.alkitab.base.audio.BibleAudioService) -->
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
 	<!-- Keeping storage permissions for users who upgrade from an existing versions
 	and store their version files in the external storage -->
 	<uses-permission
@@ -385,6 +389,17 @@
 		<service
 			android:name="yuku.alkitab.base.sv.VersionConfigUpdaterService"
 			android:exported="false" />
+
+		<!-- Bible audio: media3 MediaSessionService. exported=true is required so
+			 the OS (notification, lock-screen, Bluetooth, Android Auto) can bind. -->
+		<service
+			android:name="yuku.alkitab.base.audio.BibleAudioService"
+			android:exported="true"
+			android:foregroundServiceType="mediaPlayback">
+			<intent-filter>
+				<action android:name="androidx.media3.session.MediaSessionService" />
+			</intent-filter>
+		</service>
 
 		<!--
 			File provider, for sharing app files.

--- a/Alkitab/src/main/java/yuku/alkitab/base/App.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/App.java
@@ -2,6 +2,7 @@ package yuku.alkitab.base;
 
 import android.content.Context;
 import android.net.Uri;
+import androidx.core.app.NotificationChannelCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.multidex.MultiDex;
 import androidx.preference.PreferenceManager;
@@ -82,6 +83,20 @@ public class App extends yuku.afw.App {
         notificationManager.deleteNotificationChannel("devotion_downloader");
         notificationManager.deleteNotificationChannel("download_mapper");
         notificationManager.deleteNotificationChannel("devotion_reminder");
+
+        // Bible audio playback channel — created here so that media3's
+        // DefaultMediaNotificationProvider posts onto a low-importance,
+        // silent channel rather than the default high-importance one.
+        // Channel attributes (importance, sound, vibration) are immutable
+        // after first creation, so creating it ourselves up-front is the
+        // only way to control them.
+        notificationManager.createNotificationChannel(
+            new NotificationChannelCompat.Builder("audio_bible", NotificationManagerCompat.IMPORTANCE_LOW)
+                .setName(context.getString(R.string.audio_bible_notification_channel_name))
+                .setVibrationEnabled(false)
+                .setSound(null, null)
+                .build()
+        );
     }
 
     public static Gson getDefaultGson() {

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioPlayer.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioPlayer.kt
@@ -1,0 +1,179 @@
+package yuku.alkitab.base.audio
+
+import android.content.Context
+import androidx.annotation.MainThread
+import androidx.annotation.OptIn
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.Renderer
+import androidx.media3.exoplayer.RenderersFactory
+import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
+import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.extractor.Extractor
+import androidx.media3.extractor.ExtractorsFactory
+import androidx.media3.extractor.mp3.Mp3Extractor
+import yuku.alkitab.base.connection.Connections
+
+/**
+ * Single-responsibility wrapper around media3 [ExoPlayer] for Bible chapter audio.
+ *
+ * Responsibilities:
+ *  - Build an audio-only ExoPlayer that fetches over [Connections.okHttp] (for
+ *    user-agent + 50 MB disk cache) and decodes MP3 only (we never serve other
+ *    formats from the audio backend).
+ *  - Forward state transitions to a [Listener]: [Listener.onReady] when the
+ *    chapter is buffered enough to play, [Listener.onEnded] when playback hits
+ *    the end of the stream, [Listener.onError] on any [PlaybackException].
+ *
+ * Out of scope:
+ *  - Foreground-service / MediaSession lifecycle — owned by [BibleAudioService].
+ *  - Highlight / verse tracking — owned by [HighlightTracker].
+ *  - Audio focus / becoming-noisy — handled inside this class via
+ *    [ExoPlayer.Builder.setAudioAttributes] +
+ *    [ExoPlayer.Builder.setHandleAudioBecomingNoisy] (built-in media3 behavior).
+ *
+ * Threading: every public method must be called on the main thread; this is the
+ * same constraint media3 itself imposes on [Player]. The internal listener also
+ * dispatches to the main thread because that's where ExoPlayer lives.
+ *
+ * Mirrors [yuku.alkitab.songs.ExoplayerController]'s data-source / renderer
+ * configuration (audio-only renderer, MP3-only extractor, OkHttp-backed
+ * data-source) but does not extend it — songs and bible audio have different
+ * state machines and different error UX.
+ */
+@OptIn(UnstableApi::class)
+class BibleAudioPlayer(appContext: Context) {
+
+    interface Listener {
+        /** Player has buffered enough to start playback. */
+        fun onReady()
+
+        /** Player reached the end of the chapter (natural end, not pause). */
+        fun onEnded()
+
+        /** Player hit a fatal error; the underlying player is now in an error state. */
+        fun onError(error: PlaybackException)
+    }
+
+    private var listener: Listener? = null
+
+    private val playerListener = object : Player.Listener {
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            when (playbackState) {
+                Player.STATE_READY -> listener?.onReady()
+                Player.STATE_ENDED -> listener?.onEnded()
+                else -> Unit
+            }
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            listener?.onError(error)
+        }
+    }
+
+    val exoPlayer: ExoPlayer = run {
+        val audioOnlyRenderersFactory = RenderersFactory { eventHandler, videoRendererEventListener, audioRendererEventListener, _, _ ->
+            arrayOf<Renderer>(
+                MediaCodecAudioRenderer(
+                    appContext,
+                    MediaCodecSelector.DEFAULT,
+                    eventHandler,
+                    audioRendererEventListener,
+                )
+            )
+        }
+        val mp3ExtractorFactory = ExtractorsFactory {
+            arrayOf<Extractor>(Mp3Extractor())
+        }
+        val okHttpDataSourceFactory = OkHttpDataSource.Factory(Connections.okHttp)
+            .setUserAgent(Connections.httpUserAgent)
+
+        // USAGE_MEDIA + CONTENT_TYPE_SPEECH gives the right ducking behavior for
+        // spoken-word audio (other apps' notifications duck us politely; calls
+        // pause us). `handleAudioFocus = true` flips on media3's built-in focus
+        // request — pause on transient loss, duck on can-duck, resume on regain.
+        val audioAttributes = AudioAttributes.Builder()
+            .setUsage(C.USAGE_MEDIA)
+            .setContentType(C.AUDIO_CONTENT_TYPE_SPEECH)
+            .build()
+
+        ExoPlayer.Builder(
+            appContext,
+            audioOnlyRenderersFactory,
+            ProgressiveMediaSource.Factory(okHttpDataSourceFactory, mp3ExtractorFactory),
+        )
+            .setAudioAttributes(audioAttributes, true)
+            .setHandleAudioBecomingNoisy(true)
+            .build()
+            .also { it.addListener(playerListener) }
+    }
+
+    @MainThread
+    fun setListener(listener: Listener?) {
+        this.listener = listener
+    }
+
+    /**
+     * Loads [url] as the current media item, prepares the player, and arms
+     * playback to start as soon as buffering completes. Replaces any previous
+     * media item.
+     */
+    @MainThread
+    fun prepare(url: String) {
+        exoPlayer.setMediaItem(MediaItem.fromUri(url))
+        exoPlayer.playWhenReady = true
+        exoPlayer.prepare()
+    }
+
+    @MainThread
+    fun play() {
+        exoPlayer.playWhenReady = true
+    }
+
+    @MainThread
+    fun pause() {
+        exoPlayer.playWhenReady = false
+    }
+
+    @MainThread
+    fun seekTo(positionMs: Long) {
+        exoPlayer.seekTo(positionMs)
+    }
+
+    @MainThread
+    fun setSpeed(speed: Float) {
+        exoPlayer.playbackParameters = PlaybackParameters(speed)
+    }
+
+    val isPlaying: Boolean
+        @MainThread
+        get() = exoPlayer.isPlaying
+
+    val currentPositionMs: Long
+        @MainThread
+        get() = exoPlayer.currentPosition.coerceAtLeast(0L)
+
+    val durationMs: Long
+        @MainThread
+        get() = exoPlayer.duration.let { if (it < 0L) 0L else it }
+
+    val speed: Float
+        @MainThread
+        get() = exoPlayer.playbackParameters.speed
+
+    /** Releases the underlying ExoPlayer. After this call the instance is unusable. */
+    @MainThread
+    fun release() {
+        exoPlayer.removeListener(playerListener)
+        listener = null
+        exoPlayer.release()
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioRepository.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioRepository.kt
@@ -1,0 +1,98 @@
+package yuku.alkitab.base.audio
+
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import okhttp3.Request
+import yuku.alkitab.base.audio.model.ChapterTiming
+import yuku.alkitab.base.connection.Connections
+import yuku.alkitab.base.util.AppLog
+import yuku.alkitab.debug.BuildConfig
+
+/**
+ * Audio data layer: turns a `(versionId, bookId, chapter_1)` triple into a chapter
+ * MP3 URL and its verse timing.
+ *
+ * Both methods consult [AudioCatalogRepository] for the per-version URL templates
+ * served by the backend. The templates live in the catalog precisely so the
+ * client never hard-codes upstream URLs — adding a new version, or moving the
+ * CDN, is a one-line backend deploy.
+ *
+ * No upstream folder names, no book-code tables, no URL-construction tricks live
+ * in this client. See `docs/features/audio-bible/backend-plan.md` §4.3 for the
+ * server-side adapter that handles all of that.
+ */
+object BibleAudioRepository {
+
+    private const val TAG = "BibleAudioRepo"
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    /**
+     * Resolves the absolute chapter MP3 URL for `(versionId, bookId, chapter_1)`,
+     * or null if the catalog has no entry for [versionId] (which means the
+     * caller should never have asked — toolbar icon visibility is gated on
+     * [AudioCatalogRepository.isAudioAvailable]).
+     *
+     * The returned URL points at `${BuildConfig.SERVER_HOST}` rather than at the
+     * upstream CDN — the backend then issues a `302 Found` to the real file.
+     */
+    suspend fun buildChapterUrl(versionId: String, bookId: Int, chapter_1: Int): String? {
+        AudioCatalogRepository.loadCatalog()
+        val entry = AudioCatalogRepository.findEntry(versionId) ?: return null
+        return BuildConfig.SERVER_HOST + entry.chapterUrlTemplate
+            .replace("{bookId}", bookId.toString())
+            .replace("{chapter_1}", chapter_1.toString())
+    }
+
+    /**
+     * Fetches the verse timing JSON for `(versionId, bookId, chapter_1)`. Returns
+     * the parsed [ChapterTiming] on success (with a possibly-empty `verses`
+     * list when the backend reports the chapter has audio but no upstream
+     * timing), or null on:
+     *  - missing catalog entry,
+     *  - missing `timingUrlTemplate` for the entry,
+     *  - any non-2xx response,
+     *  - I/O error,
+     *  - JSON parse failure.
+     *
+     * I/O happens on [Dispatchers.IO]. The 50 MB OkHttp disk cache on
+     * [Connections.okHttp] takes care of per-URL caching (TTLs are set
+     * server-side via `Cache-Control`).
+     */
+    suspend fun fetchTiming(versionId: String, bookId: Int, chapter_1: Int): ChapterTiming? {
+        AudioCatalogRepository.loadCatalog()
+        val entry = AudioCatalogRepository.findEntry(versionId) ?: return null
+        val template = entry.timingUrlTemplate ?: return null
+        val url = BuildConfig.SERVER_HOST + template
+            .replace("{bookId}", bookId.toString())
+            .replace("{chapter_1}", chapter_1.toString())
+
+        return withContext(Dispatchers.IO) {
+            val request = Request.Builder().url(url).build()
+            try {
+                Connections.okHttp.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) {
+                        AppLog.w(TAG, "timing fetch failed: HTTP ${response.code} for $url")
+                        return@use null
+                    }
+                    val body = response.body ?: return@use null
+                    try {
+                        json.decodeFromString(ChapterTiming.serializer(), body.string())
+                    } catch (e: SerializationException) {
+                        AppLog.w(TAG, "timing JSON did not parse for $url: ${e.message}")
+                        null
+                    }
+                }
+            } catch (e: IOException) {
+                AppLog.w(TAG, "timing I/O failed for $url: ${e.message}")
+                null
+            }
+        }
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
@@ -1,0 +1,318 @@
+package yuku.alkitab.base.audio
+
+import android.app.PendingIntent
+import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.DefaultMediaNotificationProvider
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSessionService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import yuku.alkitab.base.IsiActivity
+import yuku.alkitab.base.util.AppLog
+import yuku.alkitab.debug.R
+
+/**
+ * Foreground [MediaSessionService] that owns a [BibleAudioPlayer] and exposes
+ * playback state to the M3 Compose UI via a local binder + [StateFlow].
+ *
+ * Two binding paths share the same service instance:
+ *  - **MediaSession (system)** — `super.onBind(intent)` returns the standard
+ *    media3 stub so the OS can drive playback through MediaController, lock
+ *    screen, Bluetooth, Android Auto, etc.
+ *  - **Local (in-app)** — clients send `Intent` with [ACTION_LOCAL_BIND] to
+ *    receive a [LocalBinder]; they can then read [playbackState] and call
+ *    [loadChapter] / [play] / [pause] / [seekTo] / [setSpeed] / [stop]
+ *    directly. Used by the M3 `AudioBarController`.
+ *
+ * Foreground transitions (notification post / removal) are handled by media3
+ * automatically based on `Player.isPlaying`. The notification's MediaStyle,
+ * channel, and metadata come from [DefaultMediaNotificationProvider]; the
+ * channel id we set here matches the one created in `App.staticInit()`.
+ *
+ * Audio focus, becoming-noisy, lock-screen / Bluetooth media-button handling
+ * all come for free with `MediaSession` + the audio attributes set on the
+ * [BibleAudioPlayer]'s ExoPlayer.
+ */
+@OptIn(UnstableApi::class)
+class BibleAudioService : MediaSessionService() {
+
+    companion object {
+        /** Action on the binding [Intent] that asks for the in-app [LocalBinder]. */
+        const val ACTION_LOCAL_BIND = "yuku.alkitab.audio.ACTION_LOCAL_BIND"
+
+        /**
+         * Notification channel id; must match the channel created at app startup
+         * (`App.staticInit()`). media3 will auto-create the channel here too if
+         * we forget, but we want IMPORTANCE_LOW + no sound, which means we have
+         * to be the ones to create it first — channel attributes are immutable
+         * after creation.
+         */
+        const val NOTIFICATION_CHANNEL_ID = "audio_bible"
+
+        private const val POSITION_POLL_INTERVAL_MS = 100L
+        private const val TAG = "BibleAudioService"
+    }
+
+    /** Parameters for [loadChapter]. The display fields drive the lock-screen metadata. */
+    data class AudioRequest(
+        val versionId: String,
+        val bookId: Int,
+        val chapter_1: Int,
+        val displayTitle: String,
+        val displaySubtitle: String,
+    )
+
+    inner class LocalBinder : Binder() {
+        val service: BibleAudioService get() = this@BibleAudioService
+    }
+
+    private val localBinder = LocalBinder()
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var positionJob: Job? = null
+    private var loadJob: Job? = null
+    private var timingJob: Job? = null
+
+    private lateinit var player: BibleAudioPlayer
+    private var mediaSession: MediaSession? = null
+    private val highlightTracker = HighlightTracker()
+
+    private val _playbackState = MutableStateFlow(PlaybackState.IDLE)
+    val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
+
+    private val playerListener = object : BibleAudioPlayer.Listener {
+        override fun onReady() {
+            startPositionPolling()
+            _playbackState.update {
+                it.copy(
+                    preparing = false,
+                    isPlaying = player.isPlaying,
+                    durationMs = player.durationMs,
+                    speed = player.speed,
+                    error = null,
+                )
+            }
+        }
+
+        override fun onEnded() {
+            // M2: stop polling and report stopped. Auto-advance to the next
+            // chapter is M5 polish and lives outside the service.
+            positionJob?.cancel()
+            _playbackState.update {
+                it.copy(isPlaying = false, positionMs = player.durationMs)
+            }
+        }
+
+        override fun onError(error: PlaybackException) {
+            AppLog.w(TAG, "player error: ${error.errorCodeName} ${error.message}")
+            positionJob?.cancel()
+            _playbackState.update {
+                it.copy(
+                    preparing = false,
+                    isPlaying = false,
+                    error = error.errorCodeName,
+                )
+            }
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        player = BibleAudioPlayer(applicationContext)
+        player.setListener(playerListener)
+
+        // Tapping the notification opens the reader.
+        val sessionActivity = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, IsiActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+            PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        mediaSession = MediaSession.Builder(this, player.exoPlayer)
+            .setSessionActivity(sessionActivity)
+            .build()
+
+        // Use our pre-created low-importance channel so the notification doesn't
+        // make sound or vibrate.
+        setMediaNotificationProvider(
+            DefaultMediaNotificationProvider.Builder(this)
+                .setChannelId(NOTIFICATION_CHANNEL_ID)
+                .setChannelName(R.string.audio_bible_notification_channel_name)
+                .build()
+        )
+
+        // Mirror highlight changes into the playback state.
+        scope.launch {
+            highlightTracker.verse1.collect { v ->
+                _playbackState.update { it.copy(verse_1 = v) }
+            }
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        if (intent?.action == ACTION_LOCAL_BIND) {
+            return localBinder
+        }
+        return super.onBind(intent)
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? {
+        return mediaSession
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        // Match Spotify / YouTube Music: swiping the app from recents while
+        // audio is playing should keep playback alive. If we're paused,
+        // releasing is a reasonable cleanup.
+        if (player.isPlaying) {
+            return
+        }
+        stopSelf()
+    }
+
+    override fun onDestroy() {
+        positionJob?.cancel()
+        loadJob?.cancel()
+        timingJob?.cancel()
+        scope.cancel()
+        mediaSession?.release()
+        mediaSession = null
+        player.release()
+        super.onDestroy()
+    }
+
+    // -- public API surfaced via [LocalBinder] -------------------------------
+
+    /**
+     * Starts loading [request]'s chapter. Cancels any in-flight load. Updates
+     * [playbackState] to `preparing = true` immediately; the player will fire
+     * its `onReady` listener once buffering is done, at which point `preparing`
+     * flips to false. Timing data is fetched in parallel with audio buffering.
+     */
+    fun loadChapter(request: AudioRequest) {
+        loadJob?.cancel()
+        timingJob?.cancel()
+        // New chapter — reset highlight from any previous chapter and clear errors.
+        highlightTracker.setTiming(emptyList())
+        _playbackState.update {
+            it.copy(
+                preparing = true,
+                isPlaying = false,
+                verse_1 = 0,
+                positionMs = 0L,
+                durationMs = 0L,
+                error = null,
+            )
+        }
+
+        loadJob = scope.launch {
+            val url = BibleAudioRepository.buildChapterUrl(
+                request.versionId,
+                request.bookId,
+                request.chapter_1,
+            )
+            if (url == null) {
+                _playbackState.update {
+                    it.copy(preparing = false, error = "no_audio_for_version")
+                }
+                return@launch
+            }
+
+            val mediaItem = MediaItem.Builder()
+                .setUri(url)
+                .setMediaMetadata(
+                    MediaMetadata.Builder()
+                        .setTitle(request.displayTitle)
+                        .setArtist(request.displaySubtitle)
+                        .build()
+                )
+                .build()
+            player.exoPlayer.setMediaItem(mediaItem)
+            player.exoPlayer.playWhenReady = true
+            player.exoPlayer.prepare()
+        }
+
+        timingJob = scope.launch(Dispatchers.IO) {
+            val timing = BibleAudioRepository.fetchTiming(
+                request.versionId,
+                request.bookId,
+                request.chapter_1,
+            )
+            highlightTracker.setTiming(timing?.verses ?: emptyList())
+        }
+    }
+
+    fun play() {
+        player.play()
+        _playbackState.update { it.copy(isPlaying = true) }
+        startPositionPolling()
+    }
+
+    fun pause() {
+        player.pause()
+        positionJob?.cancel()
+        _playbackState.update { it.copy(isPlaying = false) }
+    }
+
+    fun seekTo(positionMs: Long) {
+        player.seekTo(positionMs)
+        highlightTracker.update(positionMs)
+        _playbackState.update { it.copy(positionMs = positionMs) }
+    }
+
+    fun setSpeed(speed: Float) {
+        player.setSpeed(speed)
+        _playbackState.update { it.copy(speed = speed) }
+    }
+
+    /**
+     * Stops playback and tears the service down (clears the foreground
+     * notification). Safe to call after `loadChapter` even if the player never
+     * reached READY.
+     */
+    fun stop() {
+        loadJob?.cancel()
+        timingJob?.cancel()
+        positionJob?.cancel()
+        player.pause()
+        _playbackState.value = PlaybackState.IDLE
+        stopSelf()
+    }
+
+    private fun startPositionPolling() {
+        positionJob?.cancel()
+        positionJob = scope.launch {
+            while (isActive) {
+                val pos = player.currentPositionMs
+                highlightTracker.update(pos)
+                _playbackState.update {
+                    it.copy(
+                        isPlaying = player.isPlaying,
+                        positionMs = pos,
+                        durationMs = player.durationMs,
+                    )
+                }
+                delay(POSITION_POLL_INTERVAL_MS)
+            }
+        }
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
@@ -251,7 +251,12 @@ class BibleAudioService : MediaSessionService() {
             player.exoPlayer.prepare()
         }
 
-        timingJob = scope.launch(Dispatchers.IO) {
+        // Stay on Dispatchers.Main.immediate (the scope's default) so
+        // setTiming runs on the same thread as positionJob's update calls —
+        // HighlightTracker is not thread-safe by design. The repository
+        // already does its own withContext(Dispatchers.IO) for the network
+        // hop, so the blocking work is still off the main thread.
+        timingJob = scope.launch {
             val timing = BibleAudioRepository.fetchTiming(
                 request.versionId,
                 request.bookId,

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/HighlightTracker.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/HighlightTracker.kt
@@ -1,0 +1,127 @@
+package yuku.alkitab.base.audio
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import yuku.alkitab.base.audio.model.VerseTiming
+
+/**
+ * Maps an audio playback position to the currently-active 1-based verse number.
+ *
+ * Owns a [StateFlow] of the active `verse_1` (`0` when no verse is active —
+ * either because the chapter hasn't reached verse 1 yet, or because no timing
+ * data is loaded). The UI layer (M3) collects this flow to drive the verse
+ * highlight and auto-scroll.
+ *
+ * Polling cadence (positionMs updates) is owned by the caller — typically the
+ * service drives this at 100ms while the player is playing. This class is
+ * intentionally pull-based on its position input rather than tying itself to
+ * a Player; that keeps it deterministic and unit-testable.
+ *
+ * Optimisation: we cache the index of the last verse that matched (`lastIndex`)
+ * so monotonic forward progress costs O(1) lookups (just a bound check on the
+ * current cell). Backwards seeks fall through to a binary search.
+ *
+ * Threading: not synchronised — call `setTiming` and `update` from the same
+ * thread (in practice, the main thread on the service side).
+ */
+class HighlightTracker {
+
+    private val _verse1 = MutableStateFlow(0)
+    val verse1: StateFlow<Int> = _verse1.asStateFlow()
+
+    private var verses: List<VerseTiming> = emptyList()
+
+    /** Hint into [verses]; -1 means no cached hit yet. */
+    private var lastIndex: Int = -1
+
+    /**
+     * Replaces the timing data the tracker resolves against. Resets the active
+     * verse to `0` and clears the binary-search hint.
+     */
+    fun setTiming(verses: List<VerseTiming>) {
+        this.verses = verses
+        lastIndex = -1
+        _verse1.value = 0
+    }
+
+    /**
+     * Updates the active verse based on [positionMs] (the player's current
+     * position). Emits a new value into [verse1] only if the resolved verse
+     * actually changed.
+     */
+    fun update(positionMs: Long) {
+        val resolved = resolveVerse(positionMs)
+        if (resolved != _verse1.value) {
+            _verse1.value = resolved
+        }
+    }
+
+    /**
+     * Returns the `verse_1` whose `[startMs, endMs)` window contains
+     * [positionMs], or `0` if no verse matches.
+     *
+     * Strategy:
+     *  1. If [lastIndex] is valid and the position still falls inside that
+     *     verse's window, return it without a search. (Steady-state hit.)
+     *  2. If the position has advanced past [lastIndex] but lies inside a
+     *     later verse, walk forward — bounded by the size of the gap, but
+     *     usually 1 step. (Common forward-progress hit.)
+     *  3. Otherwise binary-search the full list. (Cold start, rewind, or
+     *     seek across many verses.)
+     */
+    private fun resolveVerse(positionMs: Long): Int {
+        if (verses.isEmpty()) return 0
+
+        // Fast path: still inside the cached verse.
+        val li = lastIndex
+        if (li in verses.indices) {
+            val cached = verses[li]
+            if (positionMs >= cached.startMs && positionMs < cached.endMs) {
+                return cached.verse_1
+            }
+            // Forward walk — also fast for monotonic playback at 100ms ticks.
+            if (positionMs >= cached.endMs) {
+                var i = li + 1
+                while (i < verses.size) {
+                    val v = verses[i]
+                    if (positionMs < v.startMs) {
+                        // Position is in a gap between verses.
+                        lastIndex = -1
+                        return 0
+                    }
+                    if (positionMs < v.endMs) {
+                        lastIndex = i
+                        return v.verse_1
+                    }
+                    i++
+                }
+                // Past the last verse.
+                lastIndex = -1
+                return 0
+            }
+            // Backwards seek — fall through to binary search.
+        }
+
+        return binarySearch(positionMs)
+    }
+
+    private fun binarySearch(positionMs: Long): Int {
+        var lo = 0
+        var hi = verses.size - 1
+        while (lo <= hi) {
+            val mid = (lo + hi) ushr 1
+            val v = verses[mid]
+            when {
+                positionMs < v.startMs -> hi = mid - 1
+                positionMs >= v.endMs -> lo = mid + 1
+                else -> {
+                    lastIndex = mid
+                    return v.verse_1
+                }
+            }
+        }
+        lastIndex = -1
+        return 0
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/PlaybackState.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/PlaybackState.kt
@@ -1,0 +1,41 @@
+package yuku.alkitab.base.audio
+
+/**
+ * UI-facing snapshot of [BibleAudioService]'s state. Emitted via the service's
+ * `StateFlow<PlaybackState>` and consumed by the M3 audio bar.
+ *
+ *  - [isPlaying]   — true while the player is actually playing audio (not just
+ *                    "play was requested but still buffering"; that's [preparing]).
+ *  - [preparing]   — true between `loadChapter` and the player firing READY.
+ *                    Drives the toolbar-icon spinner and the bar's progress ring.
+ *  - [verse_1]     — currently active 1-based verse, or `0` when no verse is
+ *                    active (chapter intro, gap between verses, or no timing).
+ *  - [positionMs]  — last polled [androidx.media3.common.Player.getCurrentPosition].
+ *  - [durationMs]  — last polled [androidx.media3.common.Player.getDuration],
+ *                    `0` until the player reports a real duration.
+ *  - [speed]       — current playback speed, mirroring `PlaybackParameters.speed`.
+ *  - [error]       — non-null when the player or repository hit an error this
+ *                    session; the UI snackbars and offers retry. Cleared on
+ *                    the next successful `loadChapter`.
+ */
+data class PlaybackState(
+    val isPlaying: Boolean,
+    val preparing: Boolean,
+    val verse_1: Int,
+    val positionMs: Long,
+    val durationMs: Long,
+    val speed: Float,
+    val error: String?,
+) {
+    companion object {
+        val IDLE = PlaybackState(
+            isPlaying = false,
+            preparing = false,
+            verse_1 = 0,
+            positionMs = 0L,
+            durationMs = 0L,
+            speed = 1.0f,
+            error = null,
+        )
+    }
+}

--- a/Alkitab/src/main/res/values/strings.xml
+++ b/Alkitab/src/main/res/values/strings.xml
@@ -570,5 +570,6 @@
 	<!-- Notification channels -->
 	<string name="notification_channel_download_mapper_name">Downloads</string>
 	<string name="notification_channel_devotion_downloader_name">Devotion downloads</string>
+	<string name="audio_bible_notification_channel_name">Bible audio</string>
 
 </resources>

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/BibleAudioRepositoryTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/BibleAudioRepositoryTest.kt
@@ -1,0 +1,188 @@
+package yuku.alkitab.base.audio
+
+import android.app.Application
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import yuku.alkitab.base.audio.model.ChapterTiming
+import yuku.alkitab.debug.BuildConfig
+
+/**
+ * Robolectric tests for [BibleAudioRepository]. We piggyback on the M1 test
+ * pattern: Robolectric gives us a real `App.context` so the catalog repo can
+ * stream the bundled `assets/audio_catalog.json`, and we override its cache
+ * via reflection between tests.
+ *
+ * URL building and the catalog-miss path are exercised end-to-end. The HTTP
+ * layer (`fetchTiming` against a live URL) is not — `BuildConfig.SERVER_HOST`
+ * can't be rewritten at test time, so we don't try to reach it; we instead
+ * test the catalog-miss / no-timing-template branches plus a pure JSON parse
+ * that pins the v1 schema.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class BibleAudioRepositoryTest {
+
+    @Before
+    fun setUp() {
+        val app = RuntimeEnvironment.getApplication()
+        yuku.afw.App.context = app
+        resetCatalogCache()
+        overrideFile(app).delete()
+    }
+
+    @After
+    fun tearDown() {
+        resetCatalogCache()
+        overrideFile(RuntimeEnvironment.getApplication()).delete()
+    }
+
+    @Test
+    fun `buildChapterUrl substitutes bookId and chapter_1 against the catalog template`() = runBlocking {
+        val url = BibleAudioRepository.buildChapterUrl(
+            versionId = "preset/in-tb",
+            bookId = 41,
+            chapter_1 = 3,
+        )
+        assertNotNull(url)
+        assertTrue(
+            "URL should be rooted at SERVER_HOST: $url",
+            url!!.startsWith(BuildConfig.SERVER_HOST),
+        )
+        assertTrue("URL should mention bookId=41: $url", url.contains("bookId=41"))
+        assertTrue("URL should mention chapter_1=3: $url", url.contains("chapter_1=3"))
+        assertTrue("versionId stays URL-encoded in the template: $url", url.contains("preset%2Fin-tb"))
+        // Sanity: no leftover placeholders.
+        assertEquals(-1, url.indexOf("{bookId}"))
+        assertEquals(-1, url.indexOf("{chapter_1}"))
+    }
+
+    @Test
+    fun `buildChapterUrl works for KJV (different catalog entry)`() = runBlocking {
+        val url = BibleAudioRepository.buildChapterUrl("preset/en-kjv", 0, 1)
+        assertNotNull(url)
+        assertTrue(url!!.contains("preset%2Fen-kjv"))
+        assertTrue(url.contains("bookId=0"))
+        assertTrue(url.contains("chapter_1=1"))
+    }
+
+    @Test
+    fun `buildChapterUrl returns null for a version not in the catalog`() = runBlocking {
+        val url = BibleAudioRepository.buildChapterUrl("preset/zz-nonsense", 0, 1)
+        assertNull(url)
+    }
+
+    @Test
+    fun `buildChapterUrl resolves the internal version via BuildConfig INTERNAL_VERSION_AUDIO_ID`() = runBlocking {
+        // The plain flavor maps internal -> preset/in-tb.
+        assertEquals("preset/in-tb", BuildConfig.INTERNAL_VERSION_AUDIO_ID)
+        val url = BibleAudioRepository.buildChapterUrl("internal", 41, 3)
+        assertNotNull(url)
+        assertTrue(url!!.contains("preset%2Fin-tb"))
+    }
+
+    @Test
+    fun `fetchTiming returns null when the catalog has no entry for the version`() = runBlocking {
+        val timing = BibleAudioRepository.fetchTiming("preset/zz-nonsense", 0, 1)
+        assertNull(timing)
+    }
+
+    @Test
+    fun `fetchTiming returns null when the catalog entry has no timingUrlTemplate`() = runBlocking {
+        val app = RuntimeEnvironment.getApplication()
+        // Stand up a single-entry catalog whose timingUrlTemplate is missing,
+        // forcing the "no timing for this version" branch.
+        overrideFile(app).writeText(
+            """
+            {
+              "generatedAt": 1700000000,
+              "entries": [
+                {
+                  "versionId": "preset/no-timing",
+                  "shortName": "NTM",
+                  "chapterUrlTemplate": "/audio/chapter?versionId=preset%2Fno-timing&bookId={bookId}&chapter_1={chapter_1}"
+                }
+              ]
+            }
+            """.trimIndent()
+        )
+        resetCatalogCache()
+
+        val timing = BibleAudioRepository.fetchTiming("preset/no-timing", 0, 1)
+        assertNull(timing)
+    }
+
+    @Test
+    fun `ChapterTiming v1 schema parses the documented backend response shape`() {
+        // Pin the JSON shape from docs/features/audio-bible/backend-plan.md §4.2.
+        val json = Json { ignoreUnknownKeys = true; isLenient = true }
+        val raw = """
+            {
+              "schema": 1,
+              "versionId": "preset/in-tb",
+              "bookId": 41,
+              "chapter_1": 3,
+              "durationMs": 195000,
+              "verses": [
+                { "verse_1": 1, "startMs": 0,     "endMs": 5820  },
+                { "verse_1": 2, "startMs": 5820,  "endMs": 11960 },
+                { "verse_1": 3, "startMs": 11960, "endMs": 18100 }
+              ],
+              "generatedAt": 1713456000000
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(ChapterTiming.serializer(), raw)
+        assertEquals("preset/in-tb", parsed.versionId)
+        assertEquals(41, parsed.bookId)
+        assertEquals(3, parsed.chapter_1)
+        assertEquals(195_000L, parsed.durationMs)
+        assertEquals(3, parsed.verses.size)
+        assertEquals(2, parsed.verses[1].verse_1)
+        assertEquals(5_820L, parsed.verses[1].startMs)
+        assertEquals(11_960L, parsed.verses[1].endMs)
+    }
+
+    @Test
+    fun `ChapterTiming parses the empty-verses payload (chapter exists but has no timing)`() {
+        // Per backend-plan §4.2: a 200 response with verses=[] is the "version
+        // known, chapter in range, but upstream has no timing" signal.
+        val json = Json { ignoreUnknownKeys = true; isLenient = true }
+        val raw = """
+            {
+              "schema": 1,
+              "versionId": "preset/in-tb",
+              "bookId": 41,
+              "chapter_1": 3,
+              "durationMs": 0,
+              "verses": [],
+              "generatedAt": 0
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(ChapterTiming.serializer(), raw)
+        assertTrue(parsed.verses.isEmpty())
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private fun overrideFile(app: Application): File = File(app.filesDir, "audio_catalog.json")
+
+    /** Reset [AudioCatalogRepository.cached] between tests. */
+    private fun resetCatalogCache() {
+        val field = AudioCatalogRepository.javaClass.getDeclaredField("cached")
+        field.isAccessible = true
+        field.set(AudioCatalogRepository, null)
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/HighlightTrackerTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/HighlightTrackerTest.kt
@@ -1,0 +1,160 @@
+package yuku.alkitab.base.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import yuku.alkitab.base.audio.model.VerseTiming
+
+/**
+ * Pure-logic tests for [HighlightTracker]. No Android framework needed — the
+ * class is a plain Kotlin object over `StateFlow`, and `StateFlow.value`
+ * resolves synchronously in the same thread.
+ */
+class HighlightTrackerTest {
+
+    /** Three contiguous verses: 0–1000, 1000–2000, 2000–3000. */
+    private val contiguous = listOf(
+        VerseTiming(verse_1 = 1, startMs = 0L, endMs = 1000L),
+        VerseTiming(verse_1 = 2, startMs = 1000L, endMs = 2000L),
+        VerseTiming(verse_1 = 3, startMs = 2000L, endMs = 3000L),
+    )
+
+    @Test
+    fun `with no timing set, every position resolves to 0 (no-highlight sentinel)`() {
+        val t = HighlightTracker()
+        t.update(0L)
+        assertEquals(0, t.verse1.value)
+        t.update(50_000L)
+        assertEquals(0, t.verse1.value)
+    }
+
+    @Test
+    fun `setTiming with empty list keeps verse_1 at 0`() {
+        val t = HighlightTracker()
+        t.setTiming(emptyList())
+        t.update(500L)
+        assertEquals(0, t.verse1.value)
+    }
+
+    @Test
+    fun `monotonic forward progress steps through each verse exactly once`() {
+        val t = HighlightTracker()
+        t.setTiming(contiguous)
+
+        // Walk position from 0ms to 3000ms in 100ms steps. Capture every
+        // distinct value emitted by verse1.
+        val emitted = mutableListOf<Int>()
+        var last = -1
+        for (ms in 0..3000 step 100) {
+            t.update(ms.toLong())
+            val now = t.verse1.value
+            if (now != last) {
+                emitted.add(now)
+                last = now
+            }
+        }
+
+        // We expect 1, 2, 3, 0 — each verse for its window, then 0 once we
+        // pass endMs of the last verse (3000ms is exactly at the boundary).
+        assertEquals(listOf(1, 2, 3, 0), emitted)
+    }
+
+    @Test
+    fun `position before the first verse start resolves to 0`() {
+        val t = HighlightTracker()
+        // First verse starts at 500ms.
+        t.setTiming(
+            listOf(
+                VerseTiming(verse_1 = 1, startMs = 500L, endMs = 1500L),
+                VerseTiming(verse_1 = 2, startMs = 1500L, endMs = 2500L),
+            )
+        )
+        t.update(0L)
+        assertEquals(0, t.verse1.value)
+        t.update(499L)
+        assertEquals(0, t.verse1.value)
+        t.update(500L)
+        assertEquals(1, t.verse1.value)
+    }
+
+    @Test
+    fun `rewind across verses resolves correctly via fallback search`() {
+        val t = HighlightTracker()
+        t.setTiming(contiguous)
+
+        // Forward to verse 3.
+        t.update(2500L)
+        assertEquals(3, t.verse1.value)
+        // Rewind hard to verse 1.
+        t.update(100L)
+        assertEquals(1, t.verse1.value)
+        // Forward again to verse 2.
+        t.update(1500L)
+        assertEquals(2, t.verse1.value)
+    }
+
+    @Test
+    fun `seek past the last verse end resolves to 0`() {
+        val t = HighlightTracker()
+        t.setTiming(contiguous)
+        t.update(500L)
+        assertEquals(1, t.verse1.value)
+        // Seek to a position past the last verse's endMs.
+        t.update(5000L)
+        assertEquals(0, t.verse1.value)
+    }
+
+    @Test
+    fun `gap between non-contiguous verses resolves to 0`() {
+        val t = HighlightTracker()
+        // Two verses with a 500ms gap: 0–1000, 1500–2500.
+        t.setTiming(
+            listOf(
+                VerseTiming(verse_1 = 1, startMs = 0L, endMs = 1000L),
+                VerseTiming(verse_1 = 2, startMs = 1500L, endMs = 2500L),
+            )
+        )
+        t.update(500L)
+        assertEquals(1, t.verse1.value)
+        // Walk into the gap.
+        t.update(1200L)
+        assertEquals(0, t.verse1.value)
+        // Out the other side.
+        t.update(1700L)
+        assertEquals(2, t.verse1.value)
+    }
+
+    @Test
+    fun `setTiming clears the previously active verse`() {
+        val t = HighlightTracker()
+        t.setTiming(contiguous)
+        t.update(500L)
+        assertEquals(1, t.verse1.value)
+        t.setTiming(emptyList())
+        assertEquals(0, t.verse1.value)
+    }
+
+    @Test
+    fun `update only emits when the resolved verse actually changes`() {
+        val t = HighlightTracker()
+        t.setTiming(contiguous)
+
+        // First update: 0 -> 1, must emit.
+        t.update(100L)
+        val firstSnapshot = t.verse1.value
+        // Multiple updates inside the same verse: must NOT emit a new value.
+        t.update(200L)
+        t.update(500L)
+        t.update(999L)
+        assertEquals(firstSnapshot, t.verse1.value)
+        assertEquals(1, t.verse1.value)
+    }
+
+    @Test
+    fun `position exactly at endMs of one verse resolves to the next verse`() {
+        val t = HighlightTracker()
+        t.setTiming(contiguous)
+        // [0, 1000) is verse 1; 1000 itself is verse 2 (endMs is exclusive).
+        t.update(1000L)
+        assertEquals(2, t.verse1.value)
+    }
+}


### PR DESCRIPTION
## Summary

Builds on the M1 catalog skeleton (#157) with the playback layer per `docs/features/audio-bible/client-plan.md` §M2:

- **`BibleAudioPlayer`** — audio-only ExoPlayer wrapper over `Connections.okHttp`, MP3-only extractor, `USAGE_MEDIA` + `CONTENT_TYPE_SPEECH` audio attributes (proper ducking on transient loss / pause on call), `setHandleAudioBecomingNoisy(true)`. `Listener` interface for `onReady` / `onEnded` / `onError`.
- **`BibleAudioRepository`** — turns `(versionId, bookId, chapter_1)` into a chapter URL (catalog template + `BuildConfig.SERVER_HOST`) and a parsed `ChapterTiming`. Zero upstream URL knowledge in the client.
- **`HighlightTracker`** — `StateFlow<Int>` of the active 1-based verse, driven by 100ms position polling. Last-index hint keeps steady-state lookups O(1); binary-search fallback for rewind / cold start.
- **`BibleAudioService`** — media3 `MediaSessionService` that owns the player and a `MediaSession` (lock-screen / Bluetooth / Auto support comes for free). Exposes a `StateFlow<PlaybackState>` + `LocalBinder` for the upcoming M3 Compose UI to consume.
- **AndroidManifest** — service registered with `foregroundServiceType="mediaPlayback"`, plus `FOREGROUND_SERVICE` / `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permissions.
- **`App.staticInit`** — pre-creates the `audio_bible` channel at `IMPORTANCE_LOW`, no sound, no vibration, so media3's `DefaultMediaNotificationProvider` lands on the right channel.

UI integration is M3 — the service is startable cold from anywhere, but no in-app affordance exists yet.

## Test plan

- [x] `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest assemblePlainDebug` all green.
- [x] New tests pass: `HighlightTrackerTest` (10 cases: monotonic forward, rewind, gap-between-verses, seek past end, exact-boundary, no-timing, no-emit-on-no-change), `BibleAudioRepositoryTest` (8 cases: URL expansion for TB / KJV / internal-version mapping, unknown version returns null, missing timing template, v1 schema parse, empty-verses payload).
- [x] `grep -r "sabda" Alkitab/src/main/java/yuku/alkitab/base/audio` after the new files: zero hits.
- [x] Installed `Alkitab-17000532-4.11.2-7979b263-yuku.alkitab.debug-dev.apk` on `emulator-5554`; app opens cleanly to `IsiActivity`. `dumpsys notification` shows `audio_bible` channel registered with `mImportance=2` (LOW), `mSound=null`, `mVibrationEnabled=false`.
- [ ] Service start / play-a-chapter end-to-end is left for M3, when the toolbar icon and Compose audio bar are wired in (per the client plan).

## Out of scope (per `client-plan.md`)

- Compose audio bar, `IsiActivity` integration, toolbar icon, verse highlight overlay → M3.
- Lock-screen manual matrix, audio-focus matrix, `onTaskRemoved` polish → M4.
- Speed bottom sheet, auto-advance, snackbar errors, split-view source picker → M5.