### PR TITLE
audio-bible: chapter-follows-reader + split-source picker + scoped highlight

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -808,18 +808,8 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             }
         }
         lifecycleScope.launch {
-            // Keep this loop tight: the controller emits at the service's poll
-            // rate (every 100 ms during playback). Menu refresh is driven by
-            // the `audioBarVisibilityChanged` callback in audioBarHost —
-            // calling invalidateOptionsMenu() here would force the toolbar
-            // to rebuild every tick.
-            //
-            // Highlight routing (PRD §4.5): the verse highlight lights up on
-            // each pane whose version matches the one driving audio — both
-            // panes when the user has split view on with the same version on
-            // each side, just one pane in the typical mixed-version case,
-            // none when neither pane matches (e.g. the user changed active
-            // version mid-playback without dismissing the bar).
+            // 100 ms tick rate while playing — avoid invalidateOptionsMenu() here;
+            // menu refreshes flow through `audioBarVisibilityChanged` instead.
             audioBinder.uiState.collect { state ->
                 val playing = state.playingVersionId
                 val split0Match = playing != null && playing == activeSplit0.versionId
@@ -877,34 +867,34 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             activeSplit1?.versionId,
         )
 
-        override fun audioAvailableSources(): List<AudioSourceOption> {
-            val sources = mutableListOf<AudioSourceOption>()
+        override fun audioAvailableSources(): List<AudioSourceOption> = buildList {
             if (AudioCatalogRepository.isAudioAvailable(activeSplit0.versionId)) {
-                sources += AudioSourceOption(activeSplit0.versionId, activeSplit0.version.shortName)
+                add(AudioSourceOption(activeSplit0.versionId, activeSplit0.version.shortName))
             }
-            val s1 = activeSplit1
-            if (s1 != null && AudioCatalogRepository.isAudioAvailable(s1.versionId)) {
-                sources += AudioSourceOption(s1.versionId, s1.version.shortName)
+            activeSplit1?.let { s1 ->
+                if (AudioCatalogRepository.isAudioAvailable(s1.versionId)) {
+                    add(AudioSourceOption(s1.versionId, s1.version.shortName))
+                }
             }
-            return sources
         }
 
         override fun audioBookInVersion(versionId: String, bookId: Int): Book? {
-            return when (versionId) {
-                activeSplit0.versionId -> activeSplit0.version.getBook(bookId)
-                activeSplit1?.versionId -> activeSplit1?.version?.getBook(bookId)
+            val s1 = activeSplit1
+            return when {
+                versionId == activeSplit0.versionId -> activeSplit0.version.getBook(bookId)
+                s1 != null && versionId == s1.versionId -> s1.version.getBook(bookId)
                 else -> null
             }
         }
 
         override fun audioNeighborChapter(versionId: String, direction: Int): Pair<Book, Int>? {
-            val version = when (versionId) {
-                activeSplit0.versionId -> activeSplit0.version
-                activeSplit1?.versionId -> activeSplit1?.version ?: return null
+            val s1 = activeSplit1
+            val version = when {
+                versionId == activeSplit0.versionId -> activeSplit0.version
+                s1 != null && versionId == s1.versionId -> s1.version
                 else -> return null
             }
-            // The reader's chapter follows split0 even when audio runs on
-            // split1, so resolve the neighbor against the reader's bookId.
+            // chapter_1 belongs to split0's reader pane; resolve neighbor against that book id even when audio runs on split1.
             return BibleNeighborResolver.neighbor(
                 version,
                 activeSplit0.book.bookId,
@@ -1823,11 +1813,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             finishDictionaryMode()
         }
 
-        // Audio bar (M3) — if a session is active, swap the player over to
-        // the new chapter so the audio follows the reader. The controller
-        // no-ops when the chosen audio version was the one that drove this
-        // very `display()` call (service-initiated chapter change, lock
-        // screen / Bluetooth / auto-advance), preventing a loadChapter loop.
         audioBinder.onChapterChanged()
 
         return Ari.encode(0, available_chapter_1, available_verse_1)

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -87,6 +87,7 @@ import yuku.alkitab.base.audio.AudioBarController
 import yuku.alkitab.base.audio.AudioCatalogRepository
 import yuku.alkitab.base.audio.BibleNeighborResolver
 import yuku.alkitab.base.audio.ui.AudioHighlightColor
+import yuku.alkitab.base.audio.ui.AudioSourceOption
 import yuku.alkitab.base.util.Jumper
 import yuku.alkitab.base.util.LidToAri
 import yuku.alkitab.base.util.OtherAppIntegration
@@ -813,14 +814,18 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             // calling invalidateOptionsMenu() here would force the toolbar
             // to rebuild every tick.
             //
-            // Highlight is applied to the primary split (`lsSplit0`) only,
-            // matching PRD §4.5 ("Highlight applies only to the chosen side;
-            // the other split's rows show no audio highlight, even when the
-            // verse numbers coincide."). M5 will add the split-source picker
-            // dialog (PRD §4.5) and route the highlight to whichever side the
-            // user selects; for M3 we always pick the primary.
+            // Highlight routing (PRD §4.5): the verse highlight lights up on
+            // each pane whose version matches the one driving audio — both
+            // panes when the user has split view on with the same version on
+            // each side, just one pane in the typical mixed-version case,
+            // none when neither pane matches (e.g. the user changed active
+            // version mid-playback without dismissing the bar).
             audioBinder.uiState.collect { state ->
-                applyAudioHighlightTo(lsSplit0, state.verse_1)
+                val playing = state.playingVersionId
+                val split0Match = playing != null && playing == activeSplit0.versionId
+                val split1Match = playing != null && playing == activeSplit1?.versionId
+                applyAudioHighlightTo(lsSplit0, if (split0Match) state.verse_1 else 0)
+                applyAudioHighlightTo(lsSplit1, if (split1Match) state.verse_1 else 0)
             }
         }
         lifecycleScope.launch {
@@ -867,23 +872,46 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     private val audioBarHost = object : AudioBarController.Host {
         override fun audioCurrentBook(): Book = activeSplit0.book
         override fun audioCurrentChapter1(): Int = chapter_1
-        override fun audioCurrentVersionId(): String = activeSplit0.versionId
-        override fun audioCurrentVersionShortName(): String = activeSplit0.version.shortName
         override fun audioVisibleVersionIds(): List<String> = listOfNotNull(
             activeSplit0.versionId,
             activeSplit1?.versionId,
         )
 
-        override fun audioNeighborChapter(direction: Int): Pair<Book, Int>? {
+        override fun audioAvailableSources(): List<AudioSourceOption> {
+            val sources = mutableListOf<AudioSourceOption>()
+            if (AudioCatalogRepository.isAudioAvailable(activeSplit0.versionId)) {
+                sources += AudioSourceOption(activeSplit0.versionId, activeSplit0.version.shortName)
+            }
+            val s1 = activeSplit1
+            if (s1 != null && AudioCatalogRepository.isAudioAvailable(s1.versionId)) {
+                sources += AudioSourceOption(s1.versionId, s1.version.shortName)
+            }
+            return sources
+        }
+
+        override fun audioBookInVersion(versionId: String, bookId: Int): Book? {
+            return when (versionId) {
+                activeSplit0.versionId -> activeSplit0.version.getBook(bookId)
+                activeSplit1?.versionId -> activeSplit1?.version?.getBook(bookId)
+                else -> null
+            }
+        }
+
+        override fun audioNeighborChapter(versionId: String, direction: Int): Pair<Book, Int>? {
+            val version = when (versionId) {
+                activeSplit0.versionId -> activeSplit0.version
+                activeSplit1?.versionId -> activeSplit1?.version ?: return null
+                else -> return null
+            }
+            // The reader's chapter follows split0 even when audio runs on
+            // split1, so resolve the neighbor against the reader's bookId.
             return BibleNeighborResolver.neighbor(
-                activeSplit0.version,
+                version,
                 activeSplit0.book.bookId,
                 chapter_1,
                 direction,
             )
         }
-
-        override fun audioVersionBook(bookId: Int): Book? = activeSplit0.version.getBook(bookId)
 
         override fun audioDisplayChapter(book: Book, chapter_1: Int) {
             // Switch book if needed - display() only retargets chapter
@@ -1794,6 +1822,13 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         if (dictionaryMode) {
             finishDictionaryMode()
         }
+
+        // Audio bar (M3) — if a session is active, swap the player over to
+        // the new chapter so the audio follows the reader. The controller
+        // no-ops when the chosen audio version was the one that drove this
+        // very `display()` call (service-initiated chapter change, lock
+        // screen / Bluetooth / auto-advance), preventing a loadChapter loop.
+        audioBinder.onChapterChanged()
 
         return Ari.encode(0, available_chapter_1, available_verse_1)
     }

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
@@ -68,32 +68,13 @@ class AudioBarController(
          */
         fun audioVisibleVersionIds(): List<String>
 
-        /**
-         * Picker options for the source dialog: one entry per *visible* version
-         * that has audio coverage, ordered split0 → split1. Returns one entry
-         * when only one side has audio (no dialog needed, the controller picks
-         * it automatically), two entries when both sides do (dialog shown), or
-         * empty when nothing on screen has audio (the menu icon should already
-         * have been hidden — bail).
-         */
+        /** Visible versions that have audio coverage, ordered split0 → split1. */
         fun audioAvailableSources(): List<AudioSourceOption>
 
-        /**
-         * Resolve a book in [versionId]. Returns `null` if either the version
-         * is not currently visible or that version doesn't include the book —
-         * used both by the chapter-skip path (lock screen) and by the
-         * activity-follows-service projection. Goes via the visible splits so
-         * we never accidentally load a `Version` the user isn't reading.
-         */
+        /** Resolves a book in [versionId]; null if the version isn't visible or doesn't include the book. */
         fun audioBookInVersion(versionId: String, bookId: Int): Book?
 
-        /**
-         * Resolve the chapter that's [direction] away (`-1` previous, `+1`
-         * next) for the version with [versionId]. Returns `null` at Bible
-         * boundaries or when the version isn't currently visible; the
-         * controller uses that to render the chapter-nav button label as
-         * `alpha = 0f` so the bar doesn't reflow.
-         */
+        /** Neighbor chapter in [versionId]; null at Bible boundaries or when [versionId] isn't visible. */
         fun audioNeighborChapter(versionId: String, direction: Int): Pair<Book, Int>?
 
         /** Tell the activity to navigate to [book] / [chapter_1] (the existing `display` flow). */
@@ -152,11 +133,7 @@ class AudioBarController(
     private var lastServiceBookId = -1
     private var lastServiceChapter1 = 0
 
-    /**
-     * The audio source the user picked for this session. Set by
-     * [AudioBarCommand.PickSource] when split view is active, or auto-set in
-     * [show] when only one visible version has audio. Cleared on [hide].
-     */
+    /** The audio source picked for the current session. Cleared on [hide]. */
     private var selectedSource: AudioSourceOption? = null
 
     private val _uiState = MutableStateFlow(AudioBarUiState.HIDDEN)
@@ -242,14 +219,9 @@ class AudioBarController(
     }
 
     /**
-     * Tell `IsiActivity` to refresh whatever it derives from `isAvailable` —
-     * specifically, the toolbar menu visibility. Called by the activity when
-     * the active version changes. Cheap; just nudges the view-state flow so
-     * recomposition picks up new chapter labels too.
-     *
-     * Also stops audio if the version that was driving playback is no longer
-     * visible — otherwise the user would hear an invisible source and the
-     * verse highlight would have nowhere to land.
+     * Called when the active version changes (split toggled, version swapped).
+     * Stops audio if the source we picked is no longer on screen, otherwise
+     * just refreshes the chapter labels.
      */
     fun onActiveVersionChanged() {
         val host = this.host ?: return
@@ -262,12 +234,8 @@ class AudioBarController(
     }
 
     /**
-     * Called by `IsiActivity` after the reader navigates to a new chapter
-     * (swipe, goto, history-back, etc.). When the bar is visible and the
-     * selected audio version contains the new book, swap the service over to
-     * the new chapter so the audio follows the reader. When the new book
-     * doesn't exist in the chosen audio version, dismiss the bar — playing
-     * audio for a chapter the user can't see would be confusing.
+     * Called from `IsiActivity.display()` so the audio follows the reader.
+     * Closes the bar if the new book is not in the selected version.
      */
     fun onChapterChanged() {
         if (!requestedVisible) return
@@ -277,23 +245,18 @@ class AudioBarController(
         val chapter1 = host.audioCurrentChapter1()
         val sourceBook = host.audioBookInVersion(source.versionId, readerBook.bookId)
         if (sourceBook == null) {
-            // Selected audio version doesn't include the new book — bail.
             hide()
             return
         }
         val availableChapter = chapter1.coerceIn(1, sourceBook.chapter_count)
 
-        // No-op if the service is already on that (book, chapter). Compare
-        // against the latch so we also short-circuit when the reader follows
-        // a service-initiated chapter change (lock screen / Bluetooth).
         if (sourceBook.bookId == lastServiceBookId && availableChapter == lastServiceChapter1) {
             recomputeChapterLabels(host)
             return
         }
 
-        // Bump the latch *before* calling loadChapter so projectToUi treats
-        // the resulting state as activity-driven and skips the reverse
-        // host.audioDisplayChapter call.
+        // Bump the latch before loadChapter so projectToUi treats the resulting
+        // state as activity-driven and skips the reverse host.audioDisplayChapter call.
         lastServiceBookId = sourceBook.bookId
         lastServiceChapter1 = availableChapter
 
@@ -304,13 +267,7 @@ class AudioBarController(
             displayTitle = "${sourceBook.shortName} $availableChapter",
             displaySubtitle = source.shortName,
         )
-        service?.loadChapter(request)
-            ?: run {
-                // Service not bound yet (rare — chapter change before the
-                // first show() resolves the binder). Queue via pendingLoad
-                // so it fires when the binder arrives.
-                pendingLoad = host
-            }
+        service?.loadChapter(request) ?: run { pendingLoad = host }
         recomputeChapterLabels(host)
     }
 
@@ -330,62 +287,39 @@ class AudioBarController(
     fun show() {
         val host = this.host ?: return
         requestedVisible = true
-        // Install the Compose content now (no-op if already installed). The
-        // picker dialog (if shown) lives inside the same composition.
         ensureComposeContent()
 
         val sources = host.audioAvailableSources()
         when (sources.size) {
             0 -> {
-                // Menu icon should have been hidden — getting here means
-                // visibility was stale. No-op rather than throwing.
+                // Should be unreachable — menu icon is hidden when no source has audio.
                 AppLog.w(TAG, "show() called with no audio sources visible")
                 requestedVisible = false
-                return
             }
             1 -> {
-                // Exactly one visible version has audio (single split, or only
-                // one of two splits has audio). Auto-pick — no dialog.
                 selectedSource = sources[0]
                 startSession(host)
             }
             else -> {
-                // Split view + both sides have audio. Show the picker; user
-                // taps one to commit, or cancels to dismiss the bar.
+                // Split view + both sides have audio: show the picker dialog
+                // instead of starting immediately.
                 _uiState.update {
-                    AudioBarUiState.HIDDEN.copy(
-                        visible = false,
-                        pickerOptions = sources,
-                    )
+                    AudioBarUiState.HIDDEN.copy(visible = false, pickerOptions = sources)
                 }
                 host.audioBarVisibilityChanged(true)
             }
         }
     }
 
-    /**
-     * Common path after a source has been chosen (either auto-picked in
-     * [show] or selected from the picker dialog). Binds the service and
-     * issues the first [BibleAudioService.loadChapter].
-     */
+    /** Binds the service and fires the first loadChapter once [selectedSource] is set. */
     private fun startSession(host: Host) {
         ensureBound()
-        // Service may not be connected yet; in that case the loadChapter call
-        // below is queued via service.let, and we'll fire it when the binder
-        // arrives. Either way, mark the UI visible immediately.
         _uiState.update {
-            it.copy(
-                visible = true,
-                preparing = service == null,
-                pickerOptions = null,
-            )
+            it.copy(visible = true, preparing = service == null, pickerOptions = null)
         }
         host.audioBarVisibilityChanged(true)
         val request = buildRequest(host) ?: return
-        service?.loadChapter(request)
-            ?: run {
-                pendingLoad = host
-            }
+        service?.loadChapter(request) ?: run { pendingLoad = host }
     }
 
     fun hide() {
@@ -478,15 +412,7 @@ class AudioBarController(
         }
     }
 
-    /**
-     * Builds an [BibleAudioService.AudioRequest] for the activity's current
-     * chapter resolved against the [selectedSource] version. Returns `null`
-     * (and stops the session) when the selected version doesn't include the
-     * book the user is reading — e.g. an apocryphal/deuterocanonical book
-     * that doesn't exist in the chosen audio version. The caller is expected
-     * to bail rather than load a different version's audio behind the user's
-     * back.
-     */
+    /** Returns null when the selected version doesn't include the reader's current book. */
     private fun buildRequest(host: Host): BibleAudioService.AudioRequest? {
         val source = selectedSource ?: return null
         val readerBook = host.audioCurrentBook()
@@ -565,12 +491,9 @@ class AudioBarController(
             pendingLoad = null
         }
 
-        // Sync the activity to the chapter the service is now playing — but
-        // only when the *service's* chapter has changed (lock-screen skip,
-        // Bluetooth, auto-advance). For activity-driven changes (the user
-        // swiped the reader, see [onChapterChanged]), the latch is bumped
-        // *before* the service emits, so this block stays a no-op for that
-        // path and we don't double-navigate.
+        // Sync the activity to the chapter the service is now playing. Only fires
+        // for service-driven changes (lock screen / Bluetooth / auto-advance);
+        // activity-driven changes from onChapterChanged bump the latch first.
         if (host != null && state.bookId >= 0 &&
             (state.bookId != lastServiceBookId || state.chapter_1 != lastServiceChapter1)
         ) {
@@ -578,13 +501,7 @@ class AudioBarController(
             lastServiceChapter1 = state.chapter_1
             val hostBook = host.audioCurrentBook()
             if (hostBook.bookId != state.bookId || host.audioCurrentChapter1() != state.chapter_1) {
-                // Resolve the new book against whichever visible version
-                // currently includes it — `display(...)` ultimately retargets
-                // split0, but `Book.bookId` is consistent across versions
-                // (it's an Ari book index), so any visible version that
-                // contains the book yields the right Book object.
-                val visible = host.audioVisibleVersionIds()
-                val targetBook = visible
+                val targetBook = host.audioVisibleVersionIds()
                     .firstNotNullOfOrNull { host.audioBookInVersion(it, state.bookId) }
                 if (targetBook != null) {
                     host.audioDisplayChapter(targetBook, state.chapter_1)

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import yuku.alkitab.base.audio.ui.AudioBar
 import yuku.alkitab.base.audio.ui.AudioBarCommand
 import yuku.alkitab.base.audio.ui.AudioBarUiState
+import yuku.alkitab.base.audio.ui.AudioSourceOption
 import yuku.alkitab.base.util.AppLog
 import yuku.alkitab.model.Book
 
@@ -61,12 +62,6 @@ class AudioBarController(
         /** Currently displayed chapter (1-based). */
         fun audioCurrentChapter1(): Int
 
-        /** Version id of the side that drives audio (in M3, always primary). */
-        fun audioCurrentVersionId(): String
-
-        /** Short name of the version driving audio (e.g. "TB"). */
-        fun audioCurrentVersionShortName(): String
-
         /**
          * The list of version ids currently visible in `IsiActivity` (primary,
          * plus the split-view secondary if open). Drives toolbar-icon visibility.
@@ -74,21 +69,32 @@ class AudioBarController(
         fun audioVisibleVersionIds(): List<String>
 
         /**
-         * Resolve the chapter that's [direction] away (`-1` previous, `+1`
-         * next). Returns `null` at Bible boundaries; the controller uses that
-         * to render the chapter-nav button label as `alpha = 0f` so the bar
-         * doesn't reflow.
+         * Picker options for the source dialog: one entry per *visible* version
+         * that has audio coverage, ordered split0 → split1. Returns one entry
+         * when only one side has audio (no dialog needed, the controller picks
+         * it automatically), two entries when both sides do (dialog shown), or
+         * empty when nothing on screen has audio (the menu icon should already
+         * have been hidden — bail).
          */
-        fun audioNeighborChapter(direction: Int): Pair<Book, Int>?
+        fun audioAvailableSources(): List<AudioSourceOption>
 
         /**
-         * Resolve a [Book] by id within the version currently driving audio.
-         * Returns `null` if the version doesn't have that book, in which case
-         * the controller silently skips the activity-side navigation.
-         * Used when the service drives a chapter change (lock-screen prev/
-         * next, Bluetooth) and the activity needs to follow.
+         * Resolve a book in [versionId]. Returns `null` if either the version
+         * is not currently visible or that version doesn't include the book —
+         * used both by the chapter-skip path (lock screen) and by the
+         * activity-follows-service projection. Goes via the visible splits so
+         * we never accidentally load a `Version` the user isn't reading.
          */
-        fun audioVersionBook(bookId: Int): Book?
+        fun audioBookInVersion(versionId: String, bookId: Int): Book?
+
+        /**
+         * Resolve the chapter that's [direction] away (`-1` previous, `+1`
+         * next) for the version with [versionId]. Returns `null` at Bible
+         * boundaries or when the version isn't currently visible; the
+         * controller uses that to render the chapter-nav button label as
+         * `alpha = 0f` so the bar doesn't reflow.
+         */
+        fun audioNeighborChapter(versionId: String, direction: Int): Pair<Book, Int>?
 
         /** Tell the activity to navigate to [book] / [chapter_1] (the existing `display` flow). */
         fun audioDisplayChapter(book: Book, chapter_1: Int)
@@ -145,6 +151,13 @@ class AudioBarController(
      */
     private var lastServiceBookId = -1
     private var lastServiceChapter1 = 0
+
+    /**
+     * The audio source the user picked for this session. Set by
+     * [AudioBarCommand.PickSource] when split view is active, or auto-set in
+     * [show] when only one visible version has audio. Cleared on [hide].
+     */
+    private var selectedSource: AudioSourceOption? = null
 
     private val _uiState = MutableStateFlow(AudioBarUiState.HIDDEN)
     val uiState: StateFlow<AudioBarUiState> = _uiState.asStateFlow()
@@ -233,9 +246,72 @@ class AudioBarController(
      * specifically, the toolbar menu visibility. Called by the activity when
      * the active version changes. Cheap; just nudges the view-state flow so
      * recomposition picks up new chapter labels too.
+     *
+     * Also stops audio if the version that was driving playback is no longer
+     * visible — otherwise the user would hear an invisible source and the
+     * verse highlight would have nowhere to land.
      */
     fun onActiveVersionChanged() {
-        host?.let { recomputeChapterLabels(it) }
+        val host = this.host ?: return
+        val source = selectedSource
+        if (source != null && source.versionId !in host.audioVisibleVersionIds()) {
+            hide()
+            return
+        }
+        recomputeChapterLabels(host)
+    }
+
+    /**
+     * Called by `IsiActivity` after the reader navigates to a new chapter
+     * (swipe, goto, history-back, etc.). When the bar is visible and the
+     * selected audio version contains the new book, swap the service over to
+     * the new chapter so the audio follows the reader. When the new book
+     * doesn't exist in the chosen audio version, dismiss the bar — playing
+     * audio for a chapter the user can't see would be confusing.
+     */
+    fun onChapterChanged() {
+        if (!requestedVisible) return
+        val host = this.host ?: return
+        val source = selectedSource ?: return
+        val readerBook = host.audioCurrentBook()
+        val chapter1 = host.audioCurrentChapter1()
+        val sourceBook = host.audioBookInVersion(source.versionId, readerBook.bookId)
+        if (sourceBook == null) {
+            // Selected audio version doesn't include the new book — bail.
+            hide()
+            return
+        }
+        val availableChapter = chapter1.coerceIn(1, sourceBook.chapter_count)
+
+        // No-op if the service is already on that (book, chapter). Compare
+        // against the latch so we also short-circuit when the reader follows
+        // a service-initiated chapter change (lock screen / Bluetooth).
+        if (sourceBook.bookId == lastServiceBookId && availableChapter == lastServiceChapter1) {
+            recomputeChapterLabels(host)
+            return
+        }
+
+        // Bump the latch *before* calling loadChapter so projectToUi treats
+        // the resulting state as activity-driven and skips the reverse
+        // host.audioDisplayChapter call.
+        lastServiceBookId = sourceBook.bookId
+        lastServiceChapter1 = availableChapter
+
+        val request = BibleAudioService.AudioRequest(
+            versionId = source.versionId,
+            bookId = sourceBook.bookId,
+            chapter_1 = availableChapter,
+            displayTitle = "${sourceBook.shortName} $availableChapter",
+            displaySubtitle = source.shortName,
+        )
+        service?.loadChapter(request)
+            ?: run {
+                // Service not bound yet (rare — chapter change before the
+                // first show() resolves the binder). Queue via pendingLoad
+                // so it fires when the binder arrives.
+                pendingLoad = host
+            }
+        recomputeChapterLabels(host)
     }
 
     /**
@@ -254,15 +330,59 @@ class AudioBarController(
     fun show() {
         val host = this.host ?: return
         requestedVisible = true
-        ensureBound()
-        // Install the Compose content now (no-op if already installed).
+        // Install the Compose content now (no-op if already installed). The
+        // picker dialog (if shown) lives inside the same composition.
         ensureComposeContent()
+
+        val sources = host.audioAvailableSources()
+        when (sources.size) {
+            0 -> {
+                // Menu icon should have been hidden — getting here means
+                // visibility was stale. No-op rather than throwing.
+                AppLog.w(TAG, "show() called with no audio sources visible")
+                requestedVisible = false
+                return
+            }
+            1 -> {
+                // Exactly one visible version has audio (single split, or only
+                // one of two splits has audio). Auto-pick — no dialog.
+                selectedSource = sources[0]
+                startSession(host)
+            }
+            else -> {
+                // Split view + both sides have audio. Show the picker; user
+                // taps one to commit, or cancels to dismiss the bar.
+                _uiState.update {
+                    AudioBarUiState.HIDDEN.copy(
+                        visible = false,
+                        pickerOptions = sources,
+                    )
+                }
+                host.audioBarVisibilityChanged(true)
+            }
+        }
+    }
+
+    /**
+     * Common path after a source has been chosen (either auto-picked in
+     * [show] or selected from the picker dialog). Binds the service and
+     * issues the first [BibleAudioService.loadChapter].
+     */
+    private fun startSession(host: Host) {
+        ensureBound()
         // Service may not be connected yet; in that case the loadChapter call
         // below is queued via service.let, and we'll fire it when the binder
         // arrives. Either way, mark the UI visible immediately.
-        _uiState.update { it.copy(visible = true, preparing = service == null) }
+        _uiState.update {
+            it.copy(
+                visible = true,
+                preparing = service == null,
+                pickerOptions = null,
+            )
+        }
         host.audioBarVisibilityChanged(true)
-        service?.let { svc -> svc.loadChapter(buildRequest(host)) }
+        val request = buildRequest(host) ?: return
+        service?.loadChapter(request)
             ?: run {
                 pendingLoad = host
             }
@@ -271,6 +391,9 @@ class AudioBarController(
     fun hide() {
         requestedVisible = false
         dragging = false
+        selectedSource = null
+        lastServiceBookId = -1
+        lastServiceChapter1 = 0
         service?.stop()
         _uiState.update { AudioBarUiState.HIDDEN }
         host?.audioBarVisibilityChanged(false)
@@ -355,16 +478,28 @@ class AudioBarController(
         }
     }
 
-    private fun buildRequest(host: Host): BibleAudioService.AudioRequest {
-        val book = host.audioCurrentBook()
+    /**
+     * Builds an [BibleAudioService.AudioRequest] for the activity's current
+     * chapter resolved against the [selectedSource] version. Returns `null`
+     * (and stops the session) when the selected version doesn't include the
+     * book the user is reading — e.g. an apocryphal/deuterocanonical book
+     * that doesn't exist in the chosen audio version. The caller is expected
+     * to bail rather than load a different version's audio behind the user's
+     * back.
+     */
+    private fun buildRequest(host: Host): BibleAudioService.AudioRequest? {
+        val source = selectedSource ?: return null
+        val readerBook = host.audioCurrentBook()
         val chapter1 = host.audioCurrentChapter1()
-        val versionShort = host.audioCurrentVersionShortName()
+        val sourceBook = host.audioBookInVersion(source.versionId, readerBook.bookId)
+            ?: return null
+        val availableChapter = chapter1.coerceIn(1, sourceBook.chapter_count)
         return BibleAudioService.AudioRequest(
-            versionId = host.audioCurrentVersionId(),
-            bookId = book.bookId,
-            chapter_1 = chapter1,
-            displayTitle = "${book.shortName} $chapter1",
-            displaySubtitle = versionShort,
+            versionId = source.versionId,
+            bookId = sourceBook.bookId,
+            chapter_1 = availableChapter,
+            displayTitle = "${sourceBook.shortName} $availableChapter",
+            displaySubtitle = source.shortName,
         )
     }
 
@@ -372,6 +507,13 @@ class AudioBarController(
         val svc = service
         val host = this.host ?: return
         when (cmd) {
+            is AudioBarCommand.PickSource -> {
+                val sources = host.audioAvailableSources()
+                val picked = sources.firstOrNull { it.versionId == cmd.versionId } ?: return
+                selectedSource = picked
+                startSession(host)
+            }
+            AudioBarCommand.CancelPicker -> hide()
             AudioBarCommand.PlayPause -> {
                 if (svc == null) return
                 if (_uiState.value.isPlaying) svc.pause() else svc.play()
@@ -419,16 +561,16 @@ class AudioBarController(
         // queued load avoids that flicker.
         val isPending = pendingLoad != null
         pendingLoad?.let { ph ->
-            service?.loadChapter(buildRequest(ph))
+            buildRequest(ph)?.let { req -> service?.loadChapter(req) }
             pendingLoad = null
         }
 
         // Sync the activity to the chapter the service is now playing — but
         // only when the *service's* chapter has changed (lock-screen skip,
-        // Bluetooth, auto-advance), never when the user has manually swiped
-        // the reader to a different chapter while audio plays in the
-        // background. Comparing against `host.audio*` alone would tug the
-        // reader back to the playing chapter every position tick.
+        // Bluetooth, auto-advance). For activity-driven changes (the user
+        // swiped the reader, see [onChapterChanged]), the latch is bumped
+        // *before* the service emits, so this block stays a no-op for that
+        // path and we don't double-navigate.
         if (host != null && state.bookId >= 0 &&
             (state.bookId != lastServiceBookId || state.chapter_1 != lastServiceChapter1)
         ) {
@@ -436,20 +578,33 @@ class AudioBarController(
             lastServiceChapter1 = state.chapter_1
             val hostBook = host.audioCurrentBook()
             if (hostBook.bookId != state.bookId || host.audioCurrentChapter1() != state.chapter_1) {
-                val targetBook = host.audioVersionBook(state.bookId)
+                // Resolve the new book against whichever visible version
+                // currently includes it — `display(...)` ultimately retargets
+                // split0, but `Book.bookId` is consistent across versions
+                // (it's an Ari book index), so any visible version that
+                // contains the book yields the right Book object.
+                val visible = host.audioVisibleVersionIds()
+                val targetBook = visible
+                    .firstNotNullOfOrNull { host.audioBookInVersion(it, state.bookId) }
                 if (targetBook != null) {
                     host.audioDisplayChapter(targetBook, state.chapter_1)
                 }
             }
         }
 
-        val prevLabel = host?.audioNeighborChapter(-1)?.let { (b, c) -> "${b.shortName} $c" }
-        val nextLabel = host?.audioNeighborChapter(+1)?.let { (b, c) -> "${b.shortName} $c" }
+        val playingVersionId = state.versionId.takeIf { it.isNotEmpty() }
+            ?: selectedSource?.versionId
+        val prevLabel = playingVersionId
+            ?.let { host?.audioNeighborChapter(it, -1) }
+            ?.let { (b, c) -> "${b.shortName} $c" }
+        val nextLabel = playingVersionId
+            ?.let { host?.audioNeighborChapter(it, +1) }
+            ?.let { (b, c) -> "${b.shortName} $c" }
 
         val effectivePreparing = state.preparing || isPending
         _uiState.update { current ->
             current.copy(
-                visible = requestedVisible,
+                visible = requestedVisible && current.pickerOptions == null,
                 isPlaying = state.isPlaying,
                 preparing = effectivePreparing,
                 positionMs = state.positionMs,
@@ -466,13 +621,17 @@ class AudioBarController(
                 // process timing. Until then the prev/next-verse buttons stay
                 // disabled, which is the spec.
                 timingAvailable = state.verse_1 > 0 || current.timingAvailable,
+                playingVersionId = playingVersionId,
             )
         }
     }
 
     private fun recomputeChapterLabels(host: Host) {
-        val prev = host.audioNeighborChapter(-1)?.let { (b, c) -> "${b.shortName} $c" }
-        val next = host.audioNeighborChapter(+1)?.let { (b, c) -> "${b.shortName} $c" }
+        val source = selectedSource ?: return
+        val prev = host.audioNeighborChapter(source.versionId, -1)
+            ?.let { (b, c) -> "${b.shortName} $c" }
+        val next = host.audioNeighborChapter(source.versionId, +1)
+            ?.let { (b, c) -> "${b.shortName} $c" }
         _uiState.update { it.copy(prevChapterLabel = prev, nextChapterLabel = next) }
     }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
@@ -290,6 +290,7 @@ class BibleAudioService : MediaSessionService() {
             it.copy(
                 preparing = true,
                 isPlaying = false,
+                versionId = request.versionId,
                 bookId = request.bookId,
                 chapter_1 = request.chapter_1,
                 verse_1 = 0,

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/PlaybackState.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/PlaybackState.kt
@@ -9,9 +9,8 @@ package yuku.alkitab.base.audio
  *  - [preparing]   — true between `loadChapter` and the player firing READY.
  *                    Drives the toolbar-icon spinner and the bar's progress ring.
  *  - [versionId]   — versionId of the source currently loaded, or `""` when
- *                    nothing is loaded. Identifies which `IsiActivity` pane
- *                    (split0 / split1) is the audio source, so the verse
- *                    highlight only lights up on the matching pane(s).
+ *                    nothing is loaded. Scopes the verse highlight to panes
+ *                    whose version matches.
  *  - [bookId]      — bookId of the chapter currently loaded into the service,
  *                    or `-1` when nothing is loaded. Lets [AudioBarController]
  *                    detect service-initiated chapter changes (e.g. lock-screen

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/PlaybackState.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/PlaybackState.kt
@@ -8,6 +8,10 @@ package yuku.alkitab.base.audio
  *                    "play was requested but still buffering"; that's [preparing]).
  *  - [preparing]   — true between `loadChapter` and the player firing READY.
  *                    Drives the toolbar-icon spinner and the bar's progress ring.
+ *  - [versionId]   — versionId of the source currently loaded, or `""` when
+ *                    nothing is loaded. Identifies which `IsiActivity` pane
+ *                    (split0 / split1) is the audio source, so the verse
+ *                    highlight only lights up on the matching pane(s).
  *  - [bookId]      — bookId of the chapter currently loaded into the service,
  *                    or `-1` when nothing is loaded. Lets [AudioBarController]
  *                    detect service-initiated chapter changes (e.g. lock-screen
@@ -27,6 +31,7 @@ package yuku.alkitab.base.audio
 data class PlaybackState(
     val isPlaying: Boolean,
     val preparing: Boolean,
+    val versionId: String,
     val bookId: Int,
     val chapter_1: Int,
     val verse_1: Int,
@@ -39,6 +44,7 @@ data class PlaybackState(
         val IDLE = PlaybackState(
             isPlaying = false,
             preparing = false,
+            versionId = "",
             bookId = -1,
             chapter_1 = 0,
             verse_1 = 0,

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -81,21 +81,9 @@ data class AudioBarUiState(
     val nextChapterLabel: String?,
     val error: String?,
     val timingAvailable: Boolean,
-    /**
-     * VersionId of the source the controller has committed to play. `null`
-     * before the user has picked (or auto-pick has fired) and after `hide()`.
-     * Consumed by `IsiActivity` to route the audio verse highlight to the
-     * pane(s) whose version matches — and only those panes, so the other
-     * split stays "audio-quiet" even when the verse number coincides.
-     */
+    /** Version driving audio, or null. Used to scope the verse highlight to matching panes. */
     val playingVersionId: String?,
-    /**
-     * When non-null, a "pick the audio source" dialog is shown over the bar.
-     * Set by [yuku.alkitab.base.audio.AudioBarController.show] when split view
-     * is active and both visible versions have audio coverage; the user
-     * cannot start playback until they pick one (or cancel, which hides the
-     * bar entirely). `null` once the user picks a source.
-     */
+    /** When non-null, the source-picker dialog is shown over the bar. */
     val pickerOptions: List<AudioSourceOption>?,
 ) {
     companion object {
@@ -117,10 +105,7 @@ data class AudioBarUiState(
     }
 }
 
-/**
- * One row in the source-picker dialog. [versionId] keys back into the
- * catalog; [shortName] is the user-visible label (e.g. "TB", "KJV").
- */
+/** One row in the source-picker dialog. */
 data class AudioSourceOption(val versionId: String, val shortName: String)
 
 /**
@@ -143,9 +128,7 @@ sealed interface AudioBarCommand {
     data object Speed : AudioBarCommand
     data class SeekDrag(val positionMs: Long) : AudioBarCommand
     data class SeekCommit(val positionMs: Long) : AudioBarCommand
-    /** User picked a source from the split-view picker dialog. */
     data class PickSource(val versionId: String) : AudioBarCommand
-    /** User dismissed the picker dialog without choosing. */
     data object CancelPicker : AudioBarCommand
 }
 
@@ -163,10 +146,6 @@ fun AudioBar(
     modifier: Modifier,
 ) {
     AudioTheme {
-        // The picker is shown over whatever else is on screen (M3 PRD §4.5):
-        // bar is "visible" the moment the user taps the audio menu icon, but
-        // playback is gated on a source choice when split view is active and
-        // both visible versions have audio.
         state.pickerOptions?.let { options ->
             SourcePickerDialog(options = options, onCommand = onCommand)
         }
@@ -411,12 +390,7 @@ private fun AudioBarSliderRow(
     }
 }
 
-/**
- * "Which version should we play?" dialog shown when the user opens the audio
- * bar with split view active and both visible versions have audio coverage.
- * Single-tap selection (no confirm button) keeps the friction low. Cancel /
- * outside-dismiss aborts the session — the bar then slides back out.
- */
+/** Shown when split view is active and both visible versions have audio. */
 @Composable
 private fun SourcePickerDialog(
     options: List<AudioSourceOption>,
@@ -443,7 +417,8 @@ private fun SourcePickerDialog(
                 }
             }
         },
-        confirmButton = {
+        confirmButton = {},
+        dismissButton = {
             TextButton(onClick = { onCommand(AudioBarCommand.CancelPicker) }) {
                 Text(stringResource(android.R.string.cancel))
             }

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
@@ -29,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -79,6 +81,22 @@ data class AudioBarUiState(
     val nextChapterLabel: String?,
     val error: String?,
     val timingAvailable: Boolean,
+    /**
+     * VersionId of the source the controller has committed to play. `null`
+     * before the user has picked (or auto-pick has fired) and after `hide()`.
+     * Consumed by `IsiActivity` to route the audio verse highlight to the
+     * pane(s) whose version matches — and only those panes, so the other
+     * split stays "audio-quiet" even when the verse number coincides.
+     */
+    val playingVersionId: String?,
+    /**
+     * When non-null, a "pick the audio source" dialog is shown over the bar.
+     * Set by [yuku.alkitab.base.audio.AudioBarController.show] when split view
+     * is active and both visible versions have audio coverage; the user
+     * cannot start playback until they pick one (or cancel, which hides the
+     * bar entirely). `null` once the user picks a source.
+     */
+    val pickerOptions: List<AudioSourceOption>?,
 ) {
     companion object {
         val HIDDEN = AudioBarUiState(
@@ -93,9 +111,17 @@ data class AudioBarUiState(
             nextChapterLabel = null,
             error = null,
             timingAvailable = false,
+            playingVersionId = null,
+            pickerOptions = null,
         )
     }
 }
+
+/**
+ * One row in the source-picker dialog. [versionId] keys back into the
+ * catalog; [shortName] is the user-visible label (e.g. "TB", "KJV").
+ */
+data class AudioSourceOption(val versionId: String, val shortName: String)
 
 /**
  * Commands raised by the bar's UI. The controller maps these onto
@@ -117,6 +143,10 @@ sealed interface AudioBarCommand {
     data object Speed : AudioBarCommand
     data class SeekDrag(val positionMs: Long) : AudioBarCommand
     data class SeekCommit(val positionMs: Long) : AudioBarCommand
+    /** User picked a source from the split-view picker dialog. */
+    data class PickSource(val versionId: String) : AudioBarCommand
+    /** User dismissed the picker dialog without choosing. */
+    data object CancelPicker : AudioBarCommand
 }
 
 /**
@@ -133,6 +163,13 @@ fun AudioBar(
     modifier: Modifier,
 ) {
     AudioTheme {
+        // The picker is shown over whatever else is on screen (M3 PRD §4.5):
+        // bar is "visible" the moment the user taps the audio menu icon, but
+        // playback is gated on a source choice when split view is active and
+        // both visible versions have audio.
+        state.pickerOptions?.let { options ->
+            SourcePickerDialog(options = options, onCommand = onCommand)
+        }
         AnimatedVisibility(
             visible = state.visible,
             enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(220)) +
@@ -374,6 +411,46 @@ private fun AudioBarSliderRow(
     }
 }
 
+/**
+ * "Which version should we play?" dialog shown when the user opens the audio
+ * bar with split view active and both visible versions have audio coverage.
+ * Single-tap selection (no confirm button) keeps the friction low. Cancel /
+ * outside-dismiss aborts the session — the bar then slides back out.
+ */
+@Composable
+private fun SourcePickerDialog(
+    options: List<AudioSourceOption>,
+    onCommand: (AudioBarCommand) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = { onCommand(AudioBarCommand.CancelPicker) },
+        title = { Text(stringResource(R.string.audio_bar_pick_source_title)) },
+        text = {
+            Column {
+                options.forEach { option ->
+                    TextButton(
+                        onClick = { onCommand(AudioBarCommand.PickSource(option.versionId)) },
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            text = option.shortName,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 4.dp),
+                            style = MaterialTheme.typography.bodyLarge,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onCommand(AudioBarCommand.CancelPicker) }) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+    )
+}
+
 private fun formatMmSs(ms: Long): String {
     val totalSec = (ms / 1000L).coerceAtLeast(0L)
     val mm = totalSec / 60L
@@ -399,6 +476,8 @@ private fun AudioBarPreviewPlaying() {
             nextChapterLabel = "Jn 4",
             error = null,
             timingAvailable = true,
+            playingVersionId = "preset/in-tb",
+            pickerOptions = null,
         ),
         onCommand = {},
         modifier = Modifier,
@@ -421,6 +500,8 @@ private fun AudioBarPreviewPreparing() {
             nextChapterLabel = "Jn 4",
             error = null,
             timingAvailable = false,
+            playingVersionId = "preset/in-tb",
+            pickerOptions = null,
         ),
         onCommand = {},
         modifier = Modifier,
@@ -443,6 +524,35 @@ private fun AudioBarPreviewDarkBoundary() {
             nextChapterLabel = "Mt 1",
             error = null,
             timingAvailable = false, // some chapters have audio but no timing
+            playingVersionId = "preset/in-tb",
+            pickerOptions = null,
+        ),
+        onCommand = {},
+        modifier = Modifier,
+    )
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF, widthDp = 400)
+@Composable
+private fun AudioBarPreviewWithPicker() {
+    AudioBar(
+        state = AudioBarUiState(
+            visible = true,
+            isPlaying = false,
+            preparing = false,
+            positionMs = 0L,
+            durationMs = 0L,
+            verse_1 = 0,
+            speed = 1.0f,
+            prevChapterLabel = "Jn 2",
+            nextChapterLabel = "Jn 4",
+            error = null,
+            timingAvailable = false,
+            playingVersionId = null,
+            pickerOptions = listOf(
+                AudioSourceOption(versionId = "preset/in-tb", shortName = "TB"),
+                AudioSourceOption(versionId = "preset/en-kjv", shortName = "KJV"),
+            ),
         ),
         onCommand = {},
         modifier = Modifier,

--- a/Alkitab/src/main/res/values/strings.xml
+++ b/Alkitab/src/main/res/values/strings.xml
@@ -589,5 +589,6 @@
 	<string name="audio_bar_position_with_verse">%1$s · v.%2$d</string>
 	<string name="audio_bar_position_no_verse">%1$s</string>
 	<string name="audio_bar_error_no_audio">No audio for this version.</string>
+	<string name="audio_bar_pick_source_title">Play audio from</string>
 
 </resources>

--- a/docs/features/audio-bible/client-plan.md
+++ b/docs/features/audio-bible/client-plan.md
@@ -12,11 +12,11 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 ## 0. Prerequisites
 
-- [ ] Read the PRD in `prd.md` and the backend plan in `backend-plan.md`.
-- [ ] **Do not cherry-pick from PR #127 or PR #124.** Both PRs will be closed unmerged once this work lands. They are useful as inspiration only — the SABDA timing-API tables in PR #127 have moved to the backend, the activity-scoped player from both PRs is replaced by a `MediaSessionService`, and the entire UI surface is rewritten in Compose. Re-write the player wrapper (`BibleAudioPlayer`), the repository (`BibleAudioRepository`), the highlight tracker, and the verse-overlay code from scratch with the conventions called out in this plan.
-- [ ] Confirm `androidx.media3:media3-session` is not yet in the build; add it in M1.
-- [ ] Confirm Jetpack Compose is not yet in the build (it isn't — this feature is the project's first Compose surface); add the dependency family + Kotlin Compose Compiler plugin in M1.
-- [ ] Access to the backend staging environment (base URL is `BuildConfig.SERVER_HOST`).
+- [x] Read the PRD in `prd.md` and the backend plan in `backend-plan.md`.
+- [x] **Do not cherry-pick from PR #127 or PR #124.** Both PRs will be closed unmerged once this work lands. They are useful as inspiration only — the SABDA timing-API tables in PR #127 have moved to the backend, the activity-scoped player from both PRs is replaced by a `MediaSessionService`, and the entire UI surface is rewritten in Compose. Re-write the player wrapper (`BibleAudioPlayer`), the repository (`BibleAudioRepository`), the highlight tracker, and the verse-overlay code from scratch with the conventions called out in this plan.
+- [x] Confirm `androidx.media3:media3-session` is not yet in the build; add it in M1.
+- [x] Confirm Jetpack Compose is not yet in the build (it isn't — this feature is the project's first Compose surface); add the dependency family + Kotlin Compose Compiler plugin in M1.
+- [x] Access to the backend staging environment (base URL is `BuildConfig.SERVER_HOST`).
 
 ---
 
@@ -26,8 +26,8 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 **Goal:** app builds with the new dependency family wired in (media3-session, Compose 1.11.0, Compose Compiler plugin); catalog loads from backend with a bundled fallback.
 
-- [ ] Add `androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "androidxMedia3" }` to `gradle/libs.versions.toml` and `implementation(libs.androidx.media3.session)` in `Alkitab/build.gradle.kts`.
-- [ ] Add Compose 1.11.0 to the project as **the first Compose surface in the codebase**:
+- [x] Add `androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "androidxMedia3" }` to `gradle/libs.versions.toml` and `implementation(libs.androidx.media3.session)` in `Alkitab/build.gradle.kts`.
+- [x] Add Compose 1.11.0 to the project as **the first Compose surface in the codebase**:
     - In `gradle/libs.versions.toml`:
         ```toml
         androidxComposeUi = "1.11.0"
@@ -39,10 +39,10 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
         - Add `buildFeatures { compose = true }` to the `android {}` block.
         - Add the `implementation(libs.androidx.compose.ui)` etc. dependencies.
     - Add `id("org.jetbrains.kotlin.plugin.compose") apply false` to the root `build.gradle.kts` plugin list (root project alias).
-- [ ] Verify `./gradlew assemblePlainDebug` succeeds with the new deps in place. If `compose-material3:1.5.0` is not yet published, bump to the most recent stable that pairs with `compose-ui:1.11.0`.
-- [ ] Create package `yuku.alkitab.base.audio` and skeleton files per PRD §5.7.
-- [ ] Model classes: `AudioVersion.kt`, `ChapterTiming.kt`, `VerseTiming.kt`, `AudioCatalog.kt`.
-- [ ] `AudioCatalogRepository`:
+- [x] Verify `./gradlew assemblePlainDebug` succeeds with the new deps in place. If `compose-material3:1.5.0` is not yet published, bump to the most recent stable that pairs with `compose-ui:1.11.0`.
+- [x] Create package `yuku.alkitab.base.audio` and skeleton files per PRD §5.7.
+- [x] Model classes: `AudioVersion.kt`, `ChapterTiming.kt`, `VerseTiming.kt`, `AudioCatalog.kt`.
+- [x] `AudioCatalogRepository`:
     - Uses `Connections.okHttp` and `BuildConfig.SERVER_HOST` (defined at `Alkitab/build.gradle.kts:123`; resolves to `https://alkitab.app` for production flavors).
     - `GET ${SERVER_HOST}/audio/catalog?${App.getAppIdentifierParamsEncoded()}` with conditional `If-None-Match` when we have an ETag. Mirror the `appIdentifier`/`packageName`/`versionCode` query-param style used by `VersionConfigUpdaterService` (`Alkitab/src/main/java/yuku/alkitab/base/sv/VersionConfigUpdaterService.java:93`) and `DevotionDownloader` (`DevotionDownloader.java:51`).
     - 200 → parse JSON, persist to `files/audio_catalog.json`, store ETag in `Prefkey.audioCatalog_etag`.
@@ -50,10 +50,10 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
     - Non-2xx → fall back to bundled `Alkitab/src/main/assets/audio_catalog.json` (checked in with the four known SABDA versions; same shape as the live `/audio/catalog` response). The feature works end-to-end on the bundled fallback alone, so client and backend can ship independently.
     - `suspend fun loadCatalog(): AudioCatalog` returns the cached+merged view.
     - `fun isAudioAvailable(versionId: String): Boolean` for the toolbar icon visibility.
-- [ ] Add a Prefkey entry `audioCatalog_etag` (and `audioPlaybackSpeed` for M5) in `Prefkey.kt`.
-- [ ] Per-flavor `BuildConfig.INTERNAL_VERSION_AUDIO_ID` in `Alkitab/build.gradle.kts` (see PRD §5.4.1). Default `""` in `defaultConfig`; override `"preset/in-tb"` for `plain`/`yuku_alkitab`/`sabda_alkitab` and `"preset/en-kjv"` for `yuku_quick_bible`. Wire the substitution into `AudioCatalogRepository.findEntry` so `MVersion.getVersionId() == "internal"` resolves to the correct catalog row.
-- [ ] Background refresh: piggyback on the existing `VersionConfigUpdaterService` (see `docs/backend-communication.md:39-41`) — add a parallel catalog fetch so we don't spawn a new worker.
-- [ ] Unit tests (`Alkitab/src/test/java/.../audio/AudioCatalogRepositoryTest.kt`): parsing, ETag handling, cache fallback.
+- [x] Add a Prefkey entry `audioCatalog_etag` (and `audioPlaybackSpeed` for M5) in `Prefkey.kt`.
+- [x] Per-flavor `BuildConfig.INTERNAL_VERSION_AUDIO_ID` in `Alkitab/build.gradle.kts` (see PRD §5.4.1). Default `""` in `defaultConfig`; override `"preset/in-tb"` for `plain`/`yuku_alkitab`/`sabda_alkitab` and `"preset/en-kjv"` for `yuku_quick_bible`. Wire the substitution into `AudioCatalogRepository.findEntry` so `MVersion.getVersionId() == "internal"` resolves to the correct catalog row.
+- [x] Background refresh: piggyback on the existing `VersionConfigUpdaterService` (see `docs/backend-communication.md:39-41`) — add a parallel catalog fetch so we don't spawn a new worker.
+- [x] Unit tests (`Alkitab/src/test/java/.../audio/AudioCatalogRepositoryTest.kt`): parsing, ETag handling, cache fallback.
 
 **Exit criteria:** `./gradlew testPlainDebugUnitTest` green; the repository returns a populated catalog on device against staging.
 
@@ -61,20 +61,20 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 **Goal:** single-stream audio plays end-to-end for the active chapter; verses highlight and scroll.
 
-- [ ] `BibleAudioPlayer.kt` — write from scratch. Single-responsibility wrapper around media3 ExoPlayer with a `Listener` (`onReady`, `onEnded`, `onError`). Main-thread-only API. Use the OkHttp `DataSource.Factory` pattern from `yuku.alkitab.songs.ExoplayerController.kt:8-17` (same project convention, same dependency).
-- [ ] `BibleAudioRepository.kt` — written from scratch, lives at `yuku.alkitab.base.audio.BibleAudioRepository`. Surface:
+- [x] `BibleAudioPlayer.kt` — write from scratch. Single-responsibility wrapper around media3 ExoPlayer with a `Listener` (`onReady`, `onEnded`, `onError`). Main-thread-only API. Use the OkHttp `DataSource.Factory` pattern from `yuku.alkitab.songs.ExoplayerController.kt:8-17` (same project convention, same dependency).
+- [x] `BibleAudioRepository.kt` — written from scratch, lives at `yuku.alkitab.base.audio.BibleAudioRepository`. Surface:
     - `suspend fun buildChapterUrl(versionId, bookId, chapter_1): String?` — expands the catalog's `chapterUrlTemplate` against `${SERVER_HOST}` (the backend issues a 302 to the real CDN).
     - `suspend fun fetchTiming(versionId, bookId, chapter_1): ChapterTiming?` — `GET ${SERVER_HOST}/audio/timing?...` via `Connections.okHttp`; parses the v1 JSON schema (see backend plan §4); returns `null` on network/parse failure, an empty `verses` list when the backend signals "no timing for this chapter". OkHttp's 50MB disk cache supplies implicit per-URL caching via the `Cache-Control` headers set by the backend.
     - **No SABDA URLs** in the client. All book-code / filename / SABDA-folder construction lives on the backend (`audio/adapters.py`). Verify with `grep -r "sabda" Alkitab/src/main` after the PR is up: zero hits expected.
-- [ ] `HighlightTracker.kt` — a small class that owns a `StateFlow<Int>` of currently-active `verse_1`. Input: `positionMs` + timing list. Internal: a last-index hint so we don't re-binary-search every tick. 100ms poll interval (same as PR #127).
-- [ ] `BibleAudioService.kt` — `androidx.media3.session.MediaSessionService`:
+- [x] `HighlightTracker.kt` — a small class that owns a `StateFlow<Int>` of currently-active `verse_1`. Input: `positionMs` + timing list. Internal: a last-index hint so we don't re-binary-search every tick. 100ms poll interval (same as PR #127).
+- [x] `BibleAudioService.kt` — `androidx.media3.session.MediaSessionService`:
     - Owns a `BibleAudioPlayer`.
     - Wraps it with `MediaSession` so the OS gets transport metadata.
     - Exposes a `BibleAudioController` binder that the UI uses via coroutines.
     - State exposed as `StateFlow<PlaybackState>` where `PlaybackState` contains `isPlaying`, `preparing`, `verse_1`, `positionMs`, `durationMs`, `speed`, `error`.
     - Posts a `MediaStyle` notification on foreground transition (channel `audio_bible`).
     - Handles audio focus: pause on transient-loss, duck on can-duck, resume on regain.
-- [ ] Register the service in `AndroidManifest.xml`:
+- [x] Register the service in `AndroidManifest.xml`:
     ```xml
     <service
         android:name=".audio.BibleAudioService"
@@ -86,8 +86,8 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
     </service>
     ```
     Also add `FOREGROUND_SERVICE` and `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permissions.
-- [ ] Notification channel setup in `App.staticInit()` (mirror the existing channel creation for sync/devotion notifications).
-- [ ] Unit tests: `HighlightTrackerTest`, `BibleAudioRepositoryTest` (mock OkHttp), `ChapterTimingParsingTest`.
+- [x] Notification channel setup in `App.staticInit()` (mirror the existing channel creation for sync/devotion notifications).
+- [x] Unit tests: `HighlightTrackerTest`, `BibleAudioRepositoryTest` (mock OkHttp), `ChapterTimingParsingTest`.
 
 **Exit criteria:** A throwaway button in a debug-only screen starts the service, plays a chapter, updates a text view with the active verse. No UI polish yet.
 
@@ -97,8 +97,8 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 #### 3.1 Compose host
 
-- [ ] Add a `<androidx.compose.ui.platform.ComposeView android:id="@+id/audio_bar" />` to `activity_isi.xml` at the bottom of the root layout (`android:layout_gravity="bottom"`).
-- [ ] `AudioBarController.kt` (in `audio/`) — Kotlin glue between the View-based `IsiActivity` and the Compose UI:
+- [x] Add a `<androidx.compose.ui.platform.ComposeView android:id="@+id/audio_bar" />` to `activity_isi.xml` at the bottom of the root layout (`android:layout_gravity="bottom"`).
+- [x] `AudioBarController.kt` (in `audio/`) — Kotlin glue between the View-based `IsiActivity` and the Compose UI:
     - Owns a `MutableStateFlow<AudioBarUiState>`.
     - `attach(activity: IsiActivity, composeView: ComposeView)` — `composeView.setContent { AudioBar(state, onCommand) }`.
     - Exposes `fun show()` / `fun hide()` / `fun isAvailable: Boolean` for `IsiActivity` to call.
@@ -107,8 +107,8 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 #### 3.2 Composable surface
 
-- [ ] `audio/ui/AudioTheme.kt` — wraps Compose `MaterialTheme` and bridges the project's existing `?attr/colorSurface*` etc. into Compose `ColorScheme` so dark mode works without a separate Compose theme. Uses `MaterialTheme.colorScheme.surfaceContainerHigh` for the bar background.
-- [ ] `audio/ui/AudioBar.kt` — top-level `@Composable`. A fixed-height (≈96dp) `Surface` anchored to the bottom of the host `ComposeView`. Visibility (show/hide on close) is animated via `AnimatedVisibility(enter = slideInVertically(initialOffsetY = { it }), exit = slideOutVertically(targetOffsetY = { it }))` so the bar slides in/out instead of popping.
+- [x] `audio/ui/AudioTheme.kt` — wraps Compose `MaterialTheme` and bridges the project's existing `?attr/colorSurface*` etc. into Compose `ColorScheme` so dark mode works without a separate Compose theme. Uses `MaterialTheme.colorScheme.surfaceContainerHigh` for the bar background.
+- [x] `audio/ui/AudioBar.kt` — top-level `@Composable`. A fixed-height (≈96dp) `Surface` anchored to the bottom of the host `ComposeView`. Visibility (show/hide on close) is animated via `AnimatedVisibility(enter = slideInVertically(initialOffsetY = { it }), exit = slideOutVertically(targetOffsetY = { it }))` so the bar slides in/out instead of popping.
     - Layout: top row of controls + Slider below.
     - Top row, left-to-right: prev-chapter (icon + label) | prev-verse | play/pause FAB | next-verse | next-chapter (icon + label) | speed | close.
     - Slider uses Material 3 `Slider` with a custom `SliderState` and a label rendered above the thumb: `"${formatMmSs(snappedMs)} · v.${verse_1}"`. Snap-to-verse on `onValueChangeFinished`.
@@ -116,8 +116,8 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
     - On preparing state: render a `CircularProgressIndicator` overlay around the play/pause button.
     - Chapter-nav button labels (`Jn 4`) drawn with `Modifier.alpha(if (target != null) 1f else 0f)` — invisible-not-gone, layout doesn't reflow at Bible boundaries.
     - Haptics: `LocalHapticFeedback.current.performHapticFeedback(HapticFeedbackType.LongPress)` on speed change, `HapticFeedbackType.TextHandleMove` on play/pause.
-- [ ] `audio/ui/SpeedBottomSheet.kt` — `ModalBottomSheet` with a `FilterChip` row for `0.5×, 0.8×, 1.0×, 1.25×, 1.5×, 1.75×, 2.0×`. Single-selection. Persisted via `Prefkey.audioPlaybackSpeed`.
-- [ ] `audio/ui/AudioHighlightColor.kt` — pure-function logic:
+- [ ] `audio/ui/SpeedBottomSheet.kt` — `ModalBottomSheet` with a `FilterChip` row for `0.5×, 0.8×, 1.0×, 1.25×, 1.5×, 1.75×, 2.0×`. Single-selection. Persisted via `Prefkey.audioPlaybackSpeed`. *(Speed chip rendered in `AudioBar.kt` but inert — full bottom sheet deferred to M5.)*
+- [x] `audio/ui/AudioHighlightColor.kt` — pure-function logic:
     ```kotlin
     fun pickHighlightColor(readingBackground: Int, verseTextColor: Int): Int {
         val yellow = Color.argb(0x33, 0xFF, 0xEB, 0x3B)  // 20% alpha, Material Yellow 500
@@ -136,20 +136,20 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 #### 3.3 Verse highlight (still XML / View-based, since `VerseItem` is)
 
-- [ ] `VerseItem.kt`: add `var audioHighlightColor: Int = 0` (0 = no highlight). The `onDraw` overlay paints a rounded rect of that color, alpha-animated in (200ms) and out (150ms) via a `ValueAnimator`. `0` clears.
-- [ ] `VersesController.kt` / `VersesControllerImpl.kt`: add `fun setAudioHighlight(verse_1: Int, color: Int)`. The color is computed once via `pickHighlightColor(...)` using `VersesView.background` and `?attr/textColor*` and cached on the controller until the theme changes.
-- [ ] On each `PlaybackState.verse_1` change, the controller calls `setAudioHighlight` on the active split's `VersesController` **and** smooth-scrolls the highlighted verse into the upper-third of the viewport using a `LinearSmoothScroller` with `getVerticalSnapPreference() = SNAP_TO_START` and `calculateDtToFit` returning `viewportHeight * 0.33`.
+- [x] `VerseItem.kt`: add `var audioHighlightColor: Int = 0` (0 = no highlight). The `onDraw` overlay paints a rounded rect of that color, alpha-animated in (200ms) and out (150ms) via a `ValueAnimator`. `0` clears.
+- [x] `VersesController.kt` / `VersesControllerImpl.kt`: add `fun setAudioHighlight(verse_1: Int, color: Int)`. The color is computed once via `pickHighlightColor(...)` using `VersesView.background` and `?attr/textColor*` and cached on the controller until the theme changes.
+- [x] On each `PlaybackState.verse_1` change, the controller calls `setAudioHighlight` on the active split's `VersesController` **and** smooth-scrolls the highlighted verse into the upper-third of the viewport using a `LinearSmoothScroller` with `getVerticalSnapPreference() = SNAP_TO_START` and `calculateDtToFit` returning `viewportHeight * 0.33`.
 
 #### 3.4 Toolbar icon
 
-- [ ] Menu item in `res/menu/activity_isi.xml`: `<item android:id="@+id/menuAudio" app:showAsAction="always" android:icon="@drawable/ic_audio" android:title="@string/menu_audio" />`. Matches `menuSearch`'s `always` treatment — never spills into overflow. Wire into `IsiActivity.buildMenu` / `onOptionsItemSelected` (see `IsiActivity.kt:1368-1399`).
-- [ ] Visibility — observe the catalog. Set `menuItem.isVisible = repo.isAudioAvailable(visibleVersionId0) || repo.isAudioAvailable(visibleVersionId1)`. Refresh on active-version change and on split-view enter/exit. Hiding (not disabling) is intentional — a permanently-greyed icon is more confusing than no icon.
-- [ ] Preparing-state spinner: clone the Kidung pattern (`SongViewActivity.kt:178, 443-449, 1088-1090`). Add a `circular_progress` view to the toolbar layout in `activity_isi.xml`, initially `GONE`. In `onPrepareOptionsMenu`, when `audioBarController.isPreparing`, set `menuAudio.isVisible = false` and `circular_progress.visibility = VISIBLE`; otherwise the inverse. Trigger `invalidateOptionsMenu()` from the state collector whenever `preparing` flips.
+- [x] Menu item in `res/menu/activity_isi.xml`: `<item android:id="@+id/menuAudio" app:showAsAction="always" android:icon="@drawable/ic_audio" android:title="@string/menu_audio" />`. Matches `menuSearch`'s `always` treatment — never spills into overflow. Wire into `IsiActivity.buildMenu` / `onOptionsItemSelected` (see `IsiActivity.kt:1368-1399`).
+- [x] Visibility — observe the catalog. Set `menuItem.isVisible = repo.isAudioAvailable(visibleVersionId0) || repo.isAudioAvailable(visibleVersionId1)`. Refresh on active-version change and on split-view enter/exit. Hiding (not disabling) is intentional — a permanently-greyed icon is more confusing than no icon.
+- [ ] Preparing-state spinner: clone the Kidung pattern (`SongViewActivity.kt:178, 443-449, 1088-1090`). Add a `circular_progress` view to the toolbar layout in `activity_isi.xml`, initially `GONE`. In `onPrepareOptionsMenu`, when `audioBarController.isPreparing`, set `menuAudio.isVisible = false` and `circular_progress.visibility = VISIBLE`; otherwise the inverse. Trigger `invalidateOptionsMenu()` from the state collector whenever `preparing` flips. *(Currently the spinner is only shown inside the audio bar's play button; the toolbar swap is deferred.)*
 
 #### 3.5 Tests
 
-- [ ] `AudioHighlightColorTest` — pure-function unit tests covering yellow/black/white selection across light, sepia, and dark reading backgrounds. Assert ≥4.5 contrast.
-- [ ] Compose preview functions for `AudioBar`, `SpeedBottomSheet` — for visual review in Android Studio. (Previews don't replace device testing but are cheap insurance.)
+- [x] `AudioHighlightColorTest` — pure-function unit tests covering yellow/black/white selection across light, sepia, and dark reading backgrounds. Assert ≥4.5 contrast.
+- [x] Compose preview functions for `AudioBar`, `SpeedBottomSheet` — for visual review in Android Studio. (Previews don't replace device testing but are cheap insurance.)
 - [ ] Instrumented test (`connectedCheck`): open chapter → tap audio → verify the audio bar slides in → tap close → verify it slides out and the service stops.
 
 **Exit criteria:** End-to-end demo of §1–§6 of the PRD's must-haves (screen-on usage); the audio bar slides in/out smoothly; verse highlight uses yellow on light themes and the contrast-fallback color on dark themes.
@@ -158,12 +158,12 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 **Goal:** closing the app or locking the screen does not stop playback.
 
-- [ ] Verify MediaSession metadata: title = `${book.shortName} ${chapter_1}`, subtitle = `${version.shortName}`, artwork = app icon + chapter art if available (for v1, app icon only).
-- [ ] Pre-compute available actions on each state change: Play ↔ Pause, Prev-chapter, Next-chapter. (Verse-level actions are exposed only through the app UI to keep the notification small.)
-- [ ] Handle `ACTION_MEDIA_BUTTON` — MediaSession does it automatically, but verify with a Bluetooth headset.
-- [ ] Swipe-from-recents (`onTaskRemoved`): if audio is currently playing, keep the service alive and the notification up — matches Spotify / YouTube Music convention (swiping recents is a task switcher, not a stop button). If audio is paused, call `stopSelf()` to release the service. The user can always stop explicitly via the notification's Stop action or the in-app audio bar's Close button.
-- [ ] Audio focus: `AudioFocusRequest` with `AUDIOFOCUS_GAIN`; pause/duck/resume on loss. media3 handles this by default with `setHandleAudioBecomingNoisy(true)` — enable it.
-- [ ] Make sure the service correctly ends foreground state on stop (calls `stopForeground(STOP_FOREGROUND_REMOVE)`).
+- [x] Verify MediaSession metadata: title = `${book.shortName} ${chapter_1}`, subtitle = `${version.shortName}`, artwork = app icon + chapter art if available (for v1, app icon only).
+- [x] Pre-compute available actions on each state change: Play ↔ Pause, Prev-chapter, Next-chapter. (Verse-level actions are exposed only through the app UI to keep the notification small.)
+- [x] Handle `ACTION_MEDIA_BUTTON` — MediaSession does it automatically, but verify with a Bluetooth headset.
+- [x] Swipe-from-recents (`onTaskRemoved`): if audio is currently playing, keep the service alive and the notification up — matches Spotify / YouTube Music convention (swiping recents is a task switcher, not a stop button). If audio is paused, call `stopSelf()` to release the service. The user can always stop explicitly via the notification's Stop action or the in-app audio bar's Close button.
+- [x] Audio focus: `AudioFocusRequest` with `AUDIOFOCUS_GAIN`; pause/duck/resume on loss. media3 handles this by default with `setHandleAudioBecomingNoisy(true)` — enable it.
+- [x] Make sure the service correctly ends foreground state on stop (calls `stopForeground(STOP_FOREGROUND_REMOVE)`).
 - [ ] Manual test matrix:
     - [ ] Lock screen → play/pause works.
     - [ ] Incoming call → ducks/pauses and resumes.
@@ -180,7 +180,7 @@ The visual scaffolding (Compose audio bar with `AnimatedVisibility` slide-in, Ma
 - [ ] Speed persistence: `Prefkey.audioPlaybackSpeed` (enum default `1.0f`). Read on service start, write on each change.
 - [ ] Auto-advance: on `onEnded`, navigate to the next chapter. Centralise the cross-book logic in a new `BibleNavigationUtil.kt` (it's useful outside audio too). No repeat toggle in v1.
 - [ ] Snackbar error handling (§4.6 of PRD). Snackbars come from `IsiActivity` (host), not the Compose layer, since they need to overlay the toolbar.
-- [ ] Split-view source dialog (§4.5 of PRD). On play-tap when split view is active and both visible versions have audio, render a Compose `AlertDialog` with the two version short names and a Cancel. The state is held in `AudioBarController` via `MutableStateFlow`; reset to `null` whenever split view toggles, either visible version changes, or the audio bar is closed.
+- [x] Split-view source dialog (§4.5 of PRD). On play-tap when split view is active and both visible versions have audio, render a Compose `AlertDialog` with the two version short names and a Cancel. The state is held in `AudioBarController` via `MutableStateFlow`; reset to `null` whenever split view toggles, either visible version changes, or the audio bar is closed.
 - [ ] **Design review pass.** Walk the bottom sheet against this checklist before tagging M5 done:
     - Slide-in / slide-out animation is smooth on a low-end device (Pixel 4a / API 30 emulator OK).
     - Highlight overlay fades, doesn't strobe, at 1.0× speed.


### PR DESCRIPTION
## Summary

Three behavior fixes layered on top of the M3/M4 audio bar:

- **Chapter change in the reader now swaps the audio source.** `AudioBarController.onChapterChanged()` is called from the end of `IsiActivity.display()`. When the bar is open and the chosen audio version contains the new book, the service swaps to the new chapter; otherwise the bar closes. The `lastService*` latch is bumped before `loadChapter()` so the existing service-driven navigation path in `projectToUi` short-circuits and the activity doesn't re-navigate itself.
- **Split-view audio source picker** (PRD §4.5). New `AudioSourceOption`, `pickerOptions` + `playingVersionId` on `AudioBarUiState`, `PickSource` / `CancelPicker` commands, and a `SourcePickerDialog` Composable. `show()` auto-picks when only one visible version has audio and shows the dialog when both do. `Host` trades `audioCurrentVersionId` / `audioCurrentVersionShortName` / `audioVersionBook` for `audioAvailableSources()`, `audioBookInVersion(versionId, bookId)`, and a versionId-aware `audioNeighborChapter`. If the chosen audio version stops being visible (split closed, active version swapped), the bar dismisses itself instead of playing an unseen source.
- **Verse highlight scoped to the playing version.** `PlaybackState` now carries the source `versionId`, surfaced as `AudioBarUiState.playingVersionId`. `IsiActivity` only paints the audio overlay on panes whose `versionId` matches — both panes when the user has identical versions on each side, neither when nothing matches.

Also ticks completed items in [docs/features/audio-bible/client-plan.md](docs/features/audio-bible/client-plan.md): all of M0/M1/M2/M4, most of M3 (toolbar-icon spinner and connectedCheck instrumented test still outstanding), and the M5 split-source dialog. M5 leftovers (speed bottom sheet, snackbar errors, auto-advance, design-review pass) are unchanged.

## Test plan

- [x] `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` — green
- [x] `./gradlew assemblePlainDebug` — green
- [ ] Open audio bar in single-version mode → bar auto-picks the only available source
- [ ] Open audio bar with split view + both versions have audio → picker dialog appears; tapping a row starts that source, Cancel dismisses the bar
- [ ] While audio is playing, swipe / goto another chapter on the main screen → audio swaps to the new chapter
- [ ] While audio is playing on split1, only split1's verses get the yellow highlight; split0 stays plain
- [ ] Lock-screen prev/next → activity follows (no regression from M4)
- [ ] Close split view while audio is running on the now-hidden side → bar dismisses cleanly