### PR TITLE
REM-08: extract IsiActivity split-view logic into SplitViewManager

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -4,7 +4,6 @@ import android.content.ActivityNotFoundException
 import android.content.ContentResolver
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.graphics.Point
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableStringBuilder
@@ -21,11 +20,9 @@ import android.util.TypedValue
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewTreeObserver
 import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.ImageButton
-import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.compose.ui.platform.ComposeView
@@ -40,9 +37,7 @@ import androidx.core.text.HtmlCompat
 import androidx.core.text.buildSpannedString
 import androidx.core.text.inSpans
 import androidx.core.util.PatternsCompat
-import androidx.core.view.isGone
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
@@ -102,6 +97,7 @@ import yuku.alkitab.base.verses.VersesControllerImpl
 import yuku.alkitab.base.verses.VersesDataModel
 import yuku.alkitab.base.verses.VersesListeners
 import yuku.alkitab.base.verses.VersesUiModel
+import yuku.alkitab.base.widget.ActiveSplit1
 import yuku.alkitab.base.widget.AriParallelClickData
 import yuku.alkitab.base.widget.DictionaryLinkInfo
 import yuku.alkitab.base.widget.Floater
@@ -116,6 +112,9 @@ import yuku.alkitab.base.widget.ReaderGestureHandler
 import yuku.alkitab.base.widget.ReaderGestureHost
 import yuku.alkitab.base.widget.ReferenceParallelClickData
 import yuku.alkitab.base.widget.SplitHandleButton
+import yuku.alkitab.base.widget.SplitViewActions
+import yuku.alkitab.base.widget.SplitViewHost
+import yuku.alkitab.base.widget.SplitViewManager
 import yuku.alkitab.base.widget.TextAppearancePanel
 import yuku.alkitab.base.widget.TwofingerLinearLayout
 import yuku.alkitab.base.widget.VerseInlineLinkSpan
@@ -136,7 +135,7 @@ private const val TAG = "IsiActivity"
 private const val EXTRA_verseUrl = "verseUrl"
 private const val INSTANCE_STATE_ari = "ari"
 
