### PR TITLE
REM-22: drop orphaned percentlayout dep + Goto cleanup

### DIFF
--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -358,7 +358,6 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.fragment.ktx)
     implementation(libs.androidx.multidex)
-    implementation(libs.androidx.percentlayout)
     implementation(libs.androidx.preference.ktx)
     implementation(libs.androidx.recyclerview)
     implementation(libs.androidx.swiperefreshlayout)

--- a/Alkitab/src/main/res/values/colors.xml
+++ b/Alkitab/src/main/res/values/colors.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<color name="keypad_text_color">#fff</color>
 	<!-- Color for something interesting -->
 	<color name="escape">#4db6ac</color>
 </resources>

--- a/Alkitab/src/main/res/values/styles.xml
+++ b/Alkitab/src/main/res/values/styles.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-	<style name="KeypadButton">
-		<item name="android:background">?selectableItemBackgroundBorderless</item>
-		<item name="android:fontFamily">sans-serif-regular</item>
-		<item name="android:textColor">@color/keypad_text_color</item>
-		<item name="android:textSize">28sp</item>
-	</style>
-
 	<!-- Applied to non-Spinner to give an appearance of drop-down control -->
 	<style name="FakeSpinner">
 		<item name="android:background">@drawable/abc_spinner_mtrl_am_alpha</item>

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -187,7 +187,7 @@ Newer files (activities, data classes) are Kotlin, creating a mixed codebase whe
 | `PRDownloader` (patched) | custom | Forked as `PrDownloaderFixed`. Maintenance burden of carrying a patched fork. |
 | `AmbilWarna` | bundled | Bundled color picker. Material color picker components exist now. |
 | ~~`LocalBroadcastManager`~~ | — | Removed in REM-03; replaced by `AppEvents` `SharedFlow` buses. |
-| `androidx.percentlayout` | 1.0.0 | Library is in maintenance mode (deprecated by Google in favor of `ConstraintLayout`). Last consumers were the goto fragment layouts; after the REM-22 Compose port (2026-05-06) no `src/` layout references it any more — the `implementation(libs.androidx.percentlayout)` line in `Alkitab/build.gradle.kts:345` can be deleted as a follow-up. |
+| ~~`androidx.percentlayout`~~ | ~~1.0.0~~ | ✅ **Fixed in REM-22 follow-up** (2026-05-07). The dep was orphaned by the GotoActivity Compose port (PR #160) once the last consumer (`fragment_goto_dialer.xml`) was deleted. Removed the `implementation(libs.androidx.percentlayout)` line from `Alkitab/build.gradle.kts` along with the version key and library entry in `gradle/libs.versions.toml`. Same cleanup also dropped the now-unused `KeypadButton` style and `keypad_text_color` color resource (former dialer-only assets). |
 
 ---
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ androidxFragment = "1.8.9"
 androidxLifecycle = "2.9.0"
 androidxMedia3 = "1.8.0"
 androidxMultidex = "2.0.1"
-androidxPercentlayout = "1.0.0"
 androidxPreference = "1.2.1"
 androidxRecyclerview = "1.4.0"
 androidxSwiperefreshlayout = "1.1.0"
@@ -70,7 +69,6 @@ androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplaye
 androidx-media3-datasource-okhttp = { group = "androidx.media3", name = "media3-datasource-okhttp", version.ref = "androidxMedia3" }
 androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "androidxMedia3" }
 androidx-multidex = { group = "androidx.multidex", name = "multidex", version.ref = "androidxMultidex" }
-androidx-percentlayout = { group = "androidx.percentlayout", name = "percentlayout", version.ref = "androidxPercentlayout" }
 androidx-preference = { group = "androidx.preference", name = "preference", version.ref = "androidxPreference" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidxPreference" }
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "androidxRecyclerview" }


### PR DESCRIPTION
## Summary

Follow-up cleanup after [PR #160](https://github.com/yukuku/androidbible/pull/160) (GotoActivity Compose port) — the port deleted the consumers of these resources but couldn't tell the build system / resource files were orphaned.

- **Drop `androidx.percentlayout` dep** — `fragment_goto_dialer.xml` was the only consumer of `PercentFrameLayout`. Removed `implementation(libs.androidx.percentlayout)` from `Alkitab/build.gradle.kts`, plus the `androidxPercentlayout` version key and library entry in `gradle/libs.versions.toml`. Confirmed no remaining `PercentLayout|percentlayout` references in `Alkitab/src`.
- **Drop `KeypadButton` style + `keypad_text_color` color** — both were only used by the deleted dialer XML. The Compose port styles its keypad inline.
- **String audit** — every string referenced by the deleted fragments/layouts/menu (`pasal_sebelumangka`, `ayat_sebelumangka`, `desc_backspace`, `jump_to_prompt`, `alamat_tidak_sah_alamat`, `pref_alphabeticBookSort_key`, `menuAskForVerse`, `goto_tab_*_label`, `goto_button_history_tip`) is still consumed by either the new Compose port or unrelated callers. No orphans, no string deletions.
- **Mark `docs/tech-debt.md` REM-22 percentlayout entry resolved.**

## Test plan

- [x] `./gradlew :Alkitab:assemblePlainDebug :Alkitab:testPlainDebugUnitTest` → `BUILD SUCCESSFUL`, all 351 tasks executed, all unit tests green.
- [x] Confirmed no remaining references to `PercentLayout`, `KeypadButton`, or `keypad_text_color` in `Alkitab/src` after the cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)