### PR TITLE
fcm: defer init until sync sign-in to avoid POST_NOTIFICATIONS prompt

### DIFF
--- a/Alkitab/src/main/AndroidManifest.xml
+++ b/Alkitab/src/main/AndroidManifest.xml
@@ -33,6 +33,18 @@
 		android:supportsRtl="true"
 		android:theme="@style/Theme.Alkitab">
 
+		<!--
+			Disable Firebase Messaging's auto-init at process startup. Without this,
+			firebase-messaging 23.1.0+ proactively requests POST_NOTIFICATIONS on
+			Android 13+ the first time the app launches, before the user has any
+			reason to grant it. We instead initialize FCM lazily once the user signs
+			into sync (see SyncLoginActivity), which is the only feature that uses
+			push messages.
+		-->
+		<meta-data
+			android:name="firebase_messaging_auto_init_enabled"
+			android:value="false" />
+
 		<activity
 			android:name="yuku.alkitab.base.IsiActivity"
 			android:exported="true">

--- a/Alkitab/src/main/java/yuku/alkitab/base/App.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/App.java
@@ -10,8 +10,10 @@ import com.downloader.PRDownloader;
 import com.downloader.PRDownloaderConfig;
 import com.google.gson.Gson;
 import java.util.concurrent.atomic.AtomicBoolean;
+import yuku.afw.storage.Preferences;
 import yuku.alkitab.base.connection.Connections;
 import yuku.alkitab.base.connection.PRDownloaderOkHttpClient;
+import yuku.alkitab.base.storage.Prefkey;
 import yuku.alkitab.base.sync.Fcm;
 import yuku.alkitab.base.sync.Sync;
 import yuku.alkitab.base.util.ExtensionManager;
@@ -59,7 +61,13 @@ public class App extends yuku.afw.App {
             PreferenceManager.setDefaultValues(context, preferenceResId, false);
         }
 
-        { // FCM
+        // FCM is only useful once the user has signed into sync — the registration id
+        // gets uploaded by Sync.notifyNewFcmRegistrationId, which itself early-exits
+        // when sync_simpleToken is null. Skipping this block on first launch (before
+        // any sync sign-in) keeps Firebase Messaging dormant and avoids prompting the
+        // user for POST_NOTIFICATIONS before they have any reason to grant it. New
+        // sign-ins are handled separately by SyncLoginActivity.gotSimpleToken.
+        if (Preferences.getString(Prefkey.sync_simpleToken) != null) {
             final String fcmRegistrationId = Fcm.renewFcmRegistrationIdIfNeeded(Sync::notifyNewFcmRegistrationId);
             if (fcmRegistrationId != null) {
                 Sync.retryPendingFcmRegistrationIfNeeded(fcmRegistrationId);


### PR DESCRIPTION
## Summary

- firebase-messaging 23.1.0+ proactively requests `POST_NOTIFICATIONS` at process startup on Android 13+, surprising first-launch users who haven't asked for any push features.
- Disable Firebase Messaging's auto-init via the `firebase_messaging_auto_init_enabled=false` manifest meta-data.
- Gate the existing FCM init in `App.staticInit` on the user already having a sync `simpleToken`. `Sync.notifyNewFcmRegistrationId` already early-exits without one, so this matches the original *effective* behavior — fresh installs were calling FCM only to throw the result away.
- New sign-ins remain covered by the existing call in `SyncLoginActivity.gotSimpleToken`, which calls `Fcm.renewFcmRegistrationIdIfNeeded` right after login.

## Why this is safe

- Sync push messages are silent data-only payloads, which never need `POST_NOTIFICATIONS` to be received and processed.
- The permission stays declared in the merged manifest (firebase-messaging adds it via library merge — harmless on its own; only an explicit `requestPermissions` call opens the system dialog, which neither this app nor the SDK does once auto-init is off).
- Existing logged-in users still get their FCM registration refreshed on every launch (the `simpleToken != null` gate is true for them).
- Fresh installs no longer make a wasted FCM call before sign-in.

## Test plan

- [x] `./gradlew assemblePlainDebug` — clean
- [x] `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` — clean
- [x] Verified `firebase_messaging_auto_init_enabled=false` survives manifest merge
- [x] Verified no app code calls `requestPermissions` for `POST_NOTIFICATIONS`
- [ ] Manual: install on Android 13+ emulator (fresh install) — confirm POST_NOTIFICATIONS dialog no longer appears on first launch
- [ ] Manual: sign into sync, then verify cross-device sync push still works (token registration goes through `SyncLoginActivity.gotSimpleToken` → `Fcm.renewFcmRegistrationIdIfNeeded`)