### PR TITLE
goto-direct: reset candidates list scroll when candidates change

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/DirectTab.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/DirectTab.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -74,12 +75,17 @@ fun DirectTab(
     var errorRef by remember { mutableStateOf<String?>(null) }
     val focusRequester = remember { FocusRequester() }
     val kbd = LocalSoftwareKeyboardController.current
+    val candidatesListState = rememberLazyListState()
 
     LaunchedEffect(isActive) {
         if (isActive) {
             focusRequester.requestFocus()
             kbd?.show()
         }
+    }
+
+    LaunchedEffect(candidates) {
+        candidatesListState.scrollToItem(0)
     }
 
     val sample = remember(initialBookId, initialChapter_1, initialVerse_1) {
@@ -132,7 +138,7 @@ fun DirectTab(
 
         if (candidates.isNotEmpty()) {
             HorizontalDivider()
-            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+            LazyColumn(modifier = Modifier.fillMaxWidth(), state = candidatesListState) {
                 items(candidates, key = { it.title }) { c ->
                     ListItem(
                         headlineContent = { Text(c.title) },


### PR DESCRIPTION
## Summary
- On the Goto > Ketik (Direct) tab, the auto-completion suggestion list kept its previous scroll offset when the candidates were recomputed.
- After scrolling and editing the query, the user could end up looking partway down the new list instead of at the top candidate.

## Fix
- Hoist a `LazyListState` for the candidates `LazyColumn` and snap it to index 0 whenever the candidates list changes (`LaunchedEffect(candidates) { scrollToItem(0) }`).
- Handles the empty→non-empty transition too, since the state persists across the conditional show/hide of the list.

## Test plan
- [ ] Open Goto > Ketik, type a partial book name, scroll the candidates down, then change the query — top of the new list is visible.
- [ ] Clearing the query and typing again still starts at the top.