### PR TITLE
ci: bump actions to Node.js 24 majors (checkout v5, setup-java v6, upload-artifact v7)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           java-version: '17'
           distribution: 'zulu'
@@ -44,14 +44,14 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Need full history so `git log <last-release-tag>..HEAD` in the
           # release step can walk back to the previous release.
           fetch-depth: 0
 
       - name: Check out proprietary overlay
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: yukuku/androidbible-proprietary
           ref: master
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           java-version: '17'
           distribution: 'zulu'
@@ -108,7 +108,7 @@ jobs:
       # from the run page. GitHub always wraps an artifact in a zip, but with
       # one APK + one AAB + one mapping per artifact the zip stays small.
       - name: Upload yuku_alkitab outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: yuku_alkitab-${{ steps.tag.outputs.tag }}
           if-no-files-found: error
@@ -119,7 +119,7 @@ jobs:
             Alkitab/build/outputs/mapping/yuku_alkitabRelease/mapping.txt
 
       - name: Upload yuku_quick_bible outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: yuku_quick_bible-${{ steps.tag.outputs.tag }}
           if-no-files-found: error
@@ -130,7 +130,7 @@ jobs:
             Alkitab/build/outputs/mapping/yuku_quick_bibleRelease/mapping.txt
 
       - name: Upload sabda_alkitab outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sabda_alkitab-${{ steps.tag.outputs.tag }}
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- GitHub flagged \`actions/checkout@v4\`, \`actions/setup-java@v4\`, and \`actions/upload-artifact@v4\` as Node.js 20 — those are scheduled to be forced to Node 24 on 2026-06-02 and removed on 2026-09-16. Bump each to its current major that natively targets Node 24.
- \`actions/checkout\`: v4 → v5
- \`actions/setup-java\`: v4 → v6 (v5 was preliminary; v6 defaults to Node 24)
- \`actions/upload-artifact\`: v4 → v7 (v7 adds opt-in \`archive: false\` for direct uploads; default is unchanged for our existing calls)
- All inputs we use (\`fetch-depth\`, \`repository\`/\`ref\`/\`ssh-key\`/\`path\`/\`persist-credentials\`, \`java-version\`/\`distribution\`/\`cache\`, \`name\`/\`if-no-files-found\`/\`retention-days\`/\`path\`) are unchanged across all three bumps.

## Test plan
- [ ] PR run: \`plain-debug\` and \`signed-release\` both succeed, no Node.js 20 deprecation warnings on the run.
- [ ] After merge: develop push run produces a GitHub Pre-Release identical to v21892650 (3 renamed APKs, prerelease, commit-list body), with no Node 20 warnings.