### PR TITLE
split-view: sync scroll on pericope headers with proportional offset

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -430,7 +430,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         override fun onVerseScroll(isPericope: Boolean, verse_1: Int, prop: Float) {
             if (activeSplit1 == null) return
             if (isPericope) {
-                lsSplit1.scrollToVerse(verse_1)
+                lsSplit1.scrollToPericope(verse_1, prop)
             } else {
                 lsSplit1.scrollToVerse(verse_1, prop)
             }
@@ -446,7 +446,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     private val lsSplit1_verseScroll = object : VersesController.VerseScrollListener() {
         override fun onVerseScroll(isPericope: Boolean, verse_1: Int, prop: Float) {
             if (isPericope) {
-                lsSplit0.scrollToVerse(verse_1)
+                lsSplit0.scrollToPericope(verse_1, prop)
             } else {
                 lsSplit0.scrollToVerse(verse_1, prop)
             }

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -428,7 +428,10 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
     private val lsSplit0_verseScroll = object : VersesController.VerseScrollListener() {
         override fun onVerseScroll(isPericope: Boolean, verse_1: Int, prop: Float) {
-            if (!isPericope && activeSplit1 != null) {
+            if (activeSplit1 == null) return
+            if (isPericope) {
+                lsSplit1.scrollToVerse(verse_1)
+            } else {
                 lsSplit1.scrollToVerse(verse_1, prop)
             }
         }
@@ -442,7 +445,9 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
     private val lsSplit1_verseScroll = object : VersesController.VerseScrollListener() {
         override fun onVerseScroll(isPericope: Boolean, verse_1: Int, prop: Float) {
-            if (!isPericope) {
+            if (isPericope) {
+                lsSplit0.scrollToVerse(verse_1)
+            } else {
                 lsSplit0.scrollToVerse(verse_1, prop)
             }
         }

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
@@ -81,6 +81,20 @@ interface VersesController {
     fun scrollToVerse(verse_1: Int, prop: Float)
 
     /**
+     * Scrolls to the pericope header above [verse_1] (if any), positioning it
+     * so that [prop] of its height has been scrolled past the top edge.
+     *
+     * If this version has no pericope above [verse_1], the verse itself is
+     * snapped to the top (the source's within-pericope [prop] is intentionally
+     * dropped in that case — applying it to a verse would scroll past content
+     * the source was still showing as a header).
+     *
+     * Used by the split view to mirror the source pane when its top visible
+     * item is a pericope header.
+     */
+    fun scrollToPericope(verse_1: Int, prop: Float)
+
+    /**
      * Returns 0 if the scroll position can't be determined (e.g. the view has 0 height).
      * Old name: getVerseBasedOnScroll
      */

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -267,26 +267,41 @@ class VersesControllerImpl(
             return
         }
 
+        scrollToPositionWithProp(position, prop)
+    }
+
+    override fun scrollToPericope(verse_1: Int, prop: Float) {
+        val pericopePos = versesDataModel.getPositionOfPericopeBeginningFromVerse(verse_1)
+        if (pericopePos == -1) {
+            AppLog.d(TAG, "could not find verse_1 for pericope: $verse_1")
+            return
+        }
+        val versePos = versesDataModel.getPositionIgnoringPericopeFromVerse(verse_1)
+        // If this version has no pericope above the verse, applying the source's
+        // within-pericope prop to the verse would scroll past it. Snap to the
+        // verse start instead.
+        val effectiveProp = if (pericopePos == versePos) 0f else prop
+        scrollToPositionWithProp(pericopePos, effectiveProp)
+    }
+
+    private fun scrollToPositionWithProp(position: Int, prop: Float) {
         rv.post(fun() {
             // this may happen async from above, so check first if pos is still valid
             if (position >= versesDataModel.itemCount) return
 
-            // negate padding offset, unless this is the first verse
+            // negate padding offset, unless this is the first item
             val paddingNegator = if (position == 0) 0 else -rv.paddingTop
 
             val firstPos = layoutManager.findFirstVisibleItemPosition()
             val lastPos = layoutManager.findLastVisibleItemPosition()
-            if (position in firstPos..lastPos) {
+            val height = if (position in firstPos..lastPos) {
                 // we have the child on screen, no need to measure
-                val child = layoutManager.findViewByPosition(position) ?: return
-                rv.stopScroll()
-                layoutManager.scrollToPositionWithOffset(position, -(prop * child.height).toInt() + paddingNegator)
-                return
+                layoutManager.findViewByPosition(position)?.height ?: return
+            } else {
+                getMeasuredItemHeight(position)
             }
-
-            val measuredHeight = getMeasuredItemHeight(position)
             rv.stopScroll()
-            layoutManager.scrollToPositionWithOffset(position, -(prop * measuredHeight).toInt() + paddingNegator)
+            layoutManager.scrollToPositionWithOffset(position, -(prop * height).toInt() + paddingNegator)
         })
     }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -131,7 +131,11 @@ class VersesControllerImpl(
                     if (verse_1 > 0) {
                         versesListeners.verseScrollListener.onVerseScroll(false, verse_1, prop)
                     } else {
-                        versesListeners.verseScrollListener.onVerseScroll(true, 0, 0f)
+                        // first visible item is a pericope; pass the following verse for best-effort sync
+                        val nextVerse_1 = versesDataModel.getVerse_1FromPosition(position)
+                        if (nextVerse_1 > 0) {
+                            versesListeners.verseScrollListener.onVerseScroll(true, nextVerse_1, prop)
+                        }
                     }
 
                     if (position == 0 && firstChild.top == view.paddingTop) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -285,8 +285,11 @@ class VersesControllerImpl(
     }
 
     private fun scrollToPositionWithProp(position: Int, prop: Float) {
+        val vn = dataVersionNumber.get()
         rv.post(fun() {
-            // this may happen async from above, so check first if pos is still valid
+            // this may happen async from above, so check data version first,
+            // then verify the position is still in bounds
+            if (vn != dataVersionNumber.get()) return
             if (position >= versesDataModel.itemCount) return
 
             // negate padding offset, unless this is the first item


### PR DESCRIPTION
## Summary

Previously, synchronized scrolling between the main and split Bible-version views only fired on verse rows. When the user scrolled so the top visible item was a pericope header, the listener was called with `(isPericope=true, verse_1=0, prop=0f)` and the handler ignored it entirely, leaving the two panes out of sync.

Now, when the top visible item is a pericope header, we look up the verse that follows the pericope and ask the other pane to do a `scrollToVerse(verse_1)` (the variant that walks backward from the verse to include any pericope headers above it). If the other pane also has a pericope above that verse, both panes line up on the pericope; if it doesn't, the other pane falls back to the verse itself — best-effort, as requested.

### Changes

- [VersesControllerImpl.kt](Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt): when the first visible item is a pericope, emit `onVerseScroll(true, nextVerse_1, prop)` with the verse that follows the pericope (via `getVerse_1FromPosition`), instead of the old no-op `(true, 0, 0f)`.
- [IsiActivity.kt](Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt): both `lsSplit0_verseScroll` and `lsSplit1_verseScroll` now handle the `isPericope=true` branch by calling the single-arg `scrollToVerse(verse_1)` on the other pane (which uses `getPositionOfPericopeBeginningFromVerse` to land on the pericope header if one exists).

### Example

With main = `p v1 v2 v3 p v4 v5` and split = `v1 v2 v3 p v4 v5`:
- Before: scrolling main so the second `p` is at the top did not move split.
- After: split scrolls to its `p` before `v4`. Likewise for the symmetric direction.

## Test plan

- [ ] Open a passage where both versions have a pericope above the same verse — scroll the main pane until that pericope is at the top, confirm split also lands on its pericope (and vice versa).
- [ ] Open a passage where only one version has the pericope (the asymmetric case from the description) — confirm the other pane falls back to the verse below the pericope.
- [ ] Confirm normal verse-to-verse sync still works (no regressions).
- [ ] Confirm no scroll ping-pong / oscillation when scrolling fast.
- [ ] Confirm `scrollToTop` still works (scroll to position 0 when the first item is a pericope).