### PR TITLE
ci: fix actions/setup-java ref (v6 → v5)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: set up JDK 17
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'zulu'
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
 
       - name: set up JDK 17
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'zulu'


### PR DESCRIPTION
## Summary
- #175 pinned \`actions/setup-java@v6\`, but that floating tag doesn't exist. The repo's latest release is \`v5.2.0\`, and \`v5\` already runs on Node.js 24 (per its release notes).
- Develop's \`signed-release\` and \`plain-debug\` jobs are failing at \"Set up job\" with \`Unable to resolve action actions/setup-java@v6, unable to find version v6\`. This fixes that.

## Test plan
- [ ] PR run: both jobs succeed.
- [ ] After merge: develop push run is green, no Node 20 deprecation warnings, GitHub Pre-Release is published as expected.