### PR TITLE
refactor: extract IsiActivity gesture handling into ReaderGestureHandler (REM-06)

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -109,6 +109,9 @@ import yuku.alkitab.base.widget.LabeledSplitHandleButton
 import yuku.alkitab.base.widget.LeftDrawer
 import yuku.alkitab.base.widget.MaterialDialogAdapterHelper
 import yuku.alkitab.base.widget.ParallelClickData
+import yuku.alkitab.base.widget.ReaderGestureActions
+import yuku.alkitab.base.widget.ReaderGestureHandler
+import yuku.alkitab.base.widget.ReaderGestureHost
 import yuku.alkitab.base.widget.ReferenceParallelClickData
 import yuku.alkitab.base.widget.SplitHandleButton
 import yuku.alkitab.base.widget.TextAppearancePanel
@@ -131,7 +134,7 @@ private const val TAG = "IsiActivity"
 private const val EXTRA_verseUrl = "verseUrl"
 private const val INSTANCE_STATE_ari = "ari"
 
-class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseActionModeHost, VerseActionModeActions {
+class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseActionModeHost, VerseActionModeActions, ReaderGestureHost, ReaderGestureActions {
     override var uncheckVersesWhenActionModeDestroyed = true
     var needsRestart = false // whether this activity needs to be restarted
 
@@ -165,104 +168,22 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     override fun uncheckAllVersesSplit0() { lsSplit0.uncheckAllVerses(true) }
     override fun onActionModeDestroyed() { actionMode = null }
 
-    private val bGoto_floaterDrag = object : GotoButton.FloaterDragListener {
-        val floaterLocationOnScreen = intArrayOf(0, 0)
-
-        override fun onFloaterDragStart(screenX: Float, screenY: Float) {
-            floater.show(activeSplit0.book.bookId, chapter_1)
-            floater.onDragStart(activeSplit0.version.consecutiveBooks)
-        }
-
-        override fun onFloaterDragMove(screenX: Float, screenY: Float) {
-            floater.getLocationOnScreen(floaterLocationOnScreen)
-            floater.onDragMove(screenX - floaterLocationOnScreen[0], screenY - floaterLocationOnScreen[1])
-        }
-
-        override fun onFloaterDragComplete(screenX: Float, screenY: Float) {
-            floater.hide()
-            floater.onDragComplete(screenX - floaterLocationOnScreen[0], screenY - floaterLocationOnScreen[1])
-        }
+    // --- ReaderGestureActions overrides (state is read via ReaderGestureHost below) ---
+    override fun onFloaterAriSelected(ari: Int) = jumpToAri(ari)
+    override fun goToPreviousChapter() = bLeft_click()
+    override fun goToNextChapter() = bRight_click()
+    override fun setFullScreenWithDrawerHandle(yes: Boolean) {
+        setFullScreen(yes)
+        leftDrawer.handle.setFullScreen(yes)
     }
 
-    private val floater_listener = Floater.Listener { ari ->
-        jumpToAri(ari)
-    }
+    // --- ReaderGestureHost overrides ---
+    // `floater` and `textAppearancePanel` are existing fields, marked with `override`
+    // at their declarations below. The two resource-derived values are computed here.
+    override val gestureDisplayDensity: Float get() = resources.displayMetrics.density
+    override val defaultUkuranHuruf2: Float get() = resources.getInteger(R.integer.pref_ukuranHuruf2_default).toFloat()
 
-    private val splitRoot_listener = object : TwofingerLinearLayout.Listener {
-        var startFontSize = 0f
-        var startDx = Float.MIN_VALUE
-        var chapterSwipeCellWidth = 0f // initted later
-        var moreSwipeYAllowed = true // to prevent setting and unsetting fullscreen many times within one gesture
-
-        override fun onOnefingerLeft() {
-            bRight_click()
-        }
-
-        override fun onOnefingerRight() {
-            bLeft_click()
-        }
-
-        override fun onTwofingerStart() {
-            chapterSwipeCellWidth = 24f * resources.displayMetrics.density
-            startFontSize = Preferences.getFloat(Prefkey.ukuranHuruf2, resources.getInteger(R.integer.pref_ukuranHuruf2_default).toFloat())
-        }
-
-        override fun onTwofingerScale(scale: Float) {
-            var nowFontSize = startFontSize * scale
-
-            if (nowFontSize < 2f) nowFontSize = 2f
-            if (nowFontSize > 42f) nowFontSize = 42f
-
-            Preferences.setFloat(Prefkey.ukuranHuruf2, nowFontSize)
-
-            applyPreferences()
-
-            textAppearancePanel?.displayValues()
-        }
-
-        override fun onTwofingerDragX(dx: Float) {
-            if (startDx == Float.MIN_VALUE) { // just started
-                startDx = dx
-
-                if (dx < 0) {
-                    bRight_click()
-                } else {
-                    bLeft_click()
-                }
-            } else { // more
-                // more to the left
-                while (dx < startDx - chapterSwipeCellWidth) {
-                    startDx -= chapterSwipeCellWidth
-                    bRight_click()
-                }
-
-                while (dx > startDx + chapterSwipeCellWidth) {
-                    startDx += chapterSwipeCellWidth
-                    bLeft_click()
-                }
-            }
-        }
-
-        override fun onTwofingerDragY(dy: Float) {
-            if (!moreSwipeYAllowed) return
-
-            if (dy < 0) {
-                setFullScreen(true)
-                leftDrawer.handle.setFullScreen(true)
-            } else {
-                setFullScreen(false)
-                leftDrawer.handle.setFullScreen(false)
-            }
-
-            moreSwipeYAllowed = false
-        }
-
-        override fun onTwofingerEnd(mode: TwofingerLinearLayout.Mode?) {
-            startFontSize = 0f
-            startDx = Float.MIN_VALUE
-            moreSwipeYAllowed = true
-        }
-    }
+    private val gestureHandler by lazy { ReaderGestureHandler(this, this) }
 
     private lateinit var drawerLayout: DrawerLayout
     lateinit var leftDrawer: LeftDrawer.Text
@@ -279,7 +200,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     private lateinit var bLeft: ImageButton
     private lateinit var bRight: ImageButton
     private lateinit var bVersion: TextView
-    lateinit var floater: Floater
+    override lateinit var floater: Floater
     private lateinit var backForwardListController: BackForwardListController<ImageButton, ImageButton>
     private var fullscreenReferenceToast: Toast? = null
 
@@ -314,7 +235,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
     var actionMode: ActionMode? = null
     private var dictionaryMode = false
-    var textAppearancePanel: TextAppearancePanel? = null
+    override var textAppearancePanel: TextAppearancePanel? = null
 
     /**
      * The following "esvsbasal" thing is a personal thing by yuku that doesn't matter to anyone else.
@@ -648,20 +569,20 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
         updateToolbarLocation()
 
-        splitRoot.setListener(splitRoot_listener)
+        splitRoot.setListener(gestureHandler)
 
         bGoto.setOnClickListener { bGoto_click() }
         bGoto.setOnLongClickListener {
             bGoto_longClick()
             true
         }
-        bGoto.setFloaterDragListener(bGoto_floaterDrag)
+        bGoto.setFloaterDragListener(gestureHandler)
 
         bLeft.setOnClickListener { bLeft_click() }
         bRight.setOnClickListener { bRight_click() }
         bVersion.setOnClickListener { openVersionsDialog() }
 
-        floater.setListener(floater_listener)
+        floater.setListener(gestureHandler)
 
         // listeners
         lsSplit0 = VersesControllerImpl(
@@ -1258,7 +1179,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
     }
 
-    fun applyPreferences() {
+    override fun applyPreferences() {
         // make sure S applied variables are set first
         S.recalculateAppliedValuesBasedOnPreferences()
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureActions.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureActions.kt
@@ -1,0 +1,27 @@
+package yuku.alkitab.base.widget
+
+/**
+ * Write-side surface that [ReaderGestureHandler] invokes to trigger Activity
+ * operations in response to gestures.
+ */
+interface ReaderGestureActions {
+    /** Called when the floater (goto-button drag) drops on a book/chapter; jump there. */
+    fun onFloaterAriSelected(ari: Int)
+
+    /** Move to the previous chapter (corresponds to the activity's `bLeft_click`). */
+    fun goToPreviousChapter()
+
+    /** Move to the next chapter (corresponds to the activity's `bRight_click`). */
+    fun goToNextChapter()
+
+    /** Re-apply preferences after the font-size preference is changed via pinch zoom. */
+    fun applyPreferences()
+
+    /**
+     * Toggle fullscreen reading mode AND flip the left-drawer handle's
+     * fullscreen state. The original gesture code called both setters together
+     * (the system fullscreen on the activity plus a UI flag on the drawer
+     * handle), so they stay paired here under a single action.
+     */
+    fun setFullScreenWithDrawerHandle(yes: Boolean)
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHandler.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHandler.kt
@@ -1,0 +1,124 @@
+package yuku.alkitab.base.widget
+
+import yuku.afw.storage.Preferences
+import yuku.alkitab.base.storage.Prefkey
+
+/**
+ * Reader gesture handling extracted from `IsiActivity` — see REM-06 in
+ * docs/tech-debt-remediation.md.
+ *
+ * Bundles the three listener interfaces that the reader screen wires up to
+ * its layout: [TwofingerLinearLayout.Listener] (split-root pinch + swipe),
+ * [GotoButton.FloaterDragListener] (drag from the goto button to drop a
+ * floating book/chapter picker), and [Floater.Listener] (final drop ari).
+ *
+ * The handler keeps no Activity references: it reads state through [host]
+ * and triggers Activity operations through [actions].
+ */
+class ReaderGestureHandler(
+    private val host: ReaderGestureHost,
+    private val actions: ReaderGestureActions,
+) : TwofingerLinearLayout.Listener, GotoButton.FloaterDragListener, Floater.Listener {
+
+    // --- GotoButton.FloaterDragListener (drag-from-goto to drop a picker) ---
+
+    private val floaterLocationOnScreen = intArrayOf(0, 0)
+
+    override fun onFloaterDragStart(screenX: Float, screenY: Float) {
+        val floater = host.floater
+        floater.show(host.activeSplit0Book.bookId, host.chapter_1)
+        floater.onDragStart(host.activeSplit0Version.consecutiveBooks)
+    }
+
+    override fun onFloaterDragMove(screenX: Float, screenY: Float) {
+        val floater = host.floater
+        floater.getLocationOnScreen(floaterLocationOnScreen)
+        floater.onDragMove(screenX - floaterLocationOnScreen[0], screenY - floaterLocationOnScreen[1])
+    }
+
+    override fun onFloaterDragComplete(screenX: Float, screenY: Float) {
+        val floater = host.floater
+        floater.hide()
+        floater.onDragComplete(screenX - floaterLocationOnScreen[0], screenY - floaterLocationOnScreen[1])
+    }
+
+    // --- Floater.Listener (selected ari from the floater) ---
+
+    override fun onSelectComplete(ari: Int) {
+        actions.onFloaterAriSelected(ari)
+    }
+
+    // --- TwofingerLinearLayout.Listener (split-root pinch/swipe gestures) ---
+
+    private var startFontSize = 0f
+    private var startDx = Float.MIN_VALUE
+    private var chapterSwipeCellWidth = 0f // initted in onTwofingerStart
+    private var moreSwipeYAllowed = true // to prevent setting and unsetting fullscreen many times within one gesture
+
+    override fun onOnefingerLeft() {
+        actions.goToNextChapter()
+    }
+
+    override fun onOnefingerRight() {
+        actions.goToPreviousChapter()
+    }
+
+    override fun onTwofingerStart() {
+        chapterSwipeCellWidth = 24f * host.gestureDisplayDensity
+        startFontSize = Preferences.getFloat(Prefkey.ukuranHuruf2, host.defaultUkuranHuruf2)
+    }
+
+    override fun onTwofingerScale(scale: Float) {
+        var nowFontSize = startFontSize * scale
+
+        if (nowFontSize < 2f) nowFontSize = 2f
+        if (nowFontSize > 42f) nowFontSize = 42f
+
+        Preferences.setFloat(Prefkey.ukuranHuruf2, nowFontSize)
+
+        actions.applyPreferences()
+
+        host.textAppearancePanel?.displayValues()
+    }
+
+    override fun onTwofingerDragX(dx: Float) {
+        if (startDx == Float.MIN_VALUE) { // just started
+            startDx = dx
+
+            if (dx < 0) {
+                actions.goToNextChapter()
+            } else {
+                actions.goToPreviousChapter()
+            }
+        } else { // more
+            // more to the left
+            while (dx < startDx - chapterSwipeCellWidth) {
+                startDx -= chapterSwipeCellWidth
+                actions.goToNextChapter()
+            }
+
+            while (dx > startDx + chapterSwipeCellWidth) {
+                startDx += chapterSwipeCellWidth
+                actions.goToPreviousChapter()
+            }
+        }
+    }
+
+    override fun onTwofingerDragY(dy: Float) {
+        if (!moreSwipeYAllowed) return
+
+        if (dy < 0) {
+            actions.setFullScreenWithDrawerHandle(true)
+        } else {
+            actions.setFullScreenWithDrawerHandle(false)
+        }
+
+        moreSwipeYAllowed = false
+    }
+
+    override fun onTwofingerEnd(mode: TwofingerLinearLayout.Mode?) {
+        startFontSize = 0f
+        startDx = Float.MIN_VALUE
+        moreSwipeYAllowed = true
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHost.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHost.kt
@@ -1,0 +1,38 @@
+package yuku.alkitab.base.widget
+
+import yuku.alkitab.model.Book
+import yuku.alkitab.model.Version
+
+/**
+ * Read-only state surface that [ReaderGestureHandler] reads from to drive
+ * reader gestures (split-pane swipe, pinch zoom, single-finger chapter swipe,
+ * two-finger fullscreen drag, and the goto-button floater drag).
+ * Implemented by the hosting Activity.
+ */
+interface ReaderGestureHost {
+    val chapter_1: Int
+    val activeSplit0Book: Book
+    val activeSplit0Version: Version
+
+    /** The goto-button floater overlay; the gesture handler drives its drag lifecycle. */
+    val floater: Floater
+
+    /**
+     * The "Aa" text-appearance panel, when open. The gesture handler refreshes
+     * its displayed font-size value after a pinch-zoom updates the preference.
+     */
+    val textAppearancePanel: TextAppearancePanel?
+
+    /**
+     * Display density in `dp -> px` units. Used to size the cell width for
+     * two-finger horizontal chapter-swipe gestures.
+     */
+    val gestureDisplayDensity: Float
+
+    /**
+     * Default value of the `ukuranHuruf2` (font size) preference, resolved
+     * from `R.integer.pref_ukuranHuruf2_default`. Used as the fallback when
+     * a pinch-zoom starts before the user has ever changed the size.
+     */
+    val defaultUkuranHuruf2: Float
+}

--- a/docs/tech-debt-remediation.md
+++ b/docs/tech-debt-remediation.md
@@ -118,18 +118,29 @@ Coroutines and `lifecycleScope` were already on the classpath transitively throu
 
 ## Phase 2: Architecture Improvements (BRICE 3.0–3.9)
 
-### REM-06: Extract IsiActivity Gesture Handling
+### REM-06: Extract IsiActivity Gesture Handling ✅ COMPLETED
 **Addresses:** TD-01 (gesture cluster)  
 **Module:** Main reader  
 **BRICE:** B=4 R=3 I=3 C=3 E=4 → **3.4**
 
-**Steps:**
-1. Create `ReaderGestureHandler.kt` implementing `TwofingerLinearLayout.Listener`
-2. Move the `splitRoot_listener` object (lines 163-237 in `IsiActivity.kt`) and the `bGoto_floaterDrag` / `floater_listener` callbacks (lines 140-161) into `ReaderGestureHandler` (~98 lines of gesture code total)
-3. Pass required callbacks as constructor parameters: `onChapterChange`, `onFontSizeChange`, `onFullscreenToggle`
-4. In `IsiActivity`, instantiate `ReaderGestureHandler` and delegate the listener interface
+**What was done:**
+1. ✅ Created `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHandler.kt` (~125 lines). The class implements **three** listener interfaces in one place: `TwofingerLinearLayout.Listener` (split-root pinch + swipe), `GotoButton.FloaterDragListener` (drag-from-goto-button), and `Floater.Listener` (final ari selection).
+2. ✅ Moved the three inline lambda objects out of `IsiActivity.kt`: the `splitRoot_listener` (75 lines, two-finger pinch/scale/dragX/dragY/end + one-finger left/right), `bGoto_floaterDrag` (18 lines, floater drag-start/move/complete), and `floater_listener` (3 lines, ari selection).
+3. ✅ Defined two interfaces following the REM-07 pattern: `ReaderGestureHost.kt` (read-only state — `chapter_1`, `activeSplit0Book`, `activeSplit0Version`, `floater`, `textAppearancePanel`, plus pre-computed `gestureDisplayDensity` and `defaultUkuranHuruf2` to avoid forcing the handler to hold a `Resources` reference) and `ReaderGestureActions.kt` (write-side triggers — `onFloaterAriSelected`, `goToPreviousChapter`, `goToNextChapter`, `applyPreferences`, `setFullScreenWithDrawerHandle`).
+4. ✅ `IsiActivity` now implements both interfaces, holds a `gestureHandler` lazy field, and wires the handler into `splitRoot.setListener`, `bGoto.setFloaterDragListener`, and `floater.setListener` (was previously three different objects).
+5. ✅ Behavior preserved verbatim: split-pane drag, pinch zoom (with the 2f–42f clamp), one-finger left/right chapter swipe, two-finger horizontal drag for multi-chapter skip, two-finger vertical drag toggling fullscreen (paired with `leftDrawer.handle.setFullScreen` under a single new action). Gesture state (`startFontSize`, `startDx`, `moreSwipeYAllowed`, `chapterSwipeCellWidth`, `floaterLocationOnScreen`) now lives on the handler instead of inline objects.
 
-**Difficulty:** Medium (4-6 hours). Risk: gesture state depends on Activity fields (`chapter_1`, `unchunkedFontSizeDp`).
+**Result:** `IsiActivity.kt` shrank from 2452 → 2371 lines (−81 lines). Gesture-state fields and 96 lines of listener code are gone from the activity; 13 lines of host/actions implementations remain as the seam between the activity and the new handler.
+
+**What stayed in `IsiActivity`:** the gesture-triggered Activity methods themselves (`bLeft_click`, `bRight_click`, `jumpToAri`, `applyPreferences`, `setFullScreen`) and the existing `leftDrawer.handle.setFullScreen` follow-up call — all wrapped in thin action overrides.
+
+**Files touched:**
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHandler.kt` (new, 125 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHost.kt` (new, 38 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureActions.kt` (new, 27 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt` (modified: −81 lines, class signature gains two interfaces, four import lines added)
+
+**Difficulty:** Medium (actually 2-3 hours, came in well under the 4-6 hour estimate).
 
 ---
 
@@ -185,7 +196,7 @@ Coroutines and `lifecycleScope` were already on the classpath transitively throu
 3. `IsiActivity` observes StateFlows and updates UI
 4. Navigation history moves to ViewModel (survives rotation)
 
-**Prerequisite:** REM-06, REM-07, REM-08 should be done first to reduce IsiActivity size before extracting ViewModel.
+**Prerequisite:** ~~REM-06~~✅, ~~REM-07~~✅, REM-08 should be done first to reduce IsiActivity size before extracting ViewModel.
 
 **Difficulty:** Hard (2-3 days). Risk: extensive refactoring of the largest file in the codebase.
 
@@ -668,7 +679,7 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 | REM-05 | ~~Fix DevotionDownloader threading~~ ✅ | **4.0** | 1 |
 | REM-03 | ~~Replace LocalBroadcastManager~~ ✅ | **3.8** | 1 |
 | REM-23 | ~~Port ybuild.sh to Gradle~~ ✅ | **3.8** | 2 |
-| REM-06 | Extract IsiActivity gestures | **3.4** | 2 |
+| REM-06 | ~~Extract IsiActivity gestures~~ ✅ | **3.4** | 2 |
 | REM-07 | ~~Extract IsiActivity action mode~~ ✅ | **3.4** | 2 |
 | REM-09 | Introduce ViewModel | **3.4** | 2 |
 | REM-10 | Room migration (Markers) | **3.4** | 2 |
@@ -690,7 +701,7 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 
 **Sprint 1 (1 week):** ~~REM-01~~✅, ~~REM-02~~✅, ~~REM-04~~✅, ~~REM-05~~✅ — quick safety fixes (all done)  
 **Sprint 2 (1 week):** ~~REM-03~~✅ — LocalBroadcastManager removal (done)  
-**Sprint 3 (2 weeks):** ~~REM-07~~✅, REM-06, REM-08 — IsiActivity decomposition (REM-07 done)  
+**Sprint 3 (2 weeks):** ~~REM-07~~✅, ~~REM-06~~✅, REM-08 — IsiActivity decomposition (REM-06, REM-07 done)  
 **Sprint 4 (1 week):** ~~REM-12~~✅, ~~REM-14~~✅ — deprecated library replacements (done)  
 **Sprint 5 (2 weeks):** REM-10, REM-11 — Room migration for core tables  
 **Sprint 6 (2 weeks):** REM-09, ~~REM-18a-e~~✅ — ViewModel + test coverage (REM-18a/b/c/d/e done)  

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -1,19 +1,19 @@
 # Tech Debt, Improvements & Critiques
 
-## TD-01: IsiActivity God Class (~2320 lines)
+## TD-01: IsiActivity God Class (~2371 lines)
 
 **File:** `Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt`
 
-The main Bible reader activity is a monolithic class containing many inline lambda callbacks, ~2320 lines of mixed concerns (down from 2897 after REM-07 extracted action mode). Specific clusters that violate single-responsibility:
+The main Bible reader activity is a monolithic class containing many inline lambda callbacks, ~2371 lines of mixed concerns (down from 2897 after REM-07 extracted action mode, then back up slightly to 2452 with the audio-bible M1–M4 additions, now down to 2371 after REM-06 extracted gesture handling). Specific clusters that violate single-responsibility:
 
-- **Gesture handling (lines 143–370):** `onFloaterDragStart/Move/Complete`, `onOnefingerLeft/Right`, `onTwofingerStart/Scale/DragX/DragY/End` — all inline lambdas that implement `TwofingerLinearLayout.Listener`. This is ~230 lines of touch gesture processing embedded in the Activity.
+- **~~Gesture handling~~** ✅ **Extracted (REM-06):** The three gesture lambdas — `splitRoot_listener` (`TwofingerLinearLayout.Listener` for pinch zoom + one/two-finger swipes), `bGoto_floaterDrag` (`GotoButton.FloaterDragListener`), and `floater_listener` (`Floater.Listener`) — have been moved to `ReaderGestureHandler.kt` behind two interfaces (`ReaderGestureHost`, `ReaderGestureActions`). The activity now wires a single `gestureHandler` lazy field into all three setListener call sites. Gesture-local state (`startFontSize`, `startDx`, `moreSwipeYAllowed`, `chapterSwipeCellWidth`, `floaterLocationOnScreen`) lives on the handler instead of in inline objects.
 - **~~Action mode~~** ✅ **Extracted (REM-07):** The ~500-line `actionMode_callback` object has been moved to `VerseActionModeController.kt` behind two interfaces (`VerseActionModeHost`, `VerseActionModeActions`). Pure text-building logic is in `VerseTextFormatter` (no Android deps). `RibkaEligibility` is a top-level file. 26 unit tests added.
 - **Broadcast receivers (lines 451–519):** Two anonymous `BroadcastReceiver` instances registered inline, one for verse attribute changes and one for version changes.
 - **Verse selection listeners (lines 463–525):** Two `SelectedVersesListener` implementations (`lsSplit0_selectedVerses`, `lsSplit1_selectedVerses`) with partially duplicated logic.
 - **Split view management:** `openSplitDisplay()`, `closeSplitDisplay()`, `displaySplitFollowingMaster()`, `loadSplitVersion()` scattered across the file.
 - **Navigation history:** `BackForwardListController` usage, `jumpToAri()`, `jumpTo(reference)`, `History` tracking.
 
-**Impact:** Any change to one concern risks breaking unrelated functionality. Testing individual behaviors requires instantiating the entire Activity. New developers face a ~2320-line class with no clear entry point.
+**Impact:** Any change to one concern risks breaking unrelated functionality. Testing individual behaviors requires instantiating the entire Activity. New developers face a ~2371-line class with no clear entry point.
 
 ---
 


### PR DESCRIPTION
## Summary

Extracts the three inline gesture-listener objects out of `IsiActivity` into a new `ReaderGestureHandler` class, following the Host/Actions interface pattern established by REM-07's `VerseActionModeController`. Implements REM-06 from `docs/tech-debt-remediation.md`.

The handler combines three listeners that the reader screen wires up to its layout — `TwofingerLinearLayout.Listener` (split-root pinch + swipe), `GotoButton.FloaterDragListener` (drag-from-goto), and `Floater.Listener` (final ari selection) — and reads state through `ReaderGestureHost` / triggers actions through `ReaderGestureActions`. The handler holds no Activity reference.

- New files (3, in `Alkitab/src/main/java/yuku/alkitab/base/widget/`): `ReaderGestureHandler.kt` (125 lines), `ReaderGestureHost.kt` (38 lines), `ReaderGestureActions.kt` (27 lines).
- `IsiActivity.kt`: −81 net lines (2452 → 2371). Gesture-local state (`startFontSize`, `startDx`, `moreSwipeYAllowed`, `chapterSwipeCellWidth`, `floaterLocationOnScreen`) moves to the handler; 13 lines of host/actions overrides remain as the seam.

## Behavior preservation

All gesture behavior preserved verbatim:
- Pinch zoom (2f–42f clamp) → `Preferences.setFloat` + `applyPreferences()` + `textAppearancePanel?.displayValues()`
- One-finger left/right swipe → next/prev chapter
- Two-finger horizontal drag → multi-chapter skip with 24dp cell width
- Two-finger vertical drag → fullscreen toggle (still paired with `leftDrawer.handle.setFullScreen` under the new single `setFullScreenWithDrawerHandle` action, preserving the original pairing in the gesture path)
- Goto-button drag → opens the floater, hit-tests in floater-local coords, drops to jump to ari

## Test plan

- [x] `./gradlew assemblePlainDebug` passes
- [x] `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` passes (all existing unit tests green; no new tests required — no characterization tests for gestures pre-existed)
- [x] Manually verified on a Pixel 7 Pro emulator:
  - chapter prev/next buttons route through new actions
  - one-finger left swipe → next chapter
  - one-finger right swipe → prev chapter
  - drag from "Kejadian 5" button → floater opened → drop landed on Ezra 1 (proves bGoto floater chain + `onFloaterAriSelected` → `jumpToAri`)
- [ ] Two-finger gestures (pinch zoom, fullscreen toggle, multi-chapter skip) — not testable through the available emulator tooling; behavior is preserved by routing the same code through the new actions/host

## Docs

- `docs/tech-debt-remediation.md` REM-06 marked ✅ COMPLETED with a "What was done" block (files, line counts, what stayed in IsiActivity). Summary table and Sprint 3 plan + REM-09 prerequisite updated.
- `docs/tech-debt.md` TD-01 gesture-cluster bullet flipped to ✅ Extracted (REM-06); IsiActivity line count refreshed.