-class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseActionModeHost, VerseActionModeActions, ReaderGestureHost, ReaderGestureActions {
+class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseActionModeHost, VerseActionModeActions, ReaderGestureHost, ReaderGestureActions, SplitViewHost, SplitViewActions {
     override var uncheckVersesWhenActionModeDestroyed = true
     var needsRestart = false // whether this activity needs to be restarted
 
@@ -187,21 +186,41 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
     private val gestureHandler by lazy { ReaderGestureHandler(this, this) }
 
+    // --- SplitViewActions overrides (state is read via SplitViewHost; the
+    // remaining SplitViewHost properties — `splitRoot`, `splitHandleButton`,
+    // `lsSplit0`, `lsSplit1`, `bVersion`, `leftDrawer` — are marked `override`
+    // at their declarations below).
+    override fun openPrimaryVersionsDialog() = openVersionsDialog()
+    override fun loadChapterIntoSplit1(version: Version, versionId: String, book: Book, chapter_1: Int): Boolean {
+        uncheckVersesWhenActionModeDestroyed = false
+        return try {
+            loadChapterToVersesController(contentResolver, lsSplit1, { dataSplit1 = it }, version, versionId, book, chapter_1, chapter_1, true)
+        } finally {
+            uncheckVersesWhenActionModeDestroyed = true
+        }
+    }
+
+    override fun setSplit1DataModel(model: VersesDataModel) {
+        dataSplit1 = model
+    }
+
+    private val splitViewManager by lazy { SplitViewManager(this, this) }
+
     private lateinit var drawerLayout: DrawerLayout
-    lateinit var leftDrawer: LeftDrawer.Text
+    override lateinit var leftDrawer: LeftDrawer.Text
 
     private lateinit var overlayContainer: FrameLayout
     override lateinit var root: ViewGroup
     lateinit var toolbar: Toolbar
     private lateinit var nontoolbar: View
-    lateinit var lsSplit0: VersesController
-    lateinit var lsSplit1: VersesController
-    lateinit var splitRoot: TwofingerLinearLayout
-    lateinit var splitHandleButton: LabeledSplitHandleButton
+    override lateinit var lsSplit0: VersesController
+    override lateinit var lsSplit1: VersesController
+    override lateinit var splitRoot: TwofingerLinearLayout
+    override lateinit var splitHandleButton: LabeledSplitHandleButton
     private lateinit var bGoto: GotoButton
     private lateinit var bLeft: ImageButton
     private lateinit var bRight: ImageButton
-    private lateinit var bVersion: TextView
+    override lateinit var bVersion: TextView
     override lateinit var floater: Floater
     private lateinit var backForwardListController: BackForwardListController<ImageButton, ImageButton>
     private var fullscreenReferenceToast: Toast? = null
@@ -235,7 +254,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
     val history get() = History
 
-    var actionMode: ActionMode? = null
+    override var actionMode: ActionMode? = null
     private var dictionaryMode = false
     override var textAppearancePanel: TextAppearancePanel? = null
 
@@ -288,19 +307,10 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
 
     /**
-     * Container class to make sure that the fields are changed simultaneously.
+     * The secondary version. Read-only here; ownership lives on [splitViewManager]
+     * (see REM-08). Set to null when the secondary version is not opened.
      */
-    data class ActiveSplit1(
-        val mv: MVersion,
-        val version: Version,
-        val versionId: String,
-    )
-
-    /**
-     * The secondary version. Set to null if the secondary version is not opened,
-     * and to non-null if the secondary version is opened.
-     */
-    var activeSplit1: ActiveSplit1? = null
+    val activeSplit1: ActiveSplit1? get() = splitViewManager.activeSplit1
 
     private val parallelListener: (data: ParallelClickData) -> Unit = { data ->
         if (data is ReferenceParallelClickData) {
@@ -379,26 +389,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
     }
 
-    private val splitRoot_globalLayout = object : ViewTreeObserver.OnGlobalLayoutListener {
-        val lastSize = Point()
-
-        override fun onGlobalLayout() {
-            if (lastSize.x == splitRoot.width && lastSize.y == splitRoot.height) {
-                return // no need to layout now
-            }
-
-            if (activeSplit1 == null) {
-                return // we are not splitting
-            }
-
-            configureSplitSizes()
-
-            lastSize.x = splitRoot.width
-            lastSize.y = splitRoot.height
-        }
-    }
-
-
     private val lsSplit0_selectedVerses = object : VersesController.SelectedVersesListener() {
         override fun onSomeVersesSelected(verses_1: IntArrayList) {
             if (activeSplit1 != null) {
@@ -462,66 +452,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     }
 
 
-    private val splitHandleButton_listener = object : SplitHandleButton.SplitHandleButtonListener {
-        var first = 0
-        var handle = 0
-        var root = 0
-        var prop = 0f // proportion from top or left
-
-        override fun onHandleDragStart() {
-            splitRoot.setOnefingerEnabled(false)
-
-            if (splitHandleButton.orientation == SplitHandleButton.Orientation.vertical) {
-                first = splitHandleButton.top
-                handle = splitHandleButton.height
-                root = splitRoot.height
-            } else {
-                first = splitHandleButton.left
-                handle = splitHandleButton.width
-                root = splitRoot.width
-            }
-
-            prop = Float.MIN_VALUE // guard against glitches
-        }
-
-        override fun onHandleDragMoveX(dxSinceLast: Float, dxSinceStart: Float) {
-            val newW = (first + dxSinceStart).toInt()
-            val maxW = root - handle
-            val width = if (newW < 0) 0 else if (newW > maxW) maxW else newW
-            lsSplit0.setViewLayoutSize(width, ViewGroup.LayoutParams.MATCH_PARENT)
-            prop = width.toFloat() / maxW
-        }
-
-        override fun onHandleDragMoveY(dySinceLast: Float, dySinceStart: Float) {
-            val newH = (first + dySinceStart).toInt()
-            val maxH = root - handle
-            val height = if (newH < 0) 0 else if (newH > maxH) maxH else newH
-            lsSplit0.setViewLayoutSize(ViewGroup.LayoutParams.MATCH_PARENT, height)
-            prop = height.toFloat() / maxH
-        }
-
-        override fun onHandleDragStop() {
-            splitRoot.setOnefingerEnabled(true)
-
-            if (prop != Float.MIN_VALUE) {
-                Preferences.setFloat(Prefkey.lastSplitProp, prop)
-            }
-        }
-    }
-
-    private val splitHandleButton_labelPressed = LabeledSplitHandleButton.ButtonPressListener { which ->
-        when (which) {
-            LabeledSplitHandleButton.Button.rotate -> {
-                closeSplitDisplay()
-                openSplitDisplay()
-            }
-
-            LabeledSplitHandleButton.Button.start -> openVersionsDialog()
-            LabeledSplitHandleButton.Button.end -> openSplitVersionsDialog()
-            else -> throw IllegalStateException("should not happen")
-        }
-    }
-
     data class IntentResult(
         val ari: Int,
         val selectVerse: Boolean = false,
@@ -556,7 +486,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         overlayContainer = findViewById(R.id.overlayContainer)
         root = findViewById(R.id.root)
         splitRoot = findViewById(R.id.splitRoot)
-        splitRoot.viewTreeObserver.addOnGlobalLayoutListener(splitRoot_globalLayout)
 
         splitHandleButton = findViewById(R.id.splitHandleButton)
         floater = findViewById(R.id.floater)
@@ -621,8 +550,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         )
 
         // for splitting
-        splitHandleButton.setListener(splitHandleButton_listener)
-        splitHandleButton.setButtonPressListener(splitHandleButton_labelPressed)
+        splitViewManager.installListeners()
 
         if (BuildConfig.DEBUG) {
             // Runtime assertions: splitRoot must have 3 children;
@@ -737,26 +665,8 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
         backForwardListController.newEntry(openingAri)
 
-        run {
-            // load last split version. This must be after load book, chapter, and verse.
-            val lastSplitVersionId = Preferences.getString(Prefkey.lastSplitVersionId, null)
-            if (lastSplitVersionId != null) {
-                val splitOrientation = Preferences.getString(Prefkey.lastSplitOrientation)
-                if (SplitHandleButton.Orientation.horizontal.name == splitOrientation) {
-                    splitHandleButton.orientation = SplitHandleButton.Orientation.horizontal
-                } else {
-                    splitHandleButton.orientation = SplitHandleButton.Orientation.vertical
-                }
-
-                val splitMv = S.getVersionFromVersionId(lastSplitVersionId)
-                val splitMvActual = splitMv ?: S.getMVersionInternal()
-
-                if (loadSplitVersion(splitMvActual)) {
-                    openSplitDisplay()
-                    displaySplitFollowingMaster(Ari.toVerse(openingAri))
-                }
-            }
-        }
+        // load last split version. This must be after load book, chapter, and verse.
+        splitViewManager.restoreFromPreferences(Ari.toVerse(openingAri))
 
         if (selectVerse) {
             for (i in 0 until selectVerseCount) {
@@ -985,7 +895,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     /**
      * Try to get the verse_1 based on split0, when failed, try to get it from the split1.
      */
-    private fun getVerse_1BasedOnScrolls(): Int {
+    override fun getVerse_1BasedOnScrolls(): Int {
         val split0verse_1 = lsSplit0.getVerse_1BasedOnScroll()
         if (split0verse_1 != 0) return split0verse_1
 
@@ -1032,40 +942,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     private fun displayActiveVersion() {
         bVersion.text = activeSplit0.version.initials
         splitHandleButton.setLabel1("\u25b2 ${activeSplit0.version.initials}")
-    }
-
-    private fun loadSplitVersion(mv: MVersion): Boolean {
-        try {
-            val version = mv.version ?: throw RuntimeException() // caught below
-
-            activeSplit1 = ActiveSplit1(mv, version, mv.versionId)
-
-            splitHandleButton.setLabel2("${version.initials} \u25bc")
-
-            configureTextAppearancePanelForSplitVersion()
-
-            return true
-        } catch (e: Throwable) { // so we don't crash on the beginning of the app
-            AppLog.e(TAG, "Error opening split version", e)
-
-            MaterialAlertDialogBuilder(this@IsiActivity)
-                .setMessage(getString(R.string.version_error_opening, mv.longName))
-                .setPositiveButton(R.string.ok, null)
-                .show()
-
-            return false
-        }
-    }
-
-    private fun configureTextAppearancePanelForSplitVersion() {
-        textAppearancePanel?.let { textAppearancePanel ->
-            val activeSplit1 = activeSplit1
-            if (activeSplit1 == null) {
-                textAppearancePanel.clearSplitVersion()
-            } else {
-                textAppearancePanel.setSplitVersion(activeSplit1.versionId, activeSplit1.version.longName)
-            }
-        }
     }
 
     private fun consumeKey(keyCode: Int): Boolean {
@@ -1270,13 +1146,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             Preferences.setInt(Prefkey.lastChapter, chapter_1)
             Preferences.setInt(Prefkey.lastVerse, getVerse_1BasedOnScrolls())
             Preferences.setString(Prefkey.lastVersionId, activeSplit0.versionId)
-            val activeSplit1 = activeSplit1
-            if (activeSplit1 == null) {
-                Preferences.remove(Prefkey.lastSplitVersionId)
-            } else {
-                Preferences.setString(Prefkey.lastSplitVersionId, activeSplit1.versionId)
-                Preferences.setString(Prefkey.lastSplitOrientation, splitHandleButton.orientation.name)
-            }
+            splitViewManager.saveToPreferences()
         }
 
         history.save()
@@ -1566,7 +1436,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
                 RequestCodes.FromActivity.TextAppearanceGetFonts,
                 RequestCodes.FromActivity.TextAppearanceCustomColors
             )
-            configureTextAppearancePanelForSplitVersion()
+            splitViewManager.configureTextAppearancePanelForSplitVersion()
             textAppearancePanel?.show()
         }
     }
@@ -1598,107 +1468,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             // We may need to apply PerVersion settings.
             applyPreferences()
         }
-    }
-
-    private fun openSplitVersionsDialog() {
-        S.openVersionsDialogWithNone(this, activeSplit1?.versionId) { mv: MVersion? ->
-            if (mv == null) { // closing split version
-                disableSplitVersion()
-            } else {
-                val ok = loadSplitVersion(mv)
-                if (ok) {
-                    openSplitDisplay()
-                    displaySplitFollowingMaster(getVerse_1BasedOnScrolls())
-                } else {
-                    disableSplitVersion()
-                }
-            }
-
-            // We may need to apply PerVersion settings.
-            applyPreferences()
-        }
-    }
-
-    private fun disableSplitVersion() {
-        activeSplit1 = null
-        closeSplitDisplay()
-
-        configureTextAppearancePanelForSplitVersion()
-    }
-
-    private fun openSplitDisplay() {
-        if (splitHandleButton.isVisible) {
-            return // it's already split, no need to do anything
-        }
-
-        configureSplitSizes()
-
-        bVersion.visibility = View.GONE
-        actionMode?.invalidate()
-        leftDrawer.handle.setSplitVersion(true)
-    }
-
-    fun configureSplitSizes() {
-        splitHandleButton.visibility = View.VISIBLE
-
-        var prop = Preferences.getFloat(Prefkey.lastSplitProp, Float.MIN_VALUE)
-        if (prop == Float.MIN_VALUE || prop < 0f || prop > 1f) {
-            prop = 0.5f // guard against invalid values
-        }
-
-        val splitHandleThickness = resources.getDimensionPixelSize(R.dimen.split_handle_thickness)
-        if (splitHandleButton.orientation == SplitHandleButton.Orientation.vertical) {
-            splitRoot.orientation = LinearLayout.VERTICAL
-
-            val totalHeight = splitRoot.height
-            val masterHeight = ((totalHeight - splitHandleThickness) * prop).toInt()
-
-            run {
-                // divide the screen space
-                lsSplit0.setViewLayoutSize(ViewGroup.LayoutParams.MATCH_PARENT, masterHeight)
-            }
-
-            // no need to set height, because it has been set to match_parent, so it takes the remaining space.
-            lsSplit1.setViewVisibility(View.VISIBLE)
-
-            splitHandleButton.updateLayoutParams {
-                width = ViewGroup.LayoutParams.MATCH_PARENT
-                height = splitHandleThickness
-            }
-        } else {
-            splitRoot.orientation = LinearLayout.HORIZONTAL
-
-            val totalWidth = splitRoot.width
-            val masterWidth = ((totalWidth - splitHandleThickness) * prop).toInt()
-
-            run {
-                // divide the screen space
-                lsSplit0.setViewLayoutSize(masterWidth, ViewGroup.LayoutParams.MATCH_PARENT)
-            }
-
-            // no need to set width, because it has been set to match_parent, so it takes the remaining space.
-            lsSplit1.setViewVisibility(View.VISIBLE)
-
-            splitHandleButton.updateLayoutParams {
-                width = splitHandleThickness
-                height = ViewGroup.LayoutParams.MATCH_PARENT
-            }
-        }
-    }
-
-    private fun closeSplitDisplay() {
-        if (splitHandleButton.isGone) {
-            return // it's already not split, no need to do anything
-        }
-
-        splitHandleButton.visibility = View.GONE
-        lsSplit1.setViewVisibility(View.GONE)
-
-        run { lsSplit0.setViewLayoutSize(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT) }
-
-        bVersion.visibility = View.VISIBLE
-        actionMode?.invalidate()
-        leftDrawer.handle.setSplitVersion(false)
     }
 
     private fun menuSearch_click() {
@@ -1793,7 +1562,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             lsSplit0.scrollToVerse(available_verse_1)
         }
 
-        displaySplitFollowingMaster(available_verse_1)
+        splitViewManager.displaySplitFollowingMaster(available_verse_1)
 
         // set goto button text
         val reference = activeSplit0.book.reference(available_chapter_1)
@@ -1882,26 +1651,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
         if (selectedVerses_1 != null) {
             versesController.checkVerses(selectedVerses_1, true)
-        }
-    }
-
-    private fun displaySplitFollowingMaster(verse_1: Int) {
-        val activeSplit1 = activeSplit1
-        if (activeSplit1 != null) { // split1
-            val splitBook = activeSplit1.version.getBook(activeSplit0.book.bookId)
-            if (splitBook == null) {
-                lsSplit1.setEmptyMessage(getString(R.string.split_version_cant_display_verse, activeSplit0.book.reference(this.chapter_1), activeSplit1.version.shortName), S.applied().fontColor)
-                dataSplit1 = VersesDataModel.EMPTY
-            } else {
-                lsSplit1.setEmptyMessage(null, S.applied().fontColor)
-                this.uncheckVersesWhenActionModeDestroyed = false
-                try {
-                    loadChapterToVersesController(contentResolver, lsSplit1, { dataSplit1 = it }, activeSplit1.version, activeSplit1.versionId, splitBook, this.chapter_1, this.chapter_1, true)
-                } finally {
-                    this.uncheckVersesWhenActionModeDestroyed = true
-                }
-                lsSplit1.scrollToVerse(verse_1)
-            }
         }
     }
 
@@ -2342,9 +2091,9 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     override fun cSplitVersion_checkedChange(cSplitVersion: SwitchCompat, isChecked: Boolean) {
         if (isChecked) {
             cSplitVersion.isChecked = false // do it later, at the version chooser dialog
-            openSplitVersionsDialog()
+            splitViewManager.openSplitVersionsDialog()
         } else {
-            disableSplitVersion()
+            splitViewManager.disableSplitVersion()
         }
     }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewActions.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewActions.kt
@@ -1,0 +1,28 @@
+package yuku.alkitab.base.widget
+
+import yuku.alkitab.base.verses.VersesDataModel
+import yuku.alkitab.model.Book
+import yuku.alkitab.model.Version
+
+/**
+ * Write-side surface that [SplitViewManager] invokes to trigger Activity
+ * operations when split state changes. Implemented by the hosting Activity.
+ */
+interface SplitViewActions {
+    /** Re-apply preferences after a split change (PerVersion settings, padding etc.). */
+    fun applyPreferences()
+
+    /** Open the primary version chooser (used by the "start" label on the split handle button). */
+    fun openPrimaryVersionsDialog()
+
+    /**
+     * Load a chapter of [book] from [version] into the split-1 verses controller.
+     * The Activity wraps the underlying loader with the action-mode suppression
+     * flag (so checked verses aren't dropped when split-1 reloads). Returns
+     * true on success.
+     */
+    fun loadChapterIntoSplit1(version: Version, versionId: String, book: Book, chapter_1: Int): Boolean
+
+    /** Replace split-1's data model — used to clear the pane when the split version can't display the current book. */
+    fun setSplit1DataModel(model: VersesDataModel)
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewHost.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewHost.kt
@@ -1,0 +1,43 @@
+package yuku.alkitab.base.widget
+
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.view.ActionMode
+import yuku.alkitab.base.verses.VersesController
+import yuku.alkitab.model.Book
+import yuku.alkitab.model.Version
+
+/**
+ * Read-only state surface that [SplitViewManager] reads from to drive the
+ * split-pane UI. Implemented by the hosting Activity.
+ *
+ * The split manager is allowed to read the master ("split 0") state to know
+ * which book/chapter to mirror in the secondary pane and which book to look up
+ * in the secondary version when "split follows master" runs.
+ */
+interface SplitViewHost {
+    val activity: AppCompatActivity
+    val chapter_1: Int
+    val activeSplit0Book: Book
+    val activeSplit0Version: Version
+
+    // --- Split-pane view refs ---
+    val splitRoot: TwofingerLinearLayout
+    val splitHandleButton: LabeledSplitHandleButton
+    val lsSplit0: VersesController
+    val lsSplit1: VersesController
+
+    /** Toolbar version-name label — hidden while the split pane is open. */
+    val bVersion: TextView
+
+    /** Left drawer; the manager flips `handle.setSplitVersion(...)` on open/close. */
+    val leftDrawer: LeftDrawer.Text
+
+    val textAppearancePanel: TextAppearancePanel?
+
+    /** Action mode is invalidated by the manager when the split state changes. */
+    val actionMode: ActionMode?
+
+    /** Anchor verse used by `openSplitVersionsDialog` after a new split version is loaded. */
+    fun getVerse_1BasedOnScrolls(): Int
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
@@ -1,0 +1,367 @@
+package yuku.alkitab.base.widget
+
+import android.graphics.Point
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewTreeObserver
+import android.widget.LinearLayout
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import yuku.afw.storage.Preferences
+import yuku.alkitab.base.S
+import yuku.alkitab.base.model.MVersion
+import yuku.alkitab.base.storage.Prefkey
+import yuku.alkitab.base.util.AppLog
+import yuku.alkitab.base.verses.VersesDataModel
+import yuku.alkitab.debug.R
+import yuku.alkitab.model.Version
+
+private const val TAG = "SplitViewManager"
+
+/**
+ * Container for the secondary ("split 1") version metadata. Kept as a single
+ * data class so the three fields update atomically (matches the pattern used
+ * by `ActiveSplit0` on `IsiActivity`).
+ */
+data class ActiveSplit1(
+    val mv: MVersion,
+    val version: Version,
+    val versionId: String,
+)
+
+/**
+ * Split-view (a.k.a. "compare versions side-by-side") manager extracted from
+ * `IsiActivity` — see REM-08 in docs/tech-debt-remediation.md.
+ *
+ * Owns the secondary version state ([activeSplit1]) and drives the split-pane
+ * UI: open/close transitions, the split handle drag and label buttons, master
+ * → split chapter following, and persistence of the split version + orientation
+ * + proportion across app restarts.
+ *
+ * The manager keeps no Activity references: it reads view + state through
+ * [host] and triggers Activity operations through [actions].
+ */
+class SplitViewManager(
+    private val host: SplitViewHost,
+    private val actions: SplitViewActions,
+) {
+    /**
+     * The secondary version. Set to null when split view is closed, non-null
+     * while open. Owned by the manager — `IsiActivity` exposes a read-only
+     * accessor that delegates here.
+     */
+    var activeSplit1: ActiveSplit1? = null
+        private set
+
+    // --- View listeners (registered via installListeners) ---
+
+    private val splitRoot_globalLayout = object : ViewTreeObserver.OnGlobalLayoutListener {
+        val lastSize = Point()
+
+        override fun onGlobalLayout() {
+            val splitRoot = host.splitRoot
+            if (lastSize.x == splitRoot.width && lastSize.y == splitRoot.height) {
+                return // no need to layout now
+            }
+
+            if (activeSplit1 == null) {
+                return // we are not splitting
+            }
+
+            configureSplitSizes()
+
+            lastSize.x = splitRoot.width
+            lastSize.y = splitRoot.height
+        }
+    }
+
+    private val splitHandleButton_listener = object : SplitHandleButton.SplitHandleButtonListener {
+        var first = 0
+        var handle = 0
+        var root = 0
+        var prop = 0f // proportion from top or left
+
+        override fun onHandleDragStart() {
+            val splitRoot = host.splitRoot
+            val splitHandleButton = host.splitHandleButton
+            splitRoot.setOnefingerEnabled(false)
+
+            if (splitHandleButton.orientation == SplitHandleButton.Orientation.vertical) {
+                first = splitHandleButton.top
+                handle = splitHandleButton.height
+                root = splitRoot.height
+            } else {
+                first = splitHandleButton.left
+                handle = splitHandleButton.width
+                root = splitRoot.width
+            }
+
+            prop = Float.MIN_VALUE // guard against glitches
+        }
+
+        override fun onHandleDragMoveX(dxSinceLast: Float, dxSinceStart: Float) {
+            val newW = (first + dxSinceStart).toInt()
+            val maxW = root - handle
+            val width = if (newW < 0) 0 else if (newW > maxW) maxW else newW
+            host.lsSplit0.setViewLayoutSize(width, ViewGroup.LayoutParams.MATCH_PARENT)
+            prop = width.toFloat() / maxW
+        }
+
+        override fun onHandleDragMoveY(dySinceLast: Float, dySinceStart: Float) {
+            val newH = (first + dySinceStart).toInt()
+            val maxH = root - handle
+            val height = if (newH < 0) 0 else if (newH > maxH) maxH else newH
+            host.lsSplit0.setViewLayoutSize(ViewGroup.LayoutParams.MATCH_PARENT, height)
+            prop = height.toFloat() / maxH
+        }
+
+        override fun onHandleDragStop() {
+            host.splitRoot.setOnefingerEnabled(true)
+
+            if (prop != Float.MIN_VALUE) {
+                Preferences.setFloat(Prefkey.lastSplitProp, prop)
+            }
+        }
+    }
+
+    private val splitHandleButton_labelPressed = LabeledSplitHandleButton.ButtonPressListener { which ->
+        when (which) {
+            LabeledSplitHandleButton.Button.rotate -> {
+                closeSplitDisplay()
+                openSplitDisplay()
+            }
+
+            LabeledSplitHandleButton.Button.start -> actions.openPrimaryVersionsDialog()
+            LabeledSplitHandleButton.Button.end -> openSplitVersionsDialog()
+            else -> throw IllegalStateException("should not happen")
+        }
+    }
+
+    /** Registers the global layout, drag, and label listeners on the split-view widgets. */
+    fun installListeners() {
+        host.splitRoot.viewTreeObserver.addOnGlobalLayoutListener(splitRoot_globalLayout)
+        host.splitHandleButton.setListener(splitHandleButton_listener)
+        host.splitHandleButton.setButtonPressListener(splitHandleButton_labelPressed)
+    }
+
+    // --- Persistence ---
+
+    /**
+     * Restore the split version + orientation from preferences and, if present,
+     * open the split pane scrolled to [verse_1]. Called from `IsiActivity.onCreate`
+     * after the master version has been displayed.
+     */
+    fun restoreFromPreferences(verse_1: Int) {
+        val lastSplitVersionId = Preferences.getString(Prefkey.lastSplitVersionId, null) ?: return
+
+        val splitOrientation = Preferences.getString(Prefkey.lastSplitOrientation)
+        host.splitHandleButton.orientation = if (SplitHandleButton.Orientation.horizontal.name == splitOrientation) {
+            SplitHandleButton.Orientation.horizontal
+        } else {
+            SplitHandleButton.Orientation.vertical
+        }
+
+        val splitMv = S.getVersionFromVersionId(lastSplitVersionId)
+        val splitMvActual = splitMv ?: S.getMVersionInternal()
+
+        if (loadSplitVersion(splitMvActual)) {
+            openSplitDisplay()
+            displaySplitFollowingMaster(verse_1)
+        }
+    }
+
+    /**
+     * Persist the current split version + orientation (or clear it if the pane
+     * is closed). Called from `IsiActivity.onStop`.
+     */
+    fun saveToPreferences() {
+        val activeSplit1 = activeSplit1
+        if (activeSplit1 == null) {
+            Preferences.remove(Prefkey.lastSplitVersionId)
+        } else {
+            Preferences.setString(Prefkey.lastSplitVersionId, activeSplit1.versionId)
+            Preferences.setString(Prefkey.lastSplitOrientation, host.splitHandleButton.orientation.name)
+        }
+    }
+
+    // --- Public API ---
+
+    /**
+     * Prompt the user to pick a secondary version (or "None" to close split).
+     * Called from the left drawer "split version" toggle and the split-handle
+     * "end" label tap.
+     */
+    fun openSplitVersionsDialog() {
+        S.openVersionsDialogWithNone(host.activity, activeSplit1?.versionId) { mv: MVersion? ->
+            if (mv == null) { // closing split version
+                disableSplitVersion()
+            } else {
+                val ok = loadSplitVersion(mv)
+                if (ok) {
+                    openSplitDisplay()
+                    displaySplitFollowingMaster(host.getVerse_1BasedOnScrolls())
+                } else {
+                    disableSplitVersion()
+                }
+            }
+
+            // We may need to apply PerVersion settings.
+            actions.applyPreferences()
+        }
+    }
+
+    /** Close the split pane and forget the secondary version. */
+    fun disableSplitVersion() {
+        activeSplit1 = null
+        closeSplitDisplay()
+
+        configureTextAppearancePanelForSplitVersion()
+    }
+
+    /**
+     * Mirror the master pane's chapter into the split pane, scrolled to [verse_1].
+     * No-op when the split pane is closed. If the secondary version doesn't have
+     * the master book, the pane is cleared and an explanatory message is shown.
+     */
+    fun displaySplitFollowingMaster(verse_1: Int) {
+        val activeSplit1 = activeSplit1 ?: return
+
+        val splitBook = activeSplit1.version.getBook(host.activeSplit0Book.bookId)
+        if (splitBook == null) {
+            host.lsSplit1.setEmptyMessage(
+                host.activity.getString(
+                    R.string.split_version_cant_display_verse,
+                    host.activeSplit0Book.reference(host.chapter_1),
+                    activeSplit1.version.shortName,
+                ),
+                S.applied().fontColor,
+            )
+            actions.setSplit1DataModel(VersesDataModel.EMPTY)
+        } else {
+            host.lsSplit1.setEmptyMessage(null, S.applied().fontColor)
+            actions.loadChapterIntoSplit1(activeSplit1.version, activeSplit1.versionId, splitBook, host.chapter_1)
+            host.lsSplit1.scrollToVerse(verse_1)
+        }
+    }
+
+    /**
+     * Push the current split version into the text-appearance panel (or clear
+     * it when split is closed). Called by `IsiActivity` when the panel opens
+     * and by [loadSplitVersion] / [disableSplitVersion] when split state changes.
+     */
+    fun configureTextAppearancePanelForSplitVersion() {
+        val textAppearancePanel = host.textAppearancePanel ?: return
+        val activeSplit1 = activeSplit1
+        if (activeSplit1 == null) {
+            textAppearancePanel.clearSplitVersion()
+        } else {
+            textAppearancePanel.setSplitVersion(activeSplit1.versionId, activeSplit1.version.longName)
+        }
+    }
+
+    // --- Internal ---
+
+    /** Loads [mv] as the split version (no UI side effects beyond updating panel + handle label). */
+    private fun loadSplitVersion(mv: MVersion): Boolean {
+        try {
+            val version = mv.version ?: throw RuntimeException() // caught below
+
+            activeSplit1 = ActiveSplit1(mv, version, mv.versionId)
+
+            host.splitHandleButton.setLabel2("${version.initials} ▼")
+
+            configureTextAppearancePanelForSplitVersion()
+
+            return true
+        } catch (e: Throwable) { // so we don't crash on the beginning of the app
+            AppLog.e(TAG, "Error opening split version", e)
+
+            MaterialAlertDialogBuilder(host.activity)
+                .setMessage(host.activity.getString(R.string.version_error_opening, mv.longName))
+                .setPositiveButton(R.string.ok, null)
+                .show()
+
+            return false
+        }
+    }
+
+    private fun openSplitDisplay() {
+        if (host.splitHandleButton.isVisible) {
+            return // it's already split, no need to do anything
+        }
+
+        configureSplitSizes()
+
+        host.bVersion.visibility = View.GONE
+        host.actionMode?.invalidate()
+        host.leftDrawer.handle.setSplitVersion(true)
+    }
+
+    private fun configureSplitSizes() {
+        val splitHandleButton = host.splitHandleButton
+        val splitRoot = host.splitRoot
+
+        splitHandleButton.visibility = View.VISIBLE
+
+        var prop = Preferences.getFloat(Prefkey.lastSplitProp, Float.MIN_VALUE)
+        if (prop == Float.MIN_VALUE || prop < 0f || prop > 1f) {
+            prop = 0.5f // guard against invalid values
+        }
+
+        val splitHandleThickness = host.activity.resources.getDimensionPixelSize(R.dimen.split_handle_thickness)
+        if (splitHandleButton.orientation == SplitHandleButton.Orientation.vertical) {
+            splitRoot.orientation = LinearLayout.VERTICAL
+
+            val totalHeight = splitRoot.height
+            val masterHeight = ((totalHeight - splitHandleThickness) * prop).toInt()
+
+            run {
+                // divide the screen space
+                host.lsSplit0.setViewLayoutSize(ViewGroup.LayoutParams.MATCH_PARENT, masterHeight)
+            }
+
+            // no need to set height, because it has been set to match_parent, so it takes the remaining space.
+            host.lsSplit1.setViewVisibility(View.VISIBLE)
+
+            splitHandleButton.updateLayoutParams {
+                width = ViewGroup.LayoutParams.MATCH_PARENT
+                height = splitHandleThickness
+            }
+        } else {
+            splitRoot.orientation = LinearLayout.HORIZONTAL
+
+            val totalWidth = splitRoot.width
+            val masterWidth = ((totalWidth - splitHandleThickness) * prop).toInt()
+
+            run {
+                // divide the screen space
+                host.lsSplit0.setViewLayoutSize(masterWidth, ViewGroup.LayoutParams.MATCH_PARENT)
+            }
+
+            // no need to set width, because it has been set to match_parent, so it takes the remaining space.
+            host.lsSplit1.setViewVisibility(View.VISIBLE)
+
+            splitHandleButton.updateLayoutParams {
+                width = splitHandleThickness
+                height = ViewGroup.LayoutParams.MATCH_PARENT
+            }
+        }
+    }
+
+    private fun closeSplitDisplay() {
+        if (host.splitHandleButton.isGone) {
+            return // it's already not split, no need to do anything
+        }
+
+        host.splitHandleButton.visibility = View.GONE
+        host.lsSplit1.setViewVisibility(View.GONE)
+
+        run { host.lsSplit0.setViewLayoutSize(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT) }
+
+        host.bVersion.visibility = View.VISIBLE
+        host.actionMode?.invalidate()
+        host.leftDrawer.handle.setSplitVersion(false)
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
@@ -270,7 +270,7 @@ class SplitViewManager(
 
             activeSplit1 = ActiveSplit1(mv, version, mv.versionId)
 
-            host.splitHandleButton.setLabel2("${version.initials} ▼")
+            host.splitHandleButton.setLabel2("${version.initials} \u25bc")
 
             configureTextAppearancePanelForSplitVersion()
 

--- a/docs/tech-debt-remediation.md
+++ b/docs/tech-debt-remediation.md
@@ -165,18 +165,32 @@ Coroutines and `lifecycleScope` were already on the classpath transitively throu
 
 ---
 
-### REM-08: Extract IsiActivity Split View Manager
+### REM-08: Extract IsiActivity Split View Manager ✅ COMPLETED
 **Addresses:** TD-01 (split view cluster)  
 **Module:** Main reader  
 **BRICE:** B=3 R=2 I=3 C=4 E=4 → **3.2**
 
-**Steps:**
-1. Create `SplitViewManager.kt` containing `openSplitDisplay()` (line 2108), `closeSplitDisplay()` (line 2168), `displaySplitFollowingMaster()` (line 2365), `loadSplitVersion()` (line 1458) — currently scattered across `IsiActivity.kt`
-2. Encapsulate `activeSplit1`, split layout views, and split-related preferences
-3. Define callbacks: `onSplitOpened`, `onSplitClosed`, `onSplitVersionChanged`
-4. `IsiActivity` holds a `SplitViewManager` instance and delegates split operations
+**What was done:**
+1. ✅ Created `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt` (~367 lines) that owns `activeSplit1` and the split-pane UI: `openSplitDisplay()`, `closeSplitDisplay()`, `configureSplitSizes()`, `displaySplitFollowingMaster()`, `loadSplitVersion()`, `disableSplitVersion()`, `openSplitVersionsDialog()`, `configureTextAppearancePanelForSplitVersion()`, plus `restoreFromPreferences(verse_1)` / `saveToPreferences()` for the `lastSplitVersionId` / `lastSplitOrientation` / `lastSplitProp` round-trip.
+2. ✅ Moved three listener objects out of `IsiActivity.kt`: the `splitRoot_globalLayout` (`OnGlobalLayoutListener` that re-invokes `configureSplitSizes` on bounds change), `splitHandleButton_listener` (drag-prop math + `lastSplitProp` persistence), and `splitHandleButton_labelPressed` (rotate / start / end label-button dispatch).
+3. ✅ Defined two interfaces following the REM-06 / REM-07 pattern: `SplitViewHost.kt` (read-only state — `splitRoot`, `splitHandleButton`, `lsSplit0`, `lsSplit1`, `bVersion`, `leftDrawer`, `textAppearancePanel`, `actionMode`, `chapter_1`, `activeSplit0Book`, `activeSplit0Version`, plus `getVerse_1BasedOnScrolls()`) and `SplitViewActions.kt` (write-side triggers — `applyPreferences`, `openPrimaryVersionsDialog`, `loadChapterIntoSplit1`, `setSplit1DataModel`).
+4. ✅ `IsiActivity` now implements both interfaces, holds a `splitViewManager by lazy { SplitViewManager(this, this) }`, and `onCreate` calls `splitViewManager.installListeners()` (replaces the inline `addOnGlobalLayoutListener` + two handle-button listener setups) and `splitViewManager.restoreFromPreferences(...)` (replaces the 17-line `Preferences.getString(Prefkey.lastSplitVersionId)` restore block). `display(...)` delegates to `splitViewManager.displaySplitFollowingMaster(...)`; `onStop` to `splitViewManager.saveToPreferences()`; `cSplitVersion_checkedChange` to the manager's open/disable methods.
+5. ✅ Moved `ActiveSplit1` from a nested data class inside `IsiActivity` to a top-level data class in `yuku.alkitab.base.widget`. `IsiActivity.activeSplit1` is now a read-only `val` getter that delegates to `splitViewManager.activeSplit1` — every existing call site (audio bar host, action mode host overrides, `applyPreferences` padding logic, `consumeKey` split scrolling, `VerseInlineLinkSpan` xref/footnote routing, Ribka eligibility, etc.) keeps reading `activeSplit1?.version` unchanged.
+6. ✅ Behavior preserved verbatim: split-pane open/close transitions (including `bVersion` show/hide, `leftDrawer.handle.setSplitVersion(...)` toggling, and `actionMode.invalidate()` re-prepare), the split handle drag with proportion clamp and `lastSplitProp` persistence, the rotate-orientation label button, master → split chapter following including the "split version can't display this book" empty-message path, the uncheck-suppression guard around split chapter loads (via the new `loadChapterIntoSplit1` action), text-appearance-panel split version label, and the `lastSplitVersionId` / `lastSplitOrientation` save/restore round-trip across app restarts.
 
-**Difficulty:** Medium (4-6 hours).
+**Result:** `IsiActivity.kt` shrank from 2411 → 2160 lines (−251 lines). Split view is now a self-contained component testable in isolation; `activeSplit1` is read-only from `IsiActivity`'s perspective (all writes happen inside the manager).
+
+**Files touched:**
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt` (new, 367 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewHost.kt` (new, 43 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewActions.kt` (new, 28 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt` (modified: −251 lines, class signature gains two interfaces, four import lines added, six lateinit vars + `actionMode` + `getVerse_1BasedOnScrolls()` widened to `override`)
+
+**Verification:**
+- `./gradlew assemblePlainDebug` → BUILD SUCCESSFUL in 14s (cold) / 5s (warm)
+- `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` → BUILD SUCCESSFUL, 420 tests pass per variant
+
+**Difficulty:** Medium (came in around the lower end of the 4-6 hour estimate). The fan-out of `activeSplit1` references was the main risk; addressed by keeping a read-through getter on the activity so no call site outside the moved methods had to change.
 
 ---
 
@@ -196,7 +210,7 @@ Coroutines and `lifecycleScope` were already on the classpath transitively throu
 3. `IsiActivity` observes StateFlows and updates UI
 4. Navigation history moves to ViewModel (survives rotation)
 
-**Prerequisite:** ~~REM-06~~✅, ~~REM-07~~✅, REM-08 should be done first to reduce IsiActivity size before extracting ViewModel.
+**Prerequisite:** ~~REM-06~~✅, ~~REM-07~~✅, ~~REM-08~~✅ should be done first to reduce IsiActivity size before extracting ViewModel.
 
 **Difficulty:** Hard (2-3 days). Risk: extensive refactoring of the largest file in the codebase.
 
@@ -700,7 +714,7 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 | REM-14 | ~~Replace material-dialogs~~ ✅ | **3.4** | 2 |
 | REM-18 | Add test coverage | **3.4** | 2 |
 | REM-24 | Refactor S.kt service locator | **3.2** | 2 |
-| REM-08 | Extract split view manager | **3.2** | 2 |
+| REM-08 | ~~Extract split view manager~~ ✅ | **3.2** | 2 |
 | REM-11 | Room migration (Version) | **3.2** | 2 |
 | REM-15 | Introduce coroutines | **3.2** | 3 |
 | REM-16 | Java→Kotlin conversion | **3.0** | 3 |
@@ -714,7 +728,7 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 
 **Sprint 1 (1 week):** ~~REM-01~~✅, ~~REM-02~~✅, ~~REM-04~~✅, ~~REM-05~~✅ — quick safety fixes (all done)  
 **Sprint 2 (1 week):** ~~REM-03~~✅ — LocalBroadcastManager removal (done)  
-**Sprint 3 (2 weeks):** ~~REM-07~~✅, ~~REM-06~~✅, REM-08 — IsiActivity decomposition (REM-06, REM-07 done)  
+**Sprint 3 (2 weeks):** ~~REM-07~~✅, ~~REM-06~~✅, ~~REM-08~~✅ — IsiActivity decomposition (REM-06, REM-07, REM-08 done)  
 **Sprint 4 (1 week):** ~~REM-12~~✅, ~~REM-14~~✅ — deprecated library replacements (done)  
 **Sprint 5 (2 weeks):** REM-10, REM-11 — Room migration for core tables  
 **Sprint 6 (2 weeks):** REM-09, ~~REM-18a-f~~✅ — ViewModel + test coverage (REM-18a/b/c/d/e/f done)  


### PR DESCRIPTION
## Summary

Third in the REM-06 → REM-07 → REM-08 series of `IsiActivity` decompositions. The split-pane logic (open/close, handle drag, master → split chapter following, persistence) is moved into a self-contained `SplitViewManager` that owns `activeSplit1`.

- New: `SplitViewManager.kt` (367 lines) + `SplitViewHost.kt` / `SplitViewActions.kt` seam interfaces, following the same pattern as REM-06 (`ReaderGestureHandler`) and REM-07 (`VerseActionModeController`).
- `IsiActivity.kt`: **2411 → 2160 lines (−251)**. `activeSplit1` becomes a read-through getter delegating to the manager, so dozens of existing call sites (audio bar host, action mode host, `VerseInlineLinkSpan`, padding logic, etc.) keep reading `activeSplit1?.version` unchanged.
- The three split listener objects (`splitRoot_globalLayout`, `splitHandleButton_listener`, `splitHandleButton_labelPressed`) move into the manager and are wired up by a single `splitViewManager.installListeners()` call in `onCreate`.
- `ActiveSplit1` is promoted from a nested data class to a top-level type in the `widget` package.

See `docs/tech-debt-remediation.md` REM-08 entry for the full ✅ COMPLETED block.

## Test plan

- [x] `./gradlew assemblePlainDebug` — BUILD SUCCESSFUL
- [x] `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` — 420 tests pass per variant (840 total)
- [ ] Manual trace verified: opening the split panel from the left drawer, closing it, switching the split version, the rotate-orientation label button, master → split chapter following (including the "split version can't display this book" empty-message path), and the `lastSplitVersionId` / `lastSplitOrientation` / `lastSplitProp` save/restore round-trip across app restarts
- [ ] Smoke test on a device: open Bible reader, open split with a second version, scroll the master pane, drag the split handle to resize, rotate split orientation, close split