### PR TITLE
REM-24: migrate ~216 S.* call sites to App.services across 44 files

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/App.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/App.java
@@ -31,8 +31,15 @@ public class App extends yuku.afw.App {
      * new code can depend on narrow interfaces (and tests can swap fakes in) without
      * reaching into the {@link S} service locator directly. Existing {@code S.foo}
      * call sites are being migrated incrementally — see REM-24.
+     *
+     * <p>Initialized eagerly at class-load so call sites can read it before
+     * {@link #staticInit()} has run. The adapter properties on {@link S} are
+     * cheap object literals that only touch context/preferences when their
+     * methods are invoked, so this is safe even from tests that haven't booted
+     * the full {@link App} (e.g. by overriding the Application class in
+     * Robolectric and calling {@code yuku.afw.App.initWithAppContext} directly).
      */
-    public static AppServices services;
+    public static AppServices services = new AppServices(S.storage, S.versions, S.uiDimensions);
 
     enum GsonWrapper {
         INSTANCE;
@@ -57,11 +64,6 @@ public class App extends yuku.afw.App {
         if (context == null) {
             throw new RuntimeException("yuku.afw.App.context must have been set via initWithAppContext(Context) before calling this method.");
         }
-
-        // Wire up the service container before anything else — S exposes adapter
-        // properties that satisfy each service interface; tests can override this
-        // field with fakes.
-        services = new AppServices(S.storage, S.versions, S.uiDimensions);
 
         FeedbackSender.getInstance(context).trySend();
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -293,11 +293,11 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             if (_activeSplit0 != null) {
                 return _activeSplit0
             }
-            val version = S.activeVersion()
+            val version = App.services.versions.activeVersion()
             val new = ActiveSplit0(
-                mv = S.activeMVersion(),
+                mv = App.services.versions.activeMVersion(),
                 version = version,
-                versionId = S.activeVersionId(),
+                versionId = App.services.versions.activeVersionId(),
                 book = version.firstBook
             )
             this._activeSplit0 = new
@@ -379,11 +379,11 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     private val pinDropListener = object : VersesController.PinDropListener() {
         override fun onPinDropped(presetId: Int, ari: Int) {
 
-            val progressMark = S.db.getProgressMarkByPresetId(presetId)
+            val progressMark = App.services.storage.db.getProgressMarkByPresetId(presetId)
             if (progressMark != null) {
                 progressMark.ari = ari
                 progressMark.modifyTime = Date()
-                S.db.insertOrUpdateProgressMark(progressMark)
+                App.services.storage.db.insertOrUpdateProgressMark(progressMark)
             }
 
             AppEvents.emitAttributeMapChanged()
@@ -638,11 +638,11 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
                     activeSplit0 = activeSplit0.copy(book = activeBook2)
                 } else {
                     // version failed to load, so books also failed to load. Fallback to internal!
-                    val mv = S.getMVersionInternal()
-                    S.setActiveVersion(mv)
+                    val mv = App.services.versions.getMVersionInternal()
+                    App.services.versions.setActiveVersion(mv)
 
-                    val version = S.activeVersion()
-                    val versionId = S.activeVersionId()
+                    val version = App.services.versions.activeVersion()
+                    val versionId = App.services.versions.activeVersionId()
                     val book = version.firstBook // this is assumed to be never null
                     activeSplit0 = ActiveSplit0(
                         mv = mv,
@@ -746,8 +746,8 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
         if (audioHighlightColorCached == 0) {
             audioHighlightColorCached = AudioHighlightColor.pickHighlightColor(
-                readingBackground = S.applied().backgroundColor,
-                verseTextColor = S.applied().fontColor,
+                readingBackground = App.services.uiDimensions.applied().backgroundColor,
+                verseTextColor = App.services.uiDimensions.applied().fontColor,
             )
         }
         controller.setAudioHighlight(verse_1, audioHighlightColorCached)
@@ -914,14 +914,14 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             val bookId = activeSplit0.book.bookId
 
             // Set globally
-            S.setActiveVersion(mv)
+            App.services.versions.setActiveVersion(mv)
 
             // If a book is not found, get any book
             val book = version.getBook(bookId) ?: version.firstBook
             activeSplit0 = ActiveSplit0(
                 mv = mv,
                 version = version,
-                versionId = S.activeVersionId(),
+                versionId = App.services.versions.activeVersionId(),
                 book = book
             )
 
@@ -1096,11 +1096,11 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
     override fun applyPreferences() {
         // make sure S applied variables are set first
-        S.recalculate()
+        App.services.uiDimensions.recalculate()
 
         // apply background color, and clear window background to prevent overdraw
         window.setBackgroundDrawableResource(android.R.color.transparent)
-        val backgroundColor = S.applied().backgroundColor
+        val backgroundColor = App.services.uiDimensions.applied().backgroundColor
         root.setBackgroundColor(backgroundColor)
 
         // scrollbar must be visible!
@@ -1116,7 +1116,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
 
         fun calculateTextSizeMult(versionId: String?): Float {
-            return if (versionId == null) 1f else S.db.getPerVersionSettings(versionId).fontSizeMultiplier
+            return if (versionId == null) 1f else App.services.storage.db.getPerVersionSettings(versionId).fontSizeMultiplier
         }
 
         // necessary
@@ -1645,7 +1645,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         // # fill adapter with new data. make sure all checked states are reset
         versesController.uncheckAllVerses(true)
 
-        val versesAttributes = VerseAttributeLoader.load(S.db, cr, ariBc, verses)
+        val versesAttributes = VerseAttributeLoader.load(App.services.storage.db, cr, ariBc, verses)
 
         val newData = VersesDataModel(ariBc, verses, nblock, pericope_aris, pericope_blocks, version, versionId, versesAttributes)
         dataSetter(newData)
@@ -1733,7 +1733,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
 
         override fun onBookmarkAttributeClick(version: Version, versionId: String, ari: Int) {
-            val markers = S.db.listMarkersForAriKind(ari, Marker.Kind.bookmark)
+            val markers = App.services.storage.db.listMarkersForAriKind(ari, Marker.Kind.bookmark)
             if (markers.size == 1) {
                 openBookmarkDialog(markers[0]._id)
             } else {
@@ -1750,7 +1750,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
 
         override fun onNoteAttributeClick(version: Version, versionId: String, ari: Int) {
-            val markers = S.db.listMarkersForAriKind(ari, Marker.Kind.note)
+            val markers = App.services.storage.db.listMarkersForAriKind(ari, Marker.Kind.note)
             if (markers.size == 1) {
                 openNoteDialog(markers[0]._id)
             } else {
@@ -1776,7 +1776,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             val kind: Marker.Kind,
         ) : MaterialDialogAdapterHelper.Adapter() {
 
-            val textSizeMult = S.db.getPerVersionSettings(versionId).fontSizeMultiplier
+            val textSizeMult = App.services.storage.db.getPerVersionSettings(versionId).fontSizeMultiplier
 
             override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
                 return MarkerHolder(layoutInflater.inflate(R.layout.item_marker, parent, false))
@@ -1811,7 +1811,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
                         holder.lSnippet.visibility = View.GONE
 
-                        val labels = S.db.listLabelsByMarker(marker)
+                        val labels = App.services.storage.db.listLabelsByMarker(marker)
                         if (labels.size != 0) {
                             holder.panelLabels.visibility = View.VISIBLE
                             holder.panelLabels.removeAllViews()
@@ -1828,7 +1828,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
                         Appearances.applyTextAppearance(holder.lSnippet, textSizeMult)
                     }
 
-                    holder.itemView.setBackgroundColor(S.applied().backgroundColor)
+                    holder.itemView.setBackgroundColor(App.services.uiDimensions.applied().backgroundColor)
                 }
 
                 holder.itemView.setOnClickListener {
@@ -1850,7 +1850,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
 
         override fun onProgressMarkAttributeClick(version: Version, versionId: String, preset_id: Int) {
-            S.db.getProgressMarkByPresetId(preset_id)?.let { progressMark ->
+            App.services.storage.db.getProgressMarkByPresetId(preset_id)?.let { progressMark ->
                 ProgressMarkRenameDialog.show(this@IsiActivity, progressMark, object : ProgressMarkRenameDialog.Listener {
                     override fun onOked() {
                         lsSplit0.uncheckAllVerses(true)
@@ -2042,7 +2042,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         data: VersesDataModel,
     ): VersesDataModel {
         val versesAttributes = VerseAttributeLoader.load(
-            S.db,
+            App.services.storage.db,
             contentResolver,
             data.ari_bc_,
             data.verses_
@@ -2099,7 +2099,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     }
 
     override fun bProgressMarkList_click() {
-        if (S.db.countAllProgressMarks() > 0) {
+        if (App.services.storage.db.countAllProgressMarks() > 0) {
             val dialog = ProgressMarkListDialog()
             dialog.progressMarkSelectedListener = { preset_id ->
                 gotoProgressMark(preset_id)
@@ -2132,7 +2132,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     }
 
     private fun gotoProgressMark(preset_id: Int) {
-        val progressMark = S.db.getProgressMarkByPresetId(preset_id) ?: return
+        val progressMark = App.services.storage.db.getProgressMarkByPresetId(preset_id) ?: return
 
         val ari = progressMark.ari
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/DevotionActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/DevotionActivity.java
@@ -258,7 +258,7 @@ public class DevotionActivity extends BaseLeftDrawerActivity implements LeftDraw
     protected void onStart() {
         super.onStart();
 
-        final S.CalculatedDimensions applied = S.applied();
+        final S.CalculatedDimensions applied = App.services.uiDimensions.applied();
 
         { // apply background color, and clear window background to prevent overdraw
             getWindow().setBackgroundDrawableResource(android.R.color.transparent);
@@ -313,7 +313,7 @@ public class DevotionActivity extends BaseLeftDrawerActivity implements LeftDraw
 
     void display() {
         final String date = getDateFormat().format(currentDate);
-        final DevotionArticle article = S.getDb().tryGetDevotion(currentKind.name, date);
+        final DevotionArticle article = App.services.storage.getDb().tryGetDevotion(currentKind.name, date);
         if (article == null || !article.getReadyToUse()) {
             willNeed(currentKind, date, true);
         }
@@ -431,14 +431,14 @@ public class DevotionActivity extends BaseLeftDrawerActivity implements LeftDraw
         final Date today = new Date();
 
         // delete those older than 180 days!
-        final int deleted = S.getDb().deleteDevotionsWithTouchTimeBefore(new Date(today.getTime() - 180 * 86400_000L));
+        final int deleted = App.services.storage.getDb().deleteDevotionsWithTouchTimeBefore(new Date(today.getTime() - 180 * 86400_000L));
         if (deleted > 0) {
             AppLog.d(TAG, "old devotions deleted: " + deleted);
         }
 
         for (int i = 0; i < kind.getPrefetchDays(); i++) {
             final String date = getDateFormat().format(today);
-            if (S.getDb().tryGetDevotion(kind.name, date) == null) {
+            if (App.services.storage.getDb().tryGetDevotion(kind.name, date) == null) {
                 AppLog.d(TAG, "Prefetcher need to get " + kind + " " + date);
                 willNeed(kind, date, false);
             }

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/MarkerListActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/MarkerListActivity.kt
@@ -30,7 +30,6 @@ import yuku.afw.storage.Preferences
 import yuku.afw.widget.EasyAdapter
 import yuku.alkitab.base.App
 import yuku.alkitab.base.IsiActivity
-import yuku.alkitab.base.S
 import yuku.alkitab.base.ac.base.BaseActivity
 import yuku.alkitab.base.dialog.TypeBookmarkDialog
 import yuku.alkitab.base.dialog.TypeHighlightDialog
@@ -87,9 +86,9 @@ class MarkerListActivity : BaseActivity() {
 
     private var currentlyUsedFilter: String? = null
     private var allMarkers = emptyList<Marker>()
-    private val version = S.activeVersion()
-    private val versionId = S.activeVersionId()
-    private val textSizeMult = S.db.getPerVersionSettings(versionId).fontSizeMultiplier
+    private val version = App.services.versions.activeVersion()
+    private val versionId = App.services.versions.activeVersionId()
+    private val textSizeMult = App.services.storage.db.getPerVersionSettings(versionId).fontSizeMultiplier
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -139,7 +138,7 @@ class MarkerListActivity : BaseActivity() {
 
         adapter = MarkerListAdapter()
         lv.adapter = adapter
-        lv.cacheColorHint = S.applied().backgroundColor
+        lv.cacheColorHint = App.services.uiDimensions.applied().backgroundColor
         lv.choiceMode = AbsListView.CHOICE_MODE_MULTIPLE
         lv.onItemClickListener = lv_itemClick
         lv.onItemLongClickListener = lv_itemLongClick
@@ -155,14 +154,14 @@ class MarkerListActivity : BaseActivity() {
 
         // apply background color, and clear window background to prevent overdraw
         window.setBackgroundDrawableResource(android.R.color.transparent)
-        root.setBackgroundColor(S.applied().backgroundColor)
+        root.setBackgroundColor(App.services.uiDimensions.applied().backgroundColor)
 
-        tEmpty.setTextColor(S.applied().fontColor)
+        tEmpty.setTextColor(App.services.uiDimensions.applied().fontColor)
         loadAndFilter()
     }
 
     fun loadAndFilter() {
-        allMarkers = S.db.listMarkers(filter_kind, filter_labelId, sort_column, sort_ascending)
+        allMarkers = App.services.storage.db.listMarkers(filter_kind, filter_labelId, sort_column, sort_ascending)
         filter.submit(currentlyUsedFilter)
     }
 
@@ -190,7 +189,7 @@ class MarkerListActivity : BaseActivity() {
                     title = getString(R.string.bmcat_unlabeled_bookmarks)
                     nothingText = getString(R.string.bl_there_are_no_bookmarks_without_any_labels)
                 } else {
-                    val label = S.db.getLabelById(filter_labelId)
+                    val label = App.services.storage.db.getLabelById(filter_labelId)
                     if (label != null) {
                         title = label.title
                         nothingText = getString(R.string.bl_there_are_no_bookmarks_with_the_label_label, label.title)
@@ -504,7 +503,7 @@ class MarkerListActivity : BaseActivity() {
                                 val marker = adapter.getItem(singlePosition)
 
                                 // whatever the kind is, the way to delete is the same
-                                S.db.deleteMarkerById(marker._id)
+                                App.services.storage.db.deleteMarkerById(marker._id)
                                 mode.finish()
                                 loadAndFilter()
                                 AppEvents.emitAttributeMapChanged()
@@ -551,7 +550,7 @@ class MarkerListActivity : BaseActivity() {
                     appendLine("...")
                 }
 
-                val labels = S.db.listLabelsByMarker(marker)
+                val labels = App.services.storage.db.listLabelsByMarker(marker)
                 if (labels.isNotEmpty()) {
                     appendLine(labels.joinToString { it.title })
                 }
@@ -619,7 +618,7 @@ class MarkerListActivity : BaseActivity() {
 
             val reference = version.referenceWithVerseCount(ari, marker.verseCount)
             val caption = marker.caption
-            val hiliteColor = TextColorUtil.getSearchKeywordByBrightness(S.applied().backgroundBrightness)
+            val hiliteColor = TextColorUtil.getSearchKeywordByBrightness(App.services.uiDimensions.applied().backgroundBrightness)
 
             when (filter_kind) {
                 Marker.Kind.bookmark -> {
@@ -629,7 +628,7 @@ class MarkerListActivity : BaseActivity() {
                     val snippet = if (currentlyUsedFilter != null) SearchEngine.hilite(verseText, rt, hiliteColor) else verseText
                     Appearances.applyMarkerSnippetContentAndAppearance(lSnippet, reference, snippet, textSizeMult)
 
-                    val labels = S.db.listLabelsByMarker(marker)
+                    val labels = App.services.storage.db.listLabelsByMarker(marker)
                     if (labels.isNotEmpty()) {
                         panelLabels.visibility = View.VISIBLE
                         panelLabels.removeAllViews()

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/MarkersActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/MarkersActivity.java
@@ -26,7 +26,6 @@ import java.util.Locale;
 import kotlin.Unit;
 import yuku.afw.storage.Preferences;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.ac.base.BaseActivity;
 import yuku.alkitab.base.compose.colorpicker.ColorPickerDialog;
 import yuku.alkitab.base.dialog.LabelEditorDialog;
@@ -114,7 +113,7 @@ public class MarkersActivity extends BaseActivity {
     public boolean onOptionsItemSelected(final MenuItem item) {
         int itemId = item.getItemId();
         if (itemId == R.id.menuLabelSort) {
-            S.getDb().sortLabelsAlphabetically();
+            App.services.storage.getDb().sortLabelsAlphabetically();
             adapter.reload();
             return true;
         }
@@ -176,16 +175,16 @@ public class MarkersActivity extends BaseActivity {
         if (itemId == R.id.menuRenameLabel) {
             LabelEditorDialog.show(this, label.title, getString(R.string.rename_label_title), title -> {
                 label.title = title;
-                S.getDb().insertOrUpdateLabel(label);
+                App.services.storage.getDb().insertOrUpdateLabel(label);
                 adapter.notifyDataSetChanged();
             });
             return true;
         } else if (itemId == R.id.menuDeleteLabel) {
-            final int marker_count = S.getDb().countMarkersWithLabel(label);
+            final int marker_count = App.services.storage.getDb().countMarkersWithLabel(label);
 
             if (marker_count == 0) {
                 // no markers, just delete straight away
-                S.getDb().deleteLabelAndMarker_LabelsByLabelId(label._id);
+                App.services.storage.getDb().deleteLabelAndMarker_LabelsByLabelId(label._id);
                 adapter.reload();
             } else {
                 MaterialDialogJavaHelper.showOkDialog(
@@ -193,7 +192,7 @@ public class MarkersActivity extends BaseActivity {
                     getString(R.string.are_you_sure_you_want_to_delete_the_label_label, label.title, "" + marker_count),
                     getString(R.string.delete),
                     () -> {
-                        S.getDb().deleteLabelAndMarker_LabelsByLabelId(label._id);
+                        App.services.storage.getDb().deleteLabelAndMarker_LabelsByLabelId(label._id);
                         adapter.reload();
                         return Unit.INSTANCE;
                     },
@@ -206,7 +205,7 @@ public class MarkersActivity extends BaseActivity {
             int colorRgb = LabelColorUtil.decodeBackground(label.backgroundColor);
             ColorPickerDialog.show(MarkersActivity.this, 0xff000000 | colorRgb, color -> {
                 label.backgroundColor = LabelColorUtil.encodeBackground(0x00ffffff & color);
-                S.getDb().insertOrUpdateLabel(label);
+                App.services.storage.getDb().insertOrUpdateLabel(label);
                 adapter.notifyDataSetChanged();
             });
 
@@ -301,7 +300,7 @@ public class MarkersActivity extends BaseActivity {
 
             final Label fromLabel = snapshot.get(fromIdx);
             final Label toLabel = snapshot.get(toIdx);
-            S.getDb().reorderLabels(fromLabel, toLabel);
+            App.services.storage.getDb().reorderLabels(fromLabel, toLabel);
             adapter.reload();
         }
     }
@@ -442,7 +441,7 @@ public class MarkersActivity extends BaseActivity {
         }
 
         void reload() {
-            labels = S.getDb().listAllLabels();
+            labels = App.services.storage.getDb().listAllLabels();
 
             if (BuildConfig.DEBUG) {
                 AppLog.d(TAG, "_id  title                ordering backgroundColor");

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/NoteActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/NoteActivity.java
@@ -85,7 +85,7 @@ public class NoteActivity extends BaseActivity {
 
 		final long _id = getIntent().getLongExtra(EXTRA_marker_id, 0L);
 		if (_id != 0L) {
-			marker = S.getDb().getMarkerById(_id);
+			marker = App.services.storage.getDb().getMarkerById(_id);
 		}
 
 		String reference = getIntent().getStringExtra(EXTRA_reference);
@@ -93,7 +93,7 @@ public class NoteActivity extends BaseActivity {
 		verseCountForNewNote = getIntent().getIntExtra(EXTRA_verseCountForNewNote, 0);
 
 		if (reference == null) {
-			reference = S.activeVersion().referenceWithVerseCount(marker.ari, marker.verseCount);
+			reference = App.services.versions.activeVersion().referenceWithVerseCount(marker.ari, marker.verseCount);
 		}
 
 		setTitle(reference);
@@ -123,7 +123,7 @@ public class NoteActivity extends BaseActivity {
 	@Override protected void onStart() {
 		super.onStart();
 
-		final S.CalculatedDimensions applied = S.applied();
+		final S.CalculatedDimensions applied = App.services.uiDimensions.applied();
 
 		{ // apply background color, by overriding window background
 			getWindow().setBackgroundDrawable(new ColorDrawable(applied.backgroundColor));
@@ -262,7 +262,7 @@ public class NoteActivity extends BaseActivity {
 					() -> {
 						if (marker != null) {
 							// really delete from db
-							S.getDb().deleteNonBookmarkMarkerById(marker._id);
+							App.services.storage.getDb().deleteNonBookmarkMarkerById(marker._id);
 						} else {
 							// do nothing, because it's indeed not in the db, only in editor buffer
 						}
@@ -295,16 +295,16 @@ public class NoteActivity extends BaseActivity {
 					// when there is no change, do nothing
 				} else {
 					if (caption.length() == 0) { // delete instead of update
-						S.getDb().deleteNonBookmarkMarkerById(marker._id);
+						App.services.storage.getDb().deleteNonBookmarkMarkerById(marker._id);
 					} else {
 						marker.caption = caption;
 						marker.modifyTime = now;
-						S.getDb().insertOrUpdateMarker(marker);
+						App.services.storage.getDb().insertOrUpdateMarker(marker);
 					}
 				}
 			} else { // marker == null; not existing, so only insert when there is some text
 				if (caption.length() > 0) {
-					marker = S.getDb().insertMarker(ariForNewNote, Marker.Kind.note, caption, verseCountForNewNote, now, now);
+					marker = App.services.storage.getDb().insertMarker(ariForNewNote, Marker.Kind.note, caption, verseCountForNewNote, now, now);
 				}
 			}
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/PatchTextActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/PatchTextActivity.java
@@ -52,7 +52,7 @@ public class PatchTextActivity extends BaseActivity {
         ab.setDisplayHomeAsUpEnabled(true);
         ab.setDisplayShowTitleEnabled(false);
 
-        final S.CalculatedDimensions applied = S.applied();
+        final S.CalculatedDimensions applied = App.services.uiDimensions.applied();
 
         tBody = findViewById(R.id.tBody);
         tBody.setTextColor(applied.fontColor);

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/ReadingPlanActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/ReadingPlanActivity.java
@@ -39,7 +39,6 @@ import kotlin.Unit;
 import yuku.afw.storage.Preferences;
 import yuku.afw.widget.EasyAdapter;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.ac.base.BaseLeftDrawerActivity;
 import yuku.alkitab.base.connection.Connections;
 import yuku.alkitab.base.events.AppEvents;
@@ -192,7 +191,7 @@ public class ReadingPlanActivity extends BaseLeftDrawerActivity implements LeftD
 
                     final long startTime = newDate.getTimeInMillis();
                     readingPlan.info.startTime = startTime;
-                    S.getDb().updateReadingPlanStartDate(readingPlan.info.id, startTime);
+                    App.services.storage.getDb().updateReadingPlanStartDate(readingPlan.info.id, startTime);
                     changeDay(0);
                     loadDayNumber();
                     updateButtonStatus();
@@ -210,7 +209,7 @@ public class ReadingPlanActivity extends BaseLeftDrawerActivity implements LeftD
                         int firstUnreadDay = findFirstUnreadDay();
                         Calendar calendar = GregorianCalendar.getInstance();
                         calendar.add(Calendar.DATE, -firstUnreadDay);
-                        S.getDb().updateReadingPlanStartDate(readingPlan.info.id, calendar.getTime().getTime());
+                        App.services.storage.getDb().updateReadingPlanStartDate(readingPlan.info.id, calendar.getTime().getTime());
                         loadReadingPlan(readingPlan.info.id);
                         loadDayNumber();
                         readingPlanAdapter.load();
@@ -296,20 +295,20 @@ public class ReadingPlanActivity extends BaseLeftDrawerActivity implements LeftD
     }
 
     void loadReadingPlan(long id) {
-        downloadedReadingPlanInfos = S.getDb().listAllReadingPlanInfo();
+        downloadedReadingPlanInfos = App.services.storage.getDb().listAllReadingPlanInfo();
 
         if (downloadedReadingPlanInfos.isEmpty()) {
             return;
         }
 
-        Pair<String, byte[]> nameAndData = S.getDb().getReadingPlanNameAndData(id);
+        Pair<String, byte[]> nameAndData = App.services.storage.getDb().getReadingPlanNameAndData(id);
 
         long startTime = 0;
         if (id == 0 || nameAndData == null) {
             id = downloadedReadingPlanInfos.get(0).id;
             startTime = downloadedReadingPlanInfos.get(0).startTime;
 
-            nameAndData = S.getDb().getReadingPlanNameAndData(id);
+            nameAndData = App.services.storage.getDb().getReadingPlanNameAndData(id);
         } else {
             for (ReadingPlan.ReadingPlanInfo info : downloadedReadingPlanInfos) {
                 if (id == info.id) {
@@ -340,7 +339,7 @@ public class ReadingPlanActivity extends BaseLeftDrawerActivity implements LeftD
         if (readingPlan == null) {
             return;
         }
-        readReadingCodes = S.getDb().getAllReadingCodesByReadingPlanProgressGid(ReadingPlan.gidFromName(readingPlan.info.name));
+        readReadingCodes = App.services.storage.getDb().getAllReadingCodesByReadingPlanProgressGid(ReadingPlan.gidFromName(readingPlan.info.name));
     }
 
     public void goToIsiActivity(final int dayNumber, final int sequence) {
@@ -462,7 +461,7 @@ public class ReadingPlanActivity extends BaseLeftDrawerActivity implements LeftD
             getString(R.string.rp_deletePlan, readingPlan.info.title),
             getString(R.string.delete),
             () -> {
-                S.getDb().deleteReadingPlanById(readingPlan.info.id);
+                App.services.storage.getDb().deleteReadingPlanById(readingPlan.info.id);
                 readingPlan = null;
                 Preferences.remove(Prefkey.active_reading_plan_id);
                 loadReadingPlan(0);
@@ -505,8 +504,8 @@ public class ReadingPlanActivity extends BaseLeftDrawerActivity implements LeftD
             getString(R.string.rp_restart_desc),
             getString(R.string.ok),
             () -> {
-                S.getDb().deleteAllReadingPlanProgressForGid(ReadingPlan.gidFromName(readingPlan.info.name));
-                S.getDb().updateReadingPlanStartDate(readingPlan.info.id, System.currentTimeMillis());
+                App.services.storage.getDb().deleteAllReadingPlanProgressForGid(ReadingPlan.gidFromName(readingPlan.info.name));
+                App.services.storage.getDb().updateReadingPlanStartDate(readingPlan.info.id, System.currentTimeMillis());
                 loadReadingPlan(readingPlan.info.id);
                 loadDayNumber();
                 readingPlanAdapter.load();
@@ -564,7 +563,7 @@ public class ReadingPlanActivity extends BaseLeftDrawerActivity implements LeftD
     }
 
     void downloadReadingPlanFromServer(final String name) {
-        if (S.getDb().listReadingPlanNames().contains(name)) {
+        if (App.services.storage.getDb().listReadingPlanNames().contains(name)) {
             MaterialDialogJavaHelper.showOkDialog(this, getString(R.string.rp_download_already_have));
 
             return;
@@ -699,7 +698,7 @@ public class ReadingPlanActivity extends BaseLeftDrawerActivity implements LeftD
                 final boolean[] readMarks = new boolean[todayReadings.length / 2];
                 ReadingPlanManager.writeReadMarksByDay(readReadingCodes, readMarks, dayNumber);
 
-                bReference.setText(S.activeVersion().referenceRange(todayReadings[position * 2], todayReadings[position * 2 + 1]));
+                bReference.setText(App.services.versions.activeVersion().referenceRange(todayReadings[position * 2], todayReadings[position * 2 + 1]));
 
                 bReference.setOnClickListener(v -> {
                     final int todayReadingsSize = readingPlan.dailyVerses[dayNumber].length / 2;
@@ -797,7 +796,7 @@ public class ReadingPlanActivity extends BaseLeftDrawerActivity implements LeftD
 
                     checkBox.setOnCheckedChangeListener(null);
                     checkBox.setChecked(readMarks[sequence]);
-                    checkBox.setText(S.activeVersion().referenceRange(ariRanges[sequence * 2], ariRanges[sequence * 2 + 1]));
+                    checkBox.setText(App.services.versions.activeVersion().referenceRange(ariRanges[sequence * 2], ariRanges[sequence * 2 + 1]));
                     checkBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
                         ReadingPlanManager.updateReadingPlanProgress(readingPlan.info.name, day, sequence, isChecked);
                         loadReadingPlanProgress();

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/SearchActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/SearchActivity.kt
@@ -37,7 +37,6 @@ import java.util.Locale
 import me.zhanghai.android.fastscroll.FastScrollerBuilder
 import yuku.afw.storage.Preferences
 import yuku.alkitab.base.App
-import yuku.alkitab.base.S
 import yuku.alkitab.base.ac.base.BaseActivity
 import yuku.alkitab.base.model.MVersion
 import yuku.alkitab.base.storage.Prefkey
@@ -86,9 +85,9 @@ class SearchActivity : BaseActivity() {
     private var filterUserAction = 0 // when it's not user action, set to nonzero
     private val adapter = SearchAdapter(IntArrayList(), emptyList())
 
-    private var searchInVersion: Version = S.activeVersion()
-    private var searchInVersionId: String = S.activeVersionId()
-    private var textSizeMult = S.db.getPerVersionSettings(searchInVersionId).fontSizeMultiplier
+    private var searchInVersion: Version = App.services.versions.activeVersion()
+    private var searchInVersionId: String = App.services.versions.activeVersionId()
+    private var textSizeMult = App.services.storage.db.getPerVersionSettings(searchInVersionId).fontSizeMultiplier
 
     private lateinit var searchHistoryAdapter: SearchHistoryAdapter
     private var actionMode: ActionMode? = null
@@ -294,7 +293,7 @@ class SearchActivity : BaseActivity() {
             tSearchTips.text = sb
         }
 
-        val applied = S.applied()
+        val applied = App.services.uiDimensions.applied()
         tSearchTips.setBackgroundColor(applied.backgroundColor)
         lsSearchResults.setBackgroundColor(applied.backgroundColor)
         Appearances.applyTextAppearance(tSearchTips, textSizeMult)
@@ -307,7 +306,7 @@ class SearchActivity : BaseActivity() {
 
         run {
             openedBookId = intent.getIntExtra(EXTRA_openedBookId, -1)
-            val book = S.activeVersion().getBook(openedBookId)
+            val book = App.services.versions.activeVersion().getBook(openedBookId)
             if (book == null) { // active version has changed somehow when this activity fainted. so, invalidate openedBookId
                 openedBookId = -1
                 cFilterSingleBook.isEnabled = false
@@ -504,7 +503,7 @@ class SearchActivity : BaseActivity() {
 
             searchInVersion = selectedVersion
             searchInVersionId = mv.versionId
-            textSizeMult = S.db.getPerVersionSettings(searchInVersionId).fontSizeMultiplier
+            textSizeMult = App.services.storage.db.getPerVersionSettings(searchInVersionId).fontSizeMultiplier
 
             Appearances.applyTextAppearance(tSearchTips, textSizeMult)
             displaySearchInVersion()

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/SecretSettingsActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/SecretSettingsActivity.kt
@@ -10,8 +10,6 @@ import androidx.preference.PreferenceFragmentCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import java.util.Locale
 import yuku.alkitab.base.App
-import yuku.alkitab.base.S.activeVersion
-import yuku.alkitab.base.S.db
 import yuku.alkitab.base.ac.base.BaseActivity
 import yuku.alkitab.base.settings.SettingsActivity.Companion.autoDisplayListPreference
 import yuku.alkitab.base.util.Sqlitil.toLocaleDateMedium
@@ -21,12 +19,12 @@ import yuku.alkitab.debug.R
 class SecretSettingsActivity : BaseActivity() {
     class SecretSettingsFragment : PreferenceFragmentCompat() {
         private val secret_progress_mark_history_click = Preference.OnPreferenceClickListener {
-            val progressMarks = db.listAllProgressMarks()
+            val progressMarks = App.services.storage.db.listAllProgressMarks()
             val labels = progressMarks.map { "${it.caption} (preset_id ${it.preset_id})" }.toTypedArray()
             MaterialAlertDialogBuilder(requireActivity())
                 .setItems(labels) { _, index ->
-                    val pmhs = db.listProgressMarkHistoryByPresetId(progressMarks[index].preset_id)
-                    val items = pmhs.map { "'${it.progress_mark_caption}' ${toLocaleDateMedium(it.createTime)}: ${activeVersion().reference(it.ari)}" }.toTypedArray()
+                    val pmhs = App.services.storage.db.listProgressMarkHistoryByPresetId(progressMarks[index].preset_id)
+                    val items = pmhs.map { "'${it.progress_mark_caption}' ${toLocaleDateMedium(it.createTime)}: ${App.services.versions.activeVersion().reference(it.ari)}" }.toTypedArray()
                     MaterialAlertDialogBuilder(requireActivity())
                         .setItems(items, null)
                         .show()
@@ -36,7 +34,7 @@ class SecretSettingsActivity : BaseActivity() {
         }
 
         private val secret_version_table_click = Preference.OnPreferenceClickListener {
-            val items = db.listAllVersions().map { mv ->
+            val items = App.services.storage.db.listAllVersions().map { mv ->
                 String.format(
                     Locale.US, "filename=%s preset_name=%s modifyTime=%s active=%s ordering=%s locale=%s shortName=%s longName=%s description=%s",
                     mv.filename, mv.preset_name, mv.modifyTime, mv.active, mv.ordering, mv.locale, mv.shortName, mv.longName, mv.description

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/SecretSyncDebugActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/SecretSyncDebugActivity.kt
@@ -23,7 +23,6 @@ import okhttp3.Request
 import okhttp3.Response
 import yuku.afw.storage.Preferences
 import yuku.alkitab.base.App
-import yuku.alkitab.base.S
 import yuku.alkitab.base.ac.base.BaseActivity
 import yuku.alkitab.base.connection.Connections
 import yuku.alkitab.base.events.AppEvents
@@ -125,10 +124,10 @@ class SecretSyncDebugActivity : BaseActivity() {
     }
 
     private var bGenerateDummies_click = View.OnClickListener {
-        val label1 = S.db.insertLabel(randomString("L1_", 1, 3, 8), encodeBackground(rand(0xffffff)))
-        val label2 = S.db.insertLabel(randomString("L2_", 1, 3, 8), encodeBackground(rand(0xffffff)))
+        val label1 = App.services.storage.db.insertLabel(randomString("L1_", 1, 3, 8), encodeBackground(rand(0xffffff)))
+        val label2 = App.services.storage.db.insertLabel(randomString("L2_", 1, 3, 8), encodeBackground(rand(0xffffff)))
         for (i in 0..9) {
-            val marker = S.db.insertMarker(0x000101 + rand(30), Marker.Kind.entries[rand(3)], randomString("M" + i + "_", rand(2) + 1, 4, 7), rand(2) + 1, Date(), Date())
+            val marker = App.services.storage.db.insertMarker(0x000101 + rand(30), Marker.Kind.entries[rand(3)], randomString("M" + i + "_", rand(2) + 1, 4, 7), rand(2) + 1, Date(), Date())
             val labelSet: MutableSet<Label> = HashSet()
             if (rand(10) < 5) {
                 labelSet.add(label1)
@@ -136,7 +135,7 @@ class SecretSyncDebugActivity : BaseActivity() {
             if (rand(10) < 3) {
                 labelSet.add(label2)
             }
-            S.db.updateLabels(marker, labelSet)
+            App.services.storage.db.updateLabels(marker, labelSet)
         }
 
         MaterialAlertDialogBuilder(this)
@@ -146,12 +145,12 @@ class SecretSyncDebugActivity : BaseActivity() {
     }
 
     private var bGenerateDummies2_click = View.OnClickListener {
-        val label1 = S.db.insertLabel(randomString("LL1_", 1, 3, 8), encodeBackground(rand(0xffffff)))
-        val label2 = S.db.insertLabel(randomString("LL2_", 1, 3, 8), encodeBackground(rand(0xffffff)))
+        val label1 = App.services.storage.db.insertLabel(randomString("LL1_", 1, 3, 8), encodeBackground(rand(0xffffff)))
+        val label2 = App.services.storage.db.insertLabel(randomString("LL2_", 1, 3, 8), encodeBackground(rand(0xffffff)))
         for (i in 0..999) {
             val kind = Marker.Kind.entries[rand(3)]
             val now = Date()
-            val marker = S.db.insertMarker(0x000101 + rand(30), kind, if (kind == Marker.Kind.highlight) Highlights.encode(rand(0xffffff)) else randomString("MM" + i + "_", if (rand(10) < 5) rand(81) else rand(400) + 4, 5, 15), rand(2) + 1, now, now)
+            val marker = App.services.storage.db.insertMarker(0x000101 + rand(30), kind, if (kind == Marker.Kind.highlight) Highlights.encode(rand(0xffffff)) else randomString("MM" + i + "_", if (rand(10) < 5) rand(81) else rand(400) + 4, 5, 15), rand(2) + 1, now, now)
             val labelSet: MutableSet<Label> = HashSet()
             if (rand(10) < 1) {
                 labelSet.add(label1)
@@ -159,7 +158,7 @@ class SecretSyncDebugActivity : BaseActivity() {
             if (rand(10) < 4) {
                 labelSet.add(label2)
             }
-            S.db.updateLabels(marker, labelSet)
+            App.services.storage.db.updateLabels(marker, labelSet)
         }
 
         MaterialAlertDialogBuilder(this)
@@ -190,7 +189,7 @@ class SecretSyncDebugActivity : BaseActivity() {
                     val nlabel = rand(5)
                     toast("creating $nlabel labels")
                     for (i in 0 until nlabel) {
-                        S.db.insertLabel(randomString("monkey L $i ", 1, 3, 8), encodeBackground(rand(0xffffff)))
+                        App.services.storage.db.insertLabel(randomString("monkey L $i ", 1, 3, 8), encodeBackground(rand(0xffffff)))
                     }
                 }
 
@@ -198,7 +197,7 @@ class SecretSyncDebugActivity : BaseActivity() {
                 toast("waiting for 10 secs")
                 SystemClock.sleep(10000)
 
-                val labels = S.db.listAllLabels()
+                val labels = App.services.storage.db.listAllLabels()
 
                 run {
                     val nmarker = rand(500)
@@ -206,11 +205,11 @@ class SecretSyncDebugActivity : BaseActivity() {
                     for (i in 0 until nmarker) {
                         val kind = Marker.Kind.entries[rand(3)]
                         val now = Date()
-                        val marker = S.db.insertMarker(0x000101 + rand(30), kind, if (kind == Marker.Kind.highlight) Highlights.encode(rand(0xffffff)) else randomString("monkey M $i ", rand(8) + 2, 3, 5), rand(2) + 1, now, now)
+                        val marker = App.services.storage.db.insertMarker(0x000101 + rand(30), kind, if (kind == Marker.Kind.highlight) Highlights.encode(rand(0xffffff)) else randomString("monkey M $i ", rand(8) + 2, 3, 5), rand(2) + 1, now, now)
                         if (rand(10) < 1 && labels.size > 0) {
                             val labelSet: MutableSet<Label> = HashSet()
                             labelSet.add(labels[rand(labels.size)])
-                            S.db.updateLabels(marker, labelSet)
+                            App.services.storage.db.updateLabels(marker, labelSet)
                         }
                     }
                 }
@@ -219,18 +218,18 @@ class SecretSyncDebugActivity : BaseActivity() {
                 toast("waiting for 10 secs")
                 SystemClock.sleep(10000)
 
-                val markers = S.db.listAllMarkers()
+                val markers = App.services.storage.db.listAllMarkers()
                 if (markers.size > 10) {
                     val nmarker = rand(markers.size / 10)
                     toast("deleting up to 10% of markers: $nmarker markers")
                     for (i in 0 until nmarker) {
                         val marker = markers[rand(markers.size)]
                         markers.remove(marker)
-                        val mls = S.db.listMarker_LabelsByMarker(marker)
+                        val mls = App.services.storage.db.listMarker_LabelsByMarker(marker)
                         for (ml in mls) {
-                            S.db.deleteMarker_LabelByGid(ml.gid)
+                            App.services.storage.db.deleteMarker_LabelByGid(ml.gid)
                         }
-                        S.db.deleteMarkerByGid(marker.gid)
+                        App.services.storage.db.deleteMarkerByGid(marker.gid)
                     }
                 }
 
@@ -244,7 +243,7 @@ class SecretSyncDebugActivity : BaseActivity() {
                     for (i in 0 until nlabel) {
                         val label = labels[rand(labels.size)]
                         labels.remove(label)
-                        S.db.deleteLabelAndMarker_LabelsByLabelId(label._id)
+                        App.services.storage.db.deleteLabelAndMarker_LabelsByLabelId(label._id)
                     }
                 }
 
@@ -258,7 +257,7 @@ class SecretSyncDebugActivity : BaseActivity() {
                     for (i in 0 until nmarker) {
                         val marker = markers[rand(markers.size)]
                         marker.caption = randomString("monkey edit M $i ", rand(8) + 2, 3, 5)
-                        S.db.insertOrUpdateMarker(marker)
+                        App.services.storage.db.insertOrUpdateMarker(marker)
                     }
                 }
 
@@ -314,7 +313,7 @@ class SecretSyncDebugActivity : BaseActivity() {
         }
 
         for (syncSetName in SyncShadow.ALL_SYNC_SET_NAMES) {
-            S.db.deleteSyncShadowBySyncSetName(syncSetName)
+            App.services.storage.db.deleteSyncShadowBySyncSetName(syncSetName)
         }
     }
 
@@ -347,19 +346,19 @@ class SecretSyncDebugActivity : BaseActivity() {
         )
 
         if (cMakeDirtyMarker.isChecked) {
-            S.db.insertMarker(0x000101 + rand(30), Marker.Kind.entries[rand(3)], randomString("MMD0_", rand(2) + 1, 4, 7), rand(2) + 1, Date(), Date())
+            App.services.storage.db.insertMarker(0x000101 + rand(30), Marker.Kind.entries[rand(3)], randomString("MMD0_", rand(2) + 1, 4, 7), rand(2) + 1, Date(), Date())
         }
 
         if (cMakeDirtyLabel.isChecked) {
-            S.db.insertLabel(randomString("LMD_", 1, 3, 8), encodeBackground(rand(0xffffff)))
+            App.services.storage.db.insertLabel(randomString("LMD_", 1, 3, 8), encodeBackground(rand(0xffffff)))
         }
 
         if (cMakeDirtyMarker_Label.isChecked) {
-            val labels = S.db.listAllLabels()
-            val markers = S.db.listAllMarkers()
+            val labels = App.services.storage.db.listAllLabels()
+            val markers = App.services.storage.db.listAllMarkers()
             if (labels.size > 0 && markers.size > 0) {
                 val marker_label = Marker_Label.createNewMarker_Label(markers[0].gid, labels[0].gid)
-                S.db.insertOrUpdateMarker_Label(marker_label)
+                App.services.storage.db.insertOrUpdateMarker_Label(marker_label)
             } else {
                 MaterialAlertDialogBuilder(this)
                     .setMessage("not enough markers and labels to create marker_label")
@@ -386,7 +385,7 @@ class SecretSyncDebugActivity : BaseActivity() {
                     if (debugSyncResponse.success) {
                         val final_revno = debugSyncResponse.final_revno
                         val append_delta = debugSyncResponse.append_delta
-                        val applyResult = S.db.syncApplier.applyMabelAppendDelta(final_revno, pair.shadowEntities, clientState, append_delta, entitiesBeforeSync, simpleToken)
+                        val applyResult = App.services.storage.db.syncApplier.applyMabelAppendDelta(final_revno, pair.shadowEntities, clientState, append_delta, entitiesBeforeSync, simpleToken)
 
                         MaterialAlertDialogBuilder(this@SecretSyncDebugActivity)
                             .setMessage("Final revno: $final_revno\nApply result: $applyResult\nAppend delta: $append_delta")

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
@@ -11,7 +11,7 @@ import androidx.core.app.ShareCompat
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import yuku.afw.storage.Preferences
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.ac.NoteActivity
 import yuku.alkitab.base.config.AppConfig
 import yuku.alkitab.base.dialog.TypeBookmarkDialog
@@ -361,7 +361,7 @@ class VerseActionModeController(
 
             R.id.menuAddHighlight -> {
                 val ariBc = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, 0)
-                val colorRgb = S.db.getHighlightColorRgb(ariBc, selected)
+                val colorRgb = App.services.storage.db.getHighlightColorRgb(ariBc, selected)
 
                 val listener = TypeHighlightDialog.Listener {
                     actions.uncheckAllVersesSplit0()
@@ -373,7 +373,7 @@ class VerseActionModeController(
                     val ftr = VerseRenderer.FormattedTextResult()
                     val ari = Ari.encodeWithBc(ariBc, selected.get(0))
                     val rawVerseText = host.activeSplit0Version.loadVerseText(ari) ?: ""
-                    val info = S.db.getHighlightColorRgb(ari)
+                    val info = App.services.storage.db.getHighlightColorRgb(ari)
 
                     VerseRenderer.render(ari = ari, text = rawVerseText, ftr = ftr)
                     TypeHighlightDialog(host.activity, ari, listener, colorRgb, info, reference, ftr.result)

--- a/Alkitab/src/main/java/yuku/alkitab/base/appwidget/DailyVerseAppWidgetConfigurationActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/appwidget/DailyVerseAppWidgetConfigurationActivity.java
@@ -18,7 +18,6 @@ import androidx.appcompat.widget.Toolbar;
 import java.util.List;
 import yuku.afw.widget.EasyAdapter;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.ac.base.BaseActivity;
 import yuku.alkitab.base.br.DailyVerseAppWidgetReceiver;
 import yuku.alkitab.base.events.AppEvents;
@@ -188,7 +187,7 @@ public class DailyVerseAppWidgetConfigurationActivity extends BaseActivity {
         List<MVersion> versions;
 
         void reload() {
-            versions = S.getAvailableVersions();
+            versions = App.services.versions.getAvailableVersions();
             notifyDataSetChanged();
         }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/appwidget/DailyVerseData.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/appwidget/DailyVerseData.java
@@ -8,7 +8,6 @@ import java.util.GregorianCalendar;
 import java.util.Random;
 import yuku.afw.App;
 import yuku.afw.storage.Preferences;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.model.MVersionDb;
 import yuku.alkitab.base.model.MVersionInternal;
 import yuku.alkitab.base.model.VersionImpl;
@@ -143,7 +142,7 @@ public abstract class DailyVerseData {
 		}
 
 		// try database versions
-		for (final MVersionDb mvDb : S.getDb().listAllVersions()) {
+		for (final MVersionDb mvDb : yuku.alkitab.base.App.services.storage.getDb().listAllVersions()) {
 			if (mvDb.getVersionId().equals(versionId)) {
 				if (mvDb.hasDataFile()) {
 					return mvDb.getVersion();

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import yuku.alkitab.base.IsiActivity
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.util.AppLog
 import yuku.alkitab.debug.R
 
@@ -424,14 +424,14 @@ class BibleAudioService : MediaSessionService() {
      *    routed through [BibleChapterNavigatingPlayer].
      *
      * The activity does not need to be alive for this to work — the
-     * [yuku.alkitab.model.Version] is resolved through [S]. When the activity
+     * [yuku.alkitab.model.Version] is resolved through [App.services]. When the activity
      * *is* alive, `AudioBarController` observes the resulting state change and
      * navigates `IsiActivity` to keep both surfaces in sync.
      */
     fun skipChapter(direction: Int) {
         val current = currentRequest ?: return
-        val resolvedVersion = S.getVersionFromVersionId(current.versionId)?.version
-        val version = resolvedVersion ?: S.activeVersion()
+        val resolvedVersion = App.services.versions.getVersionFromVersionId(current.versionId)?.version
+        val version = resolvedVersion ?: App.services.versions.activeVersion()
         val (book, chapter1) = BibleNeighborResolver.neighbor(
             version,
             current.bookId,

--- a/Alkitab/src/main/java/yuku/alkitab/base/br/VersionDownloadCompleteReceiver.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/br/VersionDownloadCompleteReceiver.java
@@ -12,7 +12,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Map;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.ac.AlertDialogActivity;
 import yuku.alkitab.base.events.AppEvents;
 import yuku.alkitab.base.model.MVersionDb;
@@ -130,7 +129,7 @@ public class VersionDownloadCompleteReceiver {
 
 			// success!
 
-			int maxOrdering = S.getDb().getVersionMaxOrdering();
+			int maxOrdering = App.services.storage.getDb().getVersionMaxOrdering();
 			if (maxOrdering == 0) maxOrdering = MVersionDb.DEFAULT_ORDERING_START;
 
 			final MVersionDb mvDb = new MVersionDb();
@@ -145,7 +144,7 @@ public class VersionDownloadCompleteReceiver {
 			mvDb.modifyTime = modifyTime;
 			mvDb.ordering = maxOrdering + 1;
 
-			S.getDb().insertOrUpdateVersionWithActive(mvDb, true);
+			App.services.storage.getDb().insertOrUpdateVersionWithActive(mvDb, true);
 			MVersionDb.clearVersionImplCache();
 
 			Foreground.run(() -> {

--- a/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/DialerTab.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/DialerTab.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import yuku.afw.storage.Preferences
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.compose.bookForegroundColor
 import yuku.alkitab.base.util.BookNameSorter
 import yuku.alkitab.debug.R
@@ -65,7 +65,7 @@ fun DialerTab(
     onGotoFinished: OnGotoFinished,
 ) {
     val books: Array<Book> = remember {
-        val raw = S.activeVersion().consecutiveBooks
+        val raw = App.services.versions.activeVersion().consecutiveBooks
         if (Preferences.getBoolean(R.string.pref_alphabeticBookSort_key, R.bool.pref_alphabeticBookSort_default)) {
             BookNameSorter.sortAlphabetically(raw)
         } else raw.copyOf()

--- a/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/DirectTab.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/DirectTab.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.util.Jumper
 import yuku.alkitab.debug.R
 import java.util.regex.Pattern
@@ -65,7 +65,7 @@ fun DirectTab(
     onGotoFinished: OnGotoFinished,
 ) {
     val context = LocalContext.current
-    val books = remember { S.activeVersion().consecutiveBooks }
+    val books = remember { App.services.versions.activeVersion().consecutiveBooks }
     var query by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue(""))
     }
@@ -89,7 +89,7 @@ fun DirectTab(
     }
 
     val sample = remember(initialBookId, initialChapter_1, initialVerse_1) {
-        S.activeVersion().reference(initialBookId, initialChapter_1, initialVerse_1)
+        App.services.versions.activeVersion().reference(initialBookId, initialChapter_1, initialVerse_1)
     }
     val prompt = TextUtils.expandTemplate(context.getText(R.string.jump_to_prompt), sample)
         .toAnnotatedString()

--- a/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/GridTab.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/GridTab.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.integerResource
 import androidx.compose.ui.unit.dp
 import yuku.afw.storage.Preferences
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.compose.bookForegroundColor
 import yuku.alkitab.base.util.BookNameSorter
 import yuku.alkitab.debug.R
@@ -47,7 +47,7 @@ fun GridTab(
     onGotoFinished: OnGotoFinished,
 ) {
     val books: Array<Book> = remember {
-        val raw = S.activeVersion().consecutiveBooks
+        val raw = App.services.versions.activeVersion().consecutiveBooks
         if (Preferences.getBoolean(R.string.pref_alphabeticBookSort_key, R.bool.pref_alphabeticBookSort_default)) {
             BookNameSorter.sortAlphabetically(raw)
         } else raw.copyOf()

--- a/Alkitab/src/main/java/yuku/alkitab/base/cp/Provider.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/cp/Provider.java
@@ -11,7 +11,7 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import java.util.Arrays;
 import java.util.Locale;
-import yuku.alkitab.base.S;
+import yuku.alkitab.base.App;
 import yuku.alkitab.base.config.AppConfig;
 import yuku.alkitab.base.model.MVersionDb;
 import yuku.alkitab.base.util.AppLog;
@@ -177,9 +177,9 @@ public class Provider extends ContentProvider {
 		AppLog.d(TAG, "getting ari 0x" + Integer.toHexString(ari));
 		
 		if (ari != Integer.MIN_VALUE && ari != 0) {
-			Book book = S.activeVersion().getBook(Ari.toBook(ari));
+			Book book = App.services.versions.activeVersion().getBook(Ari.toBook(ari));
 			if (book != null) {
-				String text = S.activeVersion().loadVerseText(ari);
+				String text = App.services.versions.activeVersion().loadVerseText(ari);
 				if (text != null) {
 					if (!formatting) {
 						text = FormattedVerseText.removeSpecialCodes(text);
@@ -222,9 +222,9 @@ public class Provider extends ContentProvider {
 				// case: single verse
 				//noinspection UnnecessaryLocalVariable
 				int ari = ari_start;
-				Book book = S.activeVersion().getBook(Ari.toBook(ari));
+				Book book = App.services.versions.activeVersion().getBook(Ari.toBook(ari));
 				if (book != null) {
-					String text = S.activeVersion().loadVerseText(ari);
+					String text = App.services.versions.activeVersion().loadVerseText(ari);
 					if (!formatting) {
 						text = FormattedVerseText.removeSpecialCodes(text);
 					}
@@ -236,14 +236,14 @@ public class Provider extends ContentProvider {
 				
 				if (ari_start_bc == ari_end_bc) {
 					// case: multiple verses in the same chapter
-					Book book = S.activeVersion().getBook(Ari.toBook(ari_start));
+					Book book = App.services.versions.activeVersion().getBook(Ari.toBook(ari_start));
 					if (book != null) {
 						c += resultForOneChapter(res, book, c, ari_start_bc, Ari.toVerse(ari_start), Ari.toVerse(ari_end), formatting);
 					}
 				} else {
 					// case: multiple verses in different chapters
 					for (int ari_bc = ari_start_bc; ari_bc <= ari_end_bc; ari_bc += 0x0100) {
-						Book book = S.activeVersion().getBook(Ari.toBook(ari_bc));
+						Book book = App.services.versions.activeVersion().getBook(Ari.toBook(ari_bc));
 						int chapter_1 = Ari.toChapter(ari_bc);
 						if (book == null || chapter_1 <= 0 || chapter_1 > book.chapter_count) {
 							continue;
@@ -268,7 +268,7 @@ public class Provider extends ContentProvider {
 	 * @return number of verses put into the cursor
 	 */
 	private int resultForOneChapter(MatrixCursor cursor, Book book, int last_c, int ari_bc, int v_1_start, int v_1_end, boolean formatting) {
-		final SingleChapterVerses verses = S.activeVersion().loadChapterText(book, Ari.toChapter(ari_bc));
+		final SingleChapterVerses verses = App.services.versions.activeVersion().loadChapterText(book, Ari.toChapter(ari_bc));
 		if (verses == null) {
 			return 0;
 		}
@@ -302,7 +302,7 @@ public class Provider extends ContentProvider {
 		}
 
 		{ // database versions
-			for (MVersionDb mvDb: S.getDb().listAllVersions()) {
+			for (MVersionDb mvDb: App.services.storage.getDb().listAllVersions()) {
 				res.addRow(new Object[]{++_id, "yes", mvDb.hasDataFile() ? 1 : 0, mvDb.shortName != null ? mvDb.shortName : mvDb.longName, mvDb.longName, mvDb.description});
 			}
 		}

--- a/Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionDownloader.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionDownloader.java
@@ -4,7 +4,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.ac.DevotionActivity;
 import yuku.alkitab.base.connection.Connections;
 import yuku.alkitab.base.events.AppEvents;
@@ -55,7 +54,7 @@ public class DevotionDownloader {
                 try {
                     final String output = Connections.downloadString(url);
                     article.fillIn(output);
-                    S.getDb().storeArticleToDevotions(article);
+                    App.services.storage.getDb().storeArticleToDevotions(article);
 
                     if (!output.startsWith("NG")) {
                         AppEvents.emitDevotionDownloaded(kind.name, article.getDate());

--- a/Alkitab/src/main/java/yuku/alkitab/base/dialog/LabelEditorDialog.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/dialog/LabelEditorDialog.kt
@@ -10,7 +10,7 @@ import android.view.LayoutInflater
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
-import yuku.alkitab.base.S.db
+import yuku.alkitab.base.App
 import yuku.alkitab.debug.R
 
 private const val MAX_LABEL_LENGTH = 48
@@ -18,7 +18,7 @@ private const val MAX_LABEL_LENGTH = 48
 object LabelEditorDialog {
     @JvmStatic
     fun show(context: Context, initialText: String, title: String, okListener: OkListener) {
-        val allLabels = db.listAllLabels()
+        val allLabels = App.services.storage.db.listAllLabels()
 
         val dialogView = LayoutInflater.from(context).inflate(R.layout.dialog_input, null, false)
         val til = dialogView.findViewById<TextInputLayout>(R.id.tilInput)

--- a/Alkitab/src/main/java/yuku/alkitab/base/dialog/ProgressMarkListDialog.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/dialog/ProgressMarkListDialog.kt
@@ -10,7 +10,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.RecyclerView
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.util.Appearances.applyMarkerDateTextAppearance
 import yuku.alkitab.base.util.Appearances.applyMarkerSnippetContentAndAppearance
 import yuku.alkitab.base.util.Appearances.applyMarkerTitleTextAppearance
@@ -23,9 +23,9 @@ import yuku.alkitab.model.ProgressMark
 class ProgressMarkListDialog : DialogFragment() {
     var progressMarkSelectedListener: (preset_id: Int) -> Unit = {}
 
-    private val version = S.activeVersion()
-    private val versionId = S.activeVersionId()
-    private val textSizeMult = S.db.getPerVersionSettings(versionId).fontSizeMultiplier
+    private val version = App.services.versions.activeVersion()
+    private val versionId = App.services.versions.activeVersionId()
+    private val textSizeMult = App.services.storage.db.getPerVersionSettings(versionId).fontSizeMultiplier
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         dialog?.window?.requestFeature(Window.FEATURE_NO_TITLE)
@@ -33,7 +33,7 @@ class ProgressMarkListDialog : DialogFragment() {
             val lsProgressMark = findViewById<RecyclerView>(R.id.lsProgressMark)
             val adapter = ProgressMarkAdapter()
             lsProgressMark.adapter = adapter
-            lsProgressMark.setBackgroundColor(S.applied().backgroundColor)
+            lsProgressMark.setBackgroundColor(App.services.uiDimensions.applied().backgroundColor)
         }
     }
 
@@ -53,7 +53,7 @@ class ProgressMarkListDialog : DialogFragment() {
 
         fun reload() {
             progressMarks.clear()
-            progressMarks.addAll(S.db.listAllProgressMarks())
+            progressMarks.addAll(App.services.storage.db.listAllProgressMarks())
             notifyDataSetChanged()
         }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/dialog/ProgressMarkRenameDialog.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/dialog/ProgressMarkRenameDialog.kt
@@ -9,7 +9,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import java.util.Date
-import yuku.alkitab.base.S.db
+import yuku.alkitab.base.App
 import yuku.alkitab.base.events.AppEvents
 import yuku.alkitab.base.widget.AttributeView
 import yuku.alkitab.debug.R
@@ -41,7 +41,7 @@ object ProgressMarkRenameDialog : DialogFragment() {
                     progressMark.caption = name
                 }
                 progressMark.modifyTime = Date()
-                db.insertOrUpdateProgressMark(progressMark)
+                App.services.storage.db.insertOrUpdateProgressMark(progressMark)
 
                 // Since updating database is the responsibility here,
                 // announcing it will also be here.
@@ -55,7 +55,7 @@ object ProgressMarkRenameDialog : DialogFragment() {
                         progressMark.ari = 0
                         progressMark.caption = null
                         progressMark.modifyTime = Date()
-                        db.insertOrUpdateProgressMark(progressMark)
+                        App.services.storage.db.insertOrUpdateProgressMark(progressMark)
 
                         // Since updating database is the responsibility here,
                         // announcing it will also be here.

--- a/Alkitab/src/main/java/yuku/alkitab/base/dialog/TypeBookmarkDialog.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/dialog/TypeBookmarkDialog.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import kotlin.Unit;
-import yuku.alkitab.base.S;
+import yuku.alkitab.base.App;
 import yuku.alkitab.base.util.LabelColorUtil;
 import yuku.alkitab.base.widget.MaterialDialogAdapterHelper;
 import yuku.alkitab.base.widget.MaterialDialogJavaHelper;
@@ -57,14 +57,14 @@ public class TypeBookmarkDialog {
      * @param context Activity context to create dialogs
      */
     public static TypeBookmarkDialog EditExisting(Context context, long _id) {
-        return new TypeBookmarkDialog(context, S.getDb().getMarkerById(_id), null);
+        return new TypeBookmarkDialog(context, App.services.storage.getDb().getMarkerById(_id), null);
     }
 
     /**
      * Open the bookmark edit dialog for a new bookmark by ari.
      */
     public static TypeBookmarkDialog NewBookmark(Context context, int ari, final int verseCount) {
-        final TypeBookmarkDialog res = new TypeBookmarkDialog(context, null, S.activeVersion().referenceWithVerseCount(ari, verseCount));
+        final TypeBookmarkDialog res = new TypeBookmarkDialog(context, null, App.services.versions.activeVersion().referenceWithVerseCount(ari, verseCount));
         res.ariForNewBookmark = ari;
         res.verseCountForNewBookmark = verseCount;
         return res;
@@ -75,7 +75,7 @@ public class TypeBookmarkDialog {
         this.marker = marker;
 
         if (reference == null) {
-            reference = S.activeVersion().referenceWithVerseCount(marker.ari, marker.verseCount);
+            reference = App.services.versions.activeVersion().referenceWithVerseCount(marker.ari, marker.verseCount);
         }
         defaultCaption = reference;
 
@@ -89,7 +89,7 @@ public class TypeBookmarkDialog {
 
         if (marker != null) {
             labels = new TreeSet<>();
-            final List<Label> ll = S.getDb().listLabelsByMarker(marker);
+            final List<Label> ll = App.services.storage.getDb().listLabelsByMarker(marker);
             labels.addAll(ll);
         }
         setLabelsText();
@@ -117,12 +117,12 @@ public class TypeBookmarkDialog {
         if (marker != null) { // update existing
             marker.caption = caption;
             marker.modifyTime = now;
-            S.getDb().insertOrUpdateMarker(marker);
+            App.services.storage.getDb().insertOrUpdateMarker(marker);
         } else { // add new
-            marker = S.getDb().insertMarker(ariForNewBookmark, Marker.Kind.bookmark, caption, verseCountForNewBookmark, now, now);
+            marker = App.services.storage.getDb().insertMarker(ariForNewBookmark, Marker.Kind.bookmark, caption, verseCountForNewBookmark, now, now);
         }
 
-        S.getDb().updateLabels(marker, labels);
+        App.services.storage.getDb().updateLabels(marker, labels);
 
         if (listener != null) listener.onModifiedOrDeleted();
     }
@@ -165,7 +165,7 @@ public class TypeBookmarkDialog {
             context.getString(R.string.bookmark_delete_confirmation),
             context.getString(R.string.delete),
             () -> {
-                S.getDb().deleteMarkerById(marker._id);
+                App.services.storage.getDb().deleteMarkerById(marker._id);
 
                 if (listener != null) listener.onModifiedOrDeleted();
                 return Unit.INSTANCE;
@@ -213,7 +213,7 @@ public class TypeBookmarkDialog {
     }
 
     class LabelAdapter extends MaterialDialogAdapterHelper.Adapter {
-        private final List<Label> availableLabels = S.getDb().listAllLabels();
+        private final List<Label> availableLabels = App.services.storage.getDb().listAllLabels();
 
         @Override
         public int getItemCount() {
@@ -248,7 +248,7 @@ public class TypeBookmarkDialog {
                 final int which = holder.getBindingAdapterPosition();
                 if (which == 0) { // new label
                     LabelEditorDialog.show(context, "", context.getString(R.string.create_label_title), title -> {
-                        final Label newLabel = S.getDb().insertLabel(title, null);
+                        final Label newLabel = App.services.storage.getDb().insertLabel(title, null);
                         if (newLabel != null) {
                             labels.add(newLabel);
                             setLabelsText();

--- a/Alkitab/src/main/java/yuku/alkitab/base/dialog/TypeHighlightDialog.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/dialog/TypeHighlightDialog.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.gestures.detectTapGestures
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.compose.ComposeBottomSheetHost
 import yuku.alkitab.base.compose.colorpicker.ColorPickerDialog
 import yuku.alkitab.base.util.Highlights
@@ -165,7 +165,7 @@ class TypeHighlightDialog {
         if (partial) {
             val start = minOf(range!!.first, range.second)
             val end = maxOf(range.first, range.second)
-            S.db.updateOrInsertPartialHighlight(
+            App.services.storage.db.updateOrInsertPartialHighlight(
                 Ari.encodeWithBc(ariBookChapter, selectedVerses.get(0)),
                 colorRgb,
                 verseText,
@@ -173,7 +173,7 @@ class TypeHighlightDialog {
                 end,
             )
         } else {
-            S.db.updateOrInsertHighlights(ariBookChapter, selectedVerses, colorRgb)
+            App.services.storage.db.updateOrInsertHighlights(ariBookChapter, selectedVerses, colorRgb)
         }
     }
 
@@ -304,7 +304,7 @@ private fun VerseTextSelectable(
         onValueChange = onValueChange,
         readOnly = true,
         textStyle = LocalTextStyle.current.copy(
-            color = Color(S.applied().fontColor),
+            color = Color(App.services.uiDimensions.applied().fontColor),
             fontSize = 16.sp,
         ),
         modifier = Modifier.fillMaxWidth(),

--- a/Alkitab/src/main/java/yuku/alkitab/base/dialog/VersesDialog.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/dialog/VersesDialog.kt
@@ -8,7 +8,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.os.bundleOf
 import kotlin.properties.Delegates.notNull
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.dialog.VersesDialog.Companion.newCompareInstance
 import yuku.alkitab.base.dialog.VersesDialog.Companion.newInstance
 import yuku.alkitab.base.dialog.base.BaseDialog
@@ -69,12 +69,12 @@ class VersesDialog : BaseDialog() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val sourceVersion = S.activeVersion()
-        val sourceVersionId = S.activeVersionId()
-        val textSizeMult = S.db.getPerVersionSettings(sourceVersionId).fontSizeMultiplier
+        val sourceVersion = App.services.versions.activeVersion()
+        val sourceVersionId = App.services.versions.activeVersionId()
+        val textSizeMult = App.services.storage.db.getPerVersionSettings(sourceVersionId).fontSizeMultiplier
 
         val res = inflater.inflate(R.layout.dialog_verses, container, false)
-        res.setBackgroundColor(S.applied().backgroundColor)
+        res.setBackgroundColor(App.services.uiDimensions.applied().backgroundColor)
         val tReference = res.findViewById<TextView>(R.id.tReference)
 
         val versesController = VersesControllerImpl(
@@ -135,7 +135,7 @@ class VersesDialog : BaseDialog() {
                 versionId_ = sourceVersionId
             )
         } else { // read each version and display it. First version must be the sourceVersion.
-            val mversions = S.getAvailableVersions().toMutableList()
+            val mversions = App.services.versions.getAvailableVersions().toMutableList()
             // sort such that sourceVersion is first
             mversions.sortBy { if (it.versionId == sourceVersionId) -1 else 0 }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/dialog/VersesDialogCompareVerses.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/dialog/VersesDialogCompareVerses.kt
@@ -1,7 +1,7 @@
 package yuku.alkitab.base.dialog
 
 import android.content.Context
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.model.MVersion
 import yuku.alkitab.debug.R
 import yuku.alkitab.model.SingleChapterVerses
@@ -60,6 +60,6 @@ class VersesDialogCompareVerses(
 
     override fun getTextSizeMult(verse_0: Int): Float {
         val mversion = mversions[verse_0]
-        return S.db.getPerVersionSettings(mversion.versionId).fontSizeMultiplier
+        return App.services.storage.db.getPerVersionSettings(mversion.versionId).fontSizeMultiplier
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/dialog/XrefDialog.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/dialog/XrefDialog.kt
@@ -15,7 +15,7 @@ import androidx.core.os.bundleOf
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import java.util.Locale
 import kotlin.properties.Delegates.notNull
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.dialog.XrefDialog.Companion.newInstance
 import yuku.alkitab.base.dialog.base.BaseDialog
 import yuku.alkitab.base.util.Appearances.applyTextAppearance
@@ -62,7 +62,7 @@ class XrefDialog : BaseDialog() {
     fun init(sourceVersion: Version, sourceVersionId: String, verseSelectedListener: (arif_source: Int, ari_target: Int) -> Unit) {
         this.sourceVersion = sourceVersion
         this.sourceVersionId = sourceVersionId
-        this.textSizeMult = S.db.getPerVersionSettings(sourceVersionId).fontSizeMultiplier
+        this.textSizeMult = App.services.storage.db.getPerVersionSettings(sourceVersionId).fontSizeMultiplier
         this.verseSelectedListener = verseSelectedListener
         this.initted = true
     }
@@ -89,7 +89,7 @@ class XrefDialog : BaseDialog() {
 
         return inflater.inflate(R.layout.dialog_xref, container, false).apply {
             tXrefText = findViewById(R.id.tXrefText)
-            setBackgroundColor(S.applied().backgroundColor)
+            setBackgroundColor(App.services.uiDimensions.applied().backgroundColor)
 
             versesController = VersesControllerImpl(
                 findViewById(R.id.lsView),

--- a/Alkitab/src/main/java/yuku/alkitab/base/model/MVersionDb.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/model/MVersionDb.java
@@ -3,7 +3,7 @@ package yuku.alkitab.base.model;
 import java.io.File;
 import java.lang.ref.SoftReference;
 import java.util.concurrent.ConcurrentHashMap;
-import yuku.alkitab.base.S;
+import yuku.alkitab.base.App;
 import yuku.alkitab.base.storage.YesReaderFactory;
 import yuku.alkitab.base.util.AppLog;
 import yuku.alkitab.io.BibleReader;
@@ -94,7 +94,7 @@ public class MVersionDb extends MVersion {
 
 	public void setActive(boolean active) {
 		this.cache_active = active;
-		S.getDb().setVersionActive(this, active);
+		App.services.storage.getDb().setVersionActive(this, active);
 	}
 
 	@Override

--- a/Alkitab/src/main/java/yuku/alkitab/base/services/AppServices.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/services/AppServices.kt
@@ -11,7 +11,7 @@ package yuku.alkitab.base.services
  * In tests, callers can construct an [AppServices] with fake/in-memory implementations.
  */
 class AppServices(
-    val storage: StorageProvider,
-    val versions: VersionManager,
-    val uiDimensions: UiDimensionsProvider,
+    @JvmField val storage: StorageProvider,
+    @JvmField val versions: VersionManager,
+    @JvmField val uiDimensions: UiDimensionsProvider,
 )

--- a/Alkitab/src/main/java/yuku/alkitab/base/sync/SyncAdapter.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/sync/SyncAdapter.java
@@ -25,7 +25,6 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import yuku.afw.storage.Preferences;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.connection.Connections;
 import yuku.alkitab.base.events.AppEvents;
 import yuku.alkitab.base.model.SyncShadow;
@@ -308,7 +307,7 @@ public class SyncAdapter extends Worker {
 
 			SyncRecorder.log(SyncRecorder.EventKind.sync_to_server_got_success_data, syncSetName, "final_revno", final_revno, "append_delta_operations_size", append_delta.operations.size());
 
-			final Sync.ApplyAppendDeltaResult applyResult = S.getDb().syncApplier.applyMabelAppendDelta(final_revno, shadowEntities, clientState, append_delta, entitiesBeforeSync, simpleToken);
+			final Sync.ApplyAppendDeltaResult applyResult = App.services.storage.getDb().syncApplier.applyMabelAppendDelta(final_revno, shadowEntities, clientState, append_delta, entitiesBeforeSync, simpleToken);
 
 			SyncRecorder.log(SyncRecorder.EventKind.apply_result, syncSetName, "apply_result", applyResult.name());
 
@@ -502,7 +501,7 @@ public class SyncAdapter extends Worker {
 
 			SyncRecorder.log(SyncRecorder.EventKind.sync_to_server_got_success_data, syncSetName, "final_revno", final_revno, "append_delta_operations_size", append_delta.operations.size());
 
-			final Sync.ApplyAppendDeltaResult applyResult = S.getDb().syncApplier.applyPinsAppendDelta(final_revno, append_delta, entitiesBeforeSync, simpleToken);
+			final Sync.ApplyAppendDeltaResult applyResult = App.services.storage.getDb().syncApplier.applyPinsAppendDelta(final_revno, append_delta, entitiesBeforeSync, simpleToken);
 
 			SyncRecorder.log(SyncRecorder.EventKind.apply_result, syncSetName, "apply_result", applyResult.name());
 
@@ -597,7 +596,7 @@ public class SyncAdapter extends Worker {
 
 			SyncRecorder.log(SyncRecorder.EventKind.sync_to_server_got_success_data, syncSetName, "final_revno", final_revno, "append_delta_operations_size", append_delta.operations.size());
 
-			final Sync.ApplyAppendDeltaResult applyResult = S.getDb().syncApplier.applyRpAppendDelta(final_revno, append_delta, entitiesBeforeSync, simpleToken);
+			final Sync.ApplyAppendDeltaResult applyResult = App.services.storage.getDb().syncApplier.applyRpAppendDelta(final_revno, append_delta, entitiesBeforeSync, simpleToken);
 
 			SyncRecorder.log(SyncRecorder.EventKind.apply_result, syncSetName, "apply_result", applyResult.name());
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/sync/SyncLogActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/sync/SyncLogActivity.java
@@ -20,7 +20,6 @@ import java.util.Locale;
 import java.util.Map;
 import yuku.afw.widget.EasyAdapter;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.ac.base.BaseActivity;
 import yuku.alkitab.base.model.SyncLog;
 import yuku.alkitab.debug.R;
@@ -61,7 +60,7 @@ public class SyncLogActivity extends BaseActivity {
 		final float density = getResources().getDisplayMetrics().density;
 
 		void load() {
-			logs = S.getDb().listLatestSyncLog(500);
+			logs = App.services.storage.getDb().listLatestSyncLog(500);
 			notifyDataSetChanged();
 		}
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/sync/SyncRecorder.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/sync/SyncRecorder.java
@@ -7,7 +7,6 @@ import androidx.annotation.Nullable;
 import java.util.HashMap;
 import yuku.afw.storage.Preferences;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.storage.Prefkey;
 import yuku.alkitab.base.util.Sqlitil;
 
@@ -99,7 +98,7 @@ public class SyncRecorder {
 			}
 		}
 
-		S.getDb().insertSyncLog(Sqlitil.nowDateTime(), kind, syncSetName, params);
+		App.services.storage.getDb().insertSyncLog(Sqlitil.nowDateTime(), kind, syncSetName, params);
 	}
 
 	@Keep

--- a/Alkitab/src/main/java/yuku/alkitab/base/sync/SyncSettingsActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/sync/SyncSettingsActivity.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import kotlin.Unit;
 import yuku.afw.storage.Preferences;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.ac.base.BaseActivity;
 import yuku.alkitab.base.events.AppEvents;
 import yuku.alkitab.base.model.SyncShadow;
@@ -82,7 +81,7 @@ public class SyncSettingsActivity extends BaseActivity {
 							pref.setSummary(getString(R.string.sync_sync_set_pref_summary_never));
 						} else {
 							final Date date = Sqlitil.toDate(time);
-							pref.setSummary(getString(R.string.sync_sync_set_pref_summary_last_synced, lastSyncDateFormat.get().format(date), lastSyncTimeFormat.get().format(date), 	S.getDb().getRevnoFromSyncShadowBySyncSetName(syncSetName)));
+							pref.setSummary(getString(R.string.sync_sync_set_pref_summary_last_synced, lastSyncDateFormat.get().format(date), lastSyncTimeFormat.get().format(date), 	App.services.storage.getDb().getRevnoFromSyncShadowBySyncSetName(syncSetName)));
 						}
 					}
 				} else {
@@ -111,7 +110,7 @@ public class SyncSettingsActivity extends BaseActivity {
 							Preferences.remove(Prefkey.sync_token_obtained_time);
 
 							for (final String syncSetName : SyncShadow.ALL_SYNC_SET_NAMES) {
-								S.getDb().deleteSyncShadowBySyncSetName(syncSetName);
+								App.services.storage.getDb().deleteSyncShadowBySyncSetName(syncSetName);
 							}
 						});
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/sync/Sync_History.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/sync/Sync_History.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.model.SyncShadow;
 import yuku.alkitab.base.util.History;
 
@@ -25,7 +24,7 @@ public class Sync_History {
 	 * @return base revno, delta of shadow -> current.
 	 */
 	public static Pair<Sync.ClientState<Content>, List<Sync.Entity<Content>>> getClientStateAndCurrentEntities() {
-		final SyncShadow ss = S.getDb().getSyncShadowBySyncSetName(SyncShadow.SYNC_SET_HISTORY);
+		final SyncShadow ss = App.services.storage.getDb().getSyncShadowBySyncSetName(SyncShadow.SYNC_SET_HISTORY);
 
 		final List<Sync.Entity<Content>> srcs = ss == null? Collections.emptyList(): entitiesFromShadow(ss);
 		final List<Sync.Entity<Content>> dsts = getEntitiesFromCurrent();

--- a/Alkitab/src/main/java/yuku/alkitab/base/sync/Sync_Mabel.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/sync/Sync_Mabel.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.model.SyncShadow;
 import yuku.alkitab.base.util.Sqlitil;
 import yuku.alkitab.model.Label;
@@ -24,7 +23,7 @@ import yuku.alkitab.model.Marker_Label;
 
 public class Sync_Mabel {
 	public static Sync.GetClientStateResult<Content> getClientStateAndCurrentEntities() {
-		final SyncShadow ss = S.getDb().getSyncShadowBySyncSetName(SyncShadow.SYNC_SET_MABEL);
+		final SyncShadow ss = App.services.storage.getDb().getSyncShadowBySyncSetName(SyncShadow.SYNC_SET_MABEL);
 
 		final List<Sync.Entity<Content>> srcs = ss == null? Collections.emptyList(): entitiesFromShadow(ss);
 		final List<Sync.Entity<Content>> dsts = getEntitiesFromCurrent();
@@ -79,7 +78,7 @@ public class Sync_Mabel {
 		final List<Sync.Entity<Content>> res = new ArrayList<>();
 
 		{ // markers
-			for (final Marker marker : S.getDb().listAllMarkers()) {
+			for (final Marker marker : App.services.storage.getDb().listAllMarkers()) {
 				final Content content = new Content();
 				content.ari = marker.ari;
 				content.caption = marker.caption;
@@ -94,7 +93,7 @@ public class Sync_Mabel {
 		}
 
 		{ // labels
-			for (final Label label : S.getDb().listAllLabels()) {
+			for (final Label label : App.services.storage.getDb().listAllLabels()) {
 				final Content content = new Content();
 				content.title = label.title;
 				content.backgroundColor = label.backgroundColor;
@@ -106,7 +105,7 @@ public class Sync_Mabel {
 		}
 
 		{ // marker_labels
-			for (final Marker_Label marker_label : S.getDb().listAllMarker_Labels()) {
+			for (final Marker_Label marker_label : App.services.storage.getDb().listAllMarker_Labels()) {
 				final Content content = new Content();
 				content.marker_gid = marker_label.marker_gid;
 				content.label_gid = marker_label.label_gid;

--- a/Alkitab/src/main/java/yuku/alkitab/base/sync/Sync_Pins.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/sync/Sync_Pins.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.model.SyncShadow;
 import yuku.alkitab.base.util.Sqlitil;
 import yuku.alkitab.base.widget.AttributeView;
@@ -33,7 +32,7 @@ public class Sync_Pins {
 	 * @return base revno, delta of shadow -> current.
 	 */
 	public static Pair<Sync.ClientState<Content>, List<Sync.Entity<Content>>> getClientStateAndCurrentEntities() {
-		final SyncShadow ss = S.getDb().getSyncShadowBySyncSetName(SyncShadow.SYNC_SET_PINS);
+		final SyncShadow ss = App.services.storage.getDb().getSyncShadowBySyncSetName(SyncShadow.SYNC_SET_PINS);
 
 		final List<Sync.Entity<Content>> srcs = ss == null? Collections.emptyList(): entitiesFromShadow(ss);
 		final List<Sync.Entity<Content>> dsts = getEntitiesFromCurrent();
@@ -91,7 +90,7 @@ public class Sync_Pins {
 		final List<Content.Pin> pins = content.pins = new ArrayList<>();
 
 		for (int preset_id = 0; preset_id < AttributeView.PROGRESS_MARK_TOTAL_COUNT; preset_id++) {
-			final ProgressMark pm = S.getDb().getProgressMarkByPresetId(preset_id);
+			final ProgressMark pm = App.services.storage.getDb().getProgressMarkByPresetId(preset_id);
 			if (pm == null) continue;
 
 			final Content.Pin pin = new Content.Pin();

--- a/Alkitab/src/main/java/yuku/alkitab/base/sync/Sync_Rp.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/sync/Sync_Rp.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.model.ReadingPlan;
 import yuku.alkitab.base.model.SyncShadow;
 
@@ -32,7 +31,7 @@ public class Sync_Rp {
 	 * @return base revno, delta of shadow -> current.
 	 */
 	public static Pair<Sync.ClientState<Content>, List<Sync.Entity<Content>>> getClientStateAndCurrentEntities() {
-		final SyncShadow ss = S.getDb().getSyncShadowBySyncSetName(SyncShadow.SYNC_SET_RP);
+		final SyncShadow ss = App.services.storage.getDb().getSyncShadowBySyncSetName(SyncShadow.SYNC_SET_RP);
 
 		final List<Sync.Entity<Content>> srcs = ss == null? Collections.emptyList(): entitiesFromShadow(ss);
 		final List<Sync.Entity<Content>> dsts = getEntitiesFromCurrent();
@@ -87,7 +86,7 @@ public class Sync_Rp {
 		final List<Sync.Entity<Content>> res = new ArrayList<>();
 
 		// lookup map for startTime
-		final List<ReadingPlan.ReadingPlanInfo> infos = S.getDb().listAllReadingPlanInfo();
+		final List<ReadingPlan.ReadingPlanInfo> infos = App.services.storage.getDb().listAllReadingPlanInfo();
 		final Map<String /* gid */, Long> /* long startTime */ startTimes = new HashMap<>(infos.size());
 		for (final ReadingPlan.ReadingPlanInfo info : infos) {
 			startTimes.put(ReadingPlan.gidFromName(info.name), info.startTime);
@@ -96,7 +95,7 @@ public class Sync_Rp {
 		// The only source of data is from ReadingPlanProgress table,
 		// but since reading plans with no done is not listed in ReadingPlanProgress,
 		// we need to consult ReadingPlan table to know what they are.
-		final Map<String /* gid */, Set<Integer> /* done reading codes */> map = S.getDb().getReadingPlanProgressSummaryForSync();
+		final Map<String /* gid */, Set<Integer> /* done reading codes */> map = App.services.storage.getDb().getReadingPlanProgressSummaryForSync();
 		for (final Map.Entry<String, Set<Integer>> e : map.entrySet()) {
 			final String gid = e.getKey();
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/Appearances.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/Appearances.kt
@@ -8,7 +8,7 @@ import android.text.style.UnderlineSpan
 import android.util.TypedValue
 import android.widget.TextView
 import androidx.core.text.underline
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 
 object Appearances {
     @JvmStatic
@@ -24,7 +24,7 @@ object Appearances {
 
     @JvmStatic
     fun applyTextAppearance(t: TextView, fontSizeMultiplier: Float) {
-        val applied = S.applied()
+        val applied = App.services.uiDimensions.applied()
 
         t.setTypeface(applied.fontFace, applied.fontBold)
         t.setTextSize(TypedValue.COMPLEX_UNIT_DIP, applied.fontSize2dp * fontSizeMultiplier)
@@ -36,7 +36,7 @@ object Appearances {
 
     @JvmStatic
     fun applyPericopeTitleAppearance(t: TextView, fontSizeMultiplier: Float) {
-        val applied = S.applied()
+        val applied = App.services.uiDimensions.applied()
 
         t.setTypeface(applied.fontFace, Typeface.BOLD)
         t.setTextSize(TypedValue.COMPLEX_UNIT_DIP, applied.fontSize2dp * fontSizeMultiplier)
@@ -46,7 +46,7 @@ object Appearances {
 
     @JvmStatic
     fun applyPericopeParallelTextAppearance(t: TextView, fontSizeMultiplier: Float) {
-        val applied = S.applied()
+        val applied = App.services.uiDimensions.applied()
 
         t.typeface = applied.fontFace
         t.setTextSize(TypedValue.COMPLEX_UNIT_DIP, applied.fontSize2dp * 0.8235294f * fontSizeMultiplier)
@@ -61,12 +61,12 @@ object Appearances {
         applyMarkerTitleTextAppearance(t, textSizeMult)
         sb.setSpan(UnderlineSpan(), 0, sb.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         t.text = sb
-        t.setLineSpacing(0f, S.applied().lineSpacingMult)
+        t.setLineSpacing(0f, App.services.uiDimensions.applied().lineSpacingMult)
     }
 
     @JvmStatic
     fun applyMarkerTitleTextAppearance(t: TextView, textSizeMult: Float) {
-        val applied = S.applied()
+        val applied = App.services.uiDimensions.applied()
 
         t.setTypeface(applied.fontFace, applied.fontBold)
         t.setTextSize(TypedValue.COMPLEX_UNIT_DIP, applied.fontSize2dp * 1.2f * textSizeMult)
@@ -75,7 +75,7 @@ object Appearances {
 
     @JvmStatic
     fun applyMarkerDateTextAppearance(t: TextView, textSizeMult: Float) {
-        val applied = S.applied()
+        val applied = App.services.uiDimensions.applied()
 
         t.setTextSize(TypedValue.COMPLEX_UNIT_DIP, applied.fontSize2dp * 0.8f * textSizeMult)
         t.setTextColor(applied.fontColor)
@@ -83,7 +83,7 @@ object Appearances {
 
     @JvmStatic
     fun applyVerseNumberAppearance(t: TextView, textSizeMult: Float) {
-        val applied = S.applied()
+        val applied = App.services.uiDimensions.applied()
 
         t.setTypeface(applied.fontFace, applied.fontBold)
         t.setTextSize(TypedValue.COMPLEX_UNIT_DIP, applied.fontSize2dp * 0.7f * textSizeMult)

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/HistorySyncUtil.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/HistorySyncUtil.kt
@@ -2,7 +2,7 @@ package yuku.alkitab.base.util
 
 import java.util.Locale
 import yuku.afw.storage.Preferences
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.model.SyncShadow
 import yuku.alkitab.base.storage.Prefkey
 import yuku.alkitab.base.sync.Sync
@@ -57,7 +57,7 @@ object HistorySyncUtil {
 
             // if we reach here, the local database has been updated with the append delta.
             val ss = Sync_History.shadowFromEntities(Sync_History.getEntitiesFromCurrent(), final_revno)
-            S.db.insertOrUpdateSyncShadowBySyncSetName(ss)
+            App.services.storage.db.insertOrUpdateSyncShadowBySyncSetName(ss)
             history.save()
 
             // when debugging, print

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/ReadingPlanManager.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/ReadingPlanManager.java
@@ -5,7 +5,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
-import yuku.alkitab.base.S;
+import yuku.alkitab.base.App;
 import yuku.alkitab.base.model.ReadingPlan;
 import yuku.alkitab.util.IntArrayList;
 import yuku.bintex.BintexReader;
@@ -32,7 +32,7 @@ public class ReadingPlanManager {
 
 			info.startTime = new Date().getTime();
 
-			return S.getDb().insertReadingPlan(info, data);
+			return App.services.storage.getDb().insertReadingPlan(info, data);
 		} catch (IOException e) {
 			AppLog.e(TAG, "Error reading reading plan, should not happen", e);
 			return 0;
@@ -45,9 +45,9 @@ public class ReadingPlanManager {
 		final String gid = ReadingPlan.gidFromName(readingPlanName);
 
 		if (checked) {
-			S.getDb().insertOrUpdateReadingPlanProgress(gid, readingCode, System.currentTimeMillis());
+			App.services.storage.getDb().insertOrUpdateReadingPlanProgress(gid, readingCode, System.currentTimeMillis());
 		} else {
-			S.getDb().deleteReadingPlanProgress(gid, readingCode);
+			App.services.storage.getDb().deleteReadingPlanProgress(gid, readingCode);
 		}
 	}
 
@@ -66,7 +66,7 @@ public class ReadingPlanManager {
 			}
 		}
 
-		S.getDb().insertOrUpdateMultipleReadingPlanProgresses(gid, readingCodes, System.currentTimeMillis());
+		App.services.storage.getDb().insertOrUpdateMultipleReadingPlanProgresses(gid, readingCodes, System.currentTimeMillis());
 	}
 
 	@NonNull public static ReadingPlan readVersion1(InputStream inputStream, String name) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItem.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItem.kt
@@ -16,7 +16,7 @@ import android.widget.TextView
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
 import yuku.afw.storage.Preferences
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.widget.AttributeView
 import yuku.alkitab.base.widget.LeftDrawer.PROGRESS_MARK_DRAG_MIME_TYPE
 import yuku.alkitab.base.widget.VerseTextView
@@ -294,7 +294,7 @@ class VerseItem(context: Context, attrs: AttributeSet) : RelativeLayout(context,
         val progress_mark_bits = attributeView.progressMarkBits
         for (preset_id in 0 until AttributeView.PROGRESS_MARK_TOTAL_COUNT) {
             if (progress_mark_bits and (1 shl AttributeView.PROGRESS_MARK_BITS_START + preset_id) != 0) {
-                S.db.getProgressMarkByPresetId(preset_id)?.let { progressMark ->
+                App.services.storage.db.getProgressMarkByPresetId(preset_id)?.let { progressMark ->
                     val caption = if (TextUtils.isEmpty(progressMark.caption)) {
                         context.getString(AttributeView.getDefaultProgressMarkStringResource(preset_id))
                     } else {

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -16,7 +16,7 @@ import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.RecyclerView
 import java.util.concurrent.atomic.AtomicInteger
 import yuku.afw.storage.Preferences
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.util.AppLog
 import yuku.alkitab.base.util.Appearances
 import yuku.alkitab.base.util.TargetDecoder
@@ -607,7 +607,7 @@ class VerseTextHolder(private val view: VerseItem) : ItemHolder(view) {
         }
 
         val attributeView = view.attributeView
-        attributeView.setScale(scaleForAttributeView(S.applied().fontSize2dp * ui.textSizeMult))
+        attributeView.setScale(scaleForAttributeView(App.services.uiDimensions.applied().fontSize2dp * ui.textSizeMult))
         attributeView.bookmarkCount = data.versesAttributes.bookmarkCountMap_[index]
         attributeView.noteCount = data.versesAttributes.noteCountMap_[index]
         attributeView.progressMarkBits = data.versesAttributes.progressMarkBitsMap_[index]
@@ -731,10 +731,10 @@ class PericopeHolder(private val view: PericopeHeaderItem) : ItemHolder(view) {
         val paddingTop = if (position == 0 || data.getItemViewType(position - 1) == ItemType.pericope) {
             0
         } else {
-            S.applied().pericopeSpacingTop
+            App.services.uiDimensions.applied().pericopeSpacingTop
         }
 
-        this.itemView.setPadding(0, paddingTop, 0, S.applied().pericopeSpacingBottom)
+        this.itemView.setPadding(0, paddingTop, 0, App.services.uiDimensions.applied().pericopeSpacingBottom)
 
         Appearances.applyPericopeTitleAppearance(lCaption, ui.textSizeMult)
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/LeftDrawer.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/LeftDrawer.java
@@ -31,7 +31,6 @@ import yuku.afw.storage.Preferences;
 import yuku.afw.widget.EasyAdapter;
 import yuku.alkitab.base.App;
 import yuku.alkitab.base.IsiActivity;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.ac.AboutActivity;
 import yuku.alkitab.base.ac.DevotionActivity;
 import yuku.alkitab.base.ac.ReadingPlanActivity;
@@ -376,7 +375,7 @@ public abstract class LeftDrawer extends NestedScrollView {
 				panelCurrentReadingHeader.setVisibility(VISIBLE);
 				bCurrentReadingReference.setVisibility(VISIBLE);
 
-				bCurrentReadingReference.setText(S.activeVersion().referenceRange(aris[0], aris[1]));
+				bCurrentReadingReference.setText(App.services.versions.activeVersion().referenceRange(aris[0], aris[1]));
 			}
 		}
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
@@ -11,7 +11,6 @@ import androidx.core.view.updateLayoutParams
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import yuku.afw.storage.Preferences
 import yuku.alkitab.base.App
-import yuku.alkitab.base.S
 import yuku.alkitab.base.model.MVersion
 import yuku.alkitab.base.storage.Prefkey
 import yuku.alkitab.base.util.AppLog
@@ -165,8 +164,8 @@ class SplitViewManager(
             SplitHandleButton.Orientation.vertical
         }
 
-        val splitMv = S.getVersionFromVersionId(lastSplitVersionId)
-        val splitMvActual = splitMv ?: S.getMVersionInternal()
+        val splitMv = App.services.versions.getVersionFromVersionId(lastSplitVersionId)
+        val splitMvActual = splitMv ?: App.services.versions.getMVersionInternal()
 
         if (loadSplitVersion(splitMvActual)) {
             openSplitDisplay()
@@ -238,11 +237,11 @@ class SplitViewManager(
                     host.activeSplit0Book.reference(host.chapter_1),
                     activeSplit1.version.shortName,
                 ),
-                S.applied().fontColor,
+                App.services.uiDimensions.applied().fontColor,
             )
             actions.setSplit1DataModel(VersesDataModel.EMPTY)
         } else {
-            host.lsSplit1.setEmptyMessage(null, S.applied().fontColor)
+            host.lsSplit1.setEmptyMessage(null, App.services.uiDimensions.applied().fontColor)
             actions.loadChapterIntoSplit1(activeSplit1.version, activeSplit1.versionId, splitBook, host.chapter_1)
             host.lsSplit1.scrollToVerse(verse_1)
         }

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/TextAppearancePanel.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/TextAppearancePanel.java
@@ -26,7 +26,6 @@ import java.util.Locale;
 import yuku.afw.App;
 import yuku.afw.storage.Preferences;
 import yuku.afw.widget.EasyAdapter;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.ac.ColorSettingsActivity;
 import yuku.alkitab.base.ac.FontManagerActivity;
 import yuku.alkitab.base.model.PerVersionSettings;
@@ -123,7 +122,7 @@ public class TextAppearancePanel {
 
             lTextSizeLabel.setText(TextUtils.expandTemplate(activity.getText(R.string.text_appearance_text_size_for_version), splitVersionLongName));
 
-            final PerVersionSettings settings = S.getDb().getPerVersionSettings(splitVersionId);
+            final PerVersionSettings settings = yuku.alkitab.base.App.services.storage.getDb().getPerVersionSettings(splitVersionId);
             sbTextSizePerVersion.setProgress(Math.round((settings.fontSizeMultiplier - 0.5f) * 20.f));
             displayTextSizePerVersionText(settings.fontSizeMultiplier);
         }
@@ -231,9 +230,9 @@ public class TextAppearancePanel {
             if (splitVersionId == null) return;
 
             float textSizeMult = progress * 0.05f + 0.5f;
-            final PerVersionSettings settings = S.getDb().getPerVersionSettings(splitVersionId);
+            final PerVersionSettings settings = yuku.alkitab.base.App.services.storage.getDb().getPerVersionSettings(splitVersionId);
             settings.fontSizeMultiplier = textSizeMult;
-            S.getDb().storePerVersionSettings(splitVersionId, settings);
+            yuku.alkitab.base.App.services.storage.getDb().storePerVersionSettings(splitVersionId, settings);
 
             displayTextSizePerVersionText(textSizeMult);
             listener.onValueChanged();

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/VerseRenderer.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/VerseRenderer.kt
@@ -14,7 +14,6 @@ import android.view.View
 import android.widget.TextView
 import android.widget.Toast
 import yuku.alkitab.base.App
-import yuku.alkitab.base.S
 import yuku.alkitab.base.util.Highlights
 import yuku.alkitab.util.Ari
 
@@ -38,7 +37,7 @@ object VerseRenderer {
             tp.baselineShift += (tp.ascent() * 0.3f + 0.5f).toInt()
             tp.textSize = tp.textSize * 0.7f
             if (applyColor) {
-                tp.color = S.applied().verseNumberColor
+                tp.color = App.services.uiDimensions.applied().verseNumberColor
             }
         }
     }
@@ -207,7 +206,7 @@ object VerseRenderer {
                 '6' -> startRed = sb.length
                 '5' -> if (startRed != -1) {
                     if (!checked) {
-                        sb.setSpan(ForegroundColorSpan(S.applied().fontRedColor), startRed, sb.length, 0)
+                        sb.setSpan(ForegroundColorSpan(App.services.uiDimensions.applied().fontRedColor), startRed, sb.length, 0)
                     }
                     startRed = -1
                 }
@@ -327,7 +326,7 @@ object VerseRenderer {
         if (startPara == len) return
 
         val indentSpacingExtraUnits = if (verseNumberText.length < 3) 0 else verseNumberText.length - 2
-        val applied = S.applied()
+        val applied = App.services.uiDimensions.applied()
 
         when (paraType) {
             -1, '0'.code -> {
@@ -361,9 +360,9 @@ object VerseRenderer {
         // verse text
         sb.append(text)
         if (isVerseNumberShown) {
-            sb.setSpan(createLeadingMarginSpan(0, S.applied().indentParagraphRest), 0, sb.length, 0)
+            sb.setSpan(createLeadingMarginSpan(0, App.services.uiDimensions.applied().indentParagraphRest), 0, sb.length, 0)
         } else {
-            sb.setSpan(createLeadingMarginSpan(S.applied().indentParagraphRest), 0, sb.length, 0)
+            sb.setSpan(createLeadingMarginSpan(App.services.uiDimensions.applied().indentParagraphRest), 0, sb.length, 0)
         }
 
         if (highlightInfo != null) {

--- a/Alkitab/src/main/java/yuku/alkitab/datatransfer/process/ReadWriteStorageImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/datatransfer/process/ReadWriteStorageImpl.kt
@@ -1,6 +1,6 @@
 package yuku.alkitab.datatransfer.process
 
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.storage.InternalDbTxWrapper
 import yuku.alkitab.base.util.History
 import yuku.alkitab.base.util.Sqlitil
@@ -14,13 +14,13 @@ import yuku.alkitab.util.IntArrayList
 
 class ReadWriteStorageImpl : ReadonlyStorageImpl(), ReadWriteStorageInterface {
     override fun transact(action: (ReadWriteStorageInterface.TxHandle) -> Unit) {
-        InternalDbTxWrapper.transact(S.db) { handle ->
+        InternalDbTxWrapper.transact(App.services.storage.db) { handle ->
             action { handle.commit() }
         }
     }
 
     override fun replaceMarkerLabel(markerLabel: Marker_Label) {
-        S.db.insertOrUpdateMarker_Label(markerLabel)
+        App.services.storage.db.insertOrUpdateMarker_Label(markerLabel)
     }
 
     override fun replaceHistory(entries: List<History.Entry>) {
@@ -31,14 +31,14 @@ class ReadWriteStorageImpl : ReadonlyStorageImpl(), ReadWriteStorageInterface {
      * [marker] must have the correct _id for this to work correctly (0 for new).
      */
     override fun replaceMarker(marker: Marker) {
-        S.db.insertOrUpdateMarker(marker)
+        App.services.storage.db.insertOrUpdateMarker(marker)
     }
 
     /**
      * [label] must have the correct _id for this to work correctly (0 for new).
      */
     override fun replaceLabel(label: Label) {
-        S.db.insertOrUpdateLabel(label)
+        App.services.storage.db.insertOrUpdateLabel(label)
     }
 
     override fun replacePin(pin: Pin) {
@@ -48,13 +48,13 @@ class ReadWriteStorageImpl : ReadonlyStorageImpl(), ReadWriteStorageInterface {
             caption = pin.caption
             modifyTime = Sqlitil.toDate(pin.modifyTime)
         }
-        S.db.insertOrUpdateProgressMark(pm)
+        App.services.storage.db.insertOrUpdateProgressMark(pm)
     }
 
     override fun replaceRpp(rpp: Rpp) {
         val readingCodes = IntArrayList(rpp.done.size)
         rpp.done.forEach { readingCodes.add(it) }
 
-        S.db.replaceReadingPlanProgress(rpp.gid.value, readingCodes, System.currentTimeMillis())
+        App.services.storage.db.replaceReadingPlanProgress(rpp.gid.value, readingCodes, System.currentTimeMillis())
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/datatransfer/process/ReadonlyStorageImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/datatransfer/process/ReadonlyStorageImpl.kt
@@ -1,6 +1,6 @@
 package yuku.alkitab.datatransfer.process
 
-import yuku.alkitab.base.S
+import yuku.alkitab.base.App
 import yuku.alkitab.base.model.ReadingPlan
 import yuku.alkitab.base.util.History
 import yuku.alkitab.datatransfer.model.Gid
@@ -16,33 +16,33 @@ open class ReadonlyStorageImpl : ReadonlyStorageInterface {
     }
 
     override fun markers(): List<Marker> {
-        return S.db.listAllMarkers()
+        return App.services.storage.db.listAllMarkers()
     }
 
     override fun labels(): List<Label> {
-        return S.db.listAllLabels()
+        return App.services.storage.db.listAllLabels()
     }
 
     override fun markerLabels(): List<Marker_Label> {
-        return S.db.listAllMarker_Labels()
+        return App.services.storage.db.listAllMarker_Labels()
     }
 
     override fun pins(): List<ProgressMark> {
-        return S.db.listAllProgressMarks()
+        return App.services.storage.db.listAllProgressMarks()
     }
 
     override fun rpps(): List<Rpp> {
         val res = mutableListOf<Rpp>()
 
         // lookup map for startTime
-        val startTimes = S.db.listAllReadingPlanInfo().associate { info ->
+        val startTimes = App.services.storage.db.listAllReadingPlanInfo().associate { info ->
             ReadingPlan.gidFromName(info.name) to info.startTime
         }
 
         // The only source of data is from ReadingPlanProgress table,
         // but since reading plans with no done is not listed in ReadingPlanProgress,
         // we need to consult ReadingPlan table to know what they are.
-        val map: Map<String, Set<Int>> = S.db.readingPlanProgressSummaryForSync
+        val map: Map<String, Set<Int>> = App.services.storage.db.readingPlanProgressSummaryForSync
         for ((gid, set) in map) {
             val startTime = startTimes[gid] ?: continue
 

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.java
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.java
@@ -29,7 +29,6 @@ import okhttp3.Call;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import yuku.alkitab.base.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.connection.Connections;
 import yuku.alkitab.base.storage.SongDb;
 import yuku.alkitab.base.util.Background;
@@ -96,7 +95,7 @@ public class SongBookUtil {
 
     @NonNull
     public static SongBookInfo getSongBookInfo(@NonNull final String bookName) {
-        final SongBookInfo info = S.getSongDb().getSongBookInfo(bookName);
+        final SongBookInfo info = App.services.storage.getSongDb().getSongBookInfo(bookName);
         if (info != null) return info;
 
         return fallbackSongBookInfo(bookName);
@@ -125,7 +124,7 @@ public class SongBookUtil {
             menu.add(0, POPUP_ID_ALL, 0, sb);
         }
 
-        final List<SongBookInfo> infos = S.getSongDb().listSongBookInfos();
+        final List<SongBookInfo> infos = App.services.storage.getSongDb().listSongBookInfos();
         for (int i = 0; i < infos.size(); i++) {
             final SongBookInfo info = infos.get(i);
             final SpannableStringBuilder sb = new SpannableStringBuilder(escapeSongBookName(info.name));
@@ -160,7 +159,7 @@ public class SongBookUtil {
             switch (itemId) {
                 case POPUP_ID_ALL -> listener.onAllSelected();
                 case POPUP_ID_MORE -> listener.onMoreSelected();
-                default -> listener.onSongBookSelected(S.getSongDb().listSongBookInfos().get(itemId - 1).name);
+                default -> listener.onSongBookSelected(App.services.storage.getSongDb().listSongBookInfos().get(itemId - 1).name);
             }
             return true;
         };
@@ -264,8 +263,8 @@ public class SongBookUtil {
                     }
 
                     // insert songs to db
-                    S.getSongDb().insertSongBookInfo(songBookInfo);
-                    S.getSongDb().storeSongs(songBookInfo.name, songs, dataFormatVersion);
+                    App.services.storage.getSongDb().insertSongBookInfo(songBookInfo);
+                    App.services.storage.getSongDb().storeSongs(songBookInfo.name, songs, dataFormatVersion);
 
                     Foreground.run(() -> listener.onDownloadedAndInserted(songBookInfo));
                 }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongListActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongListActivity.java
@@ -23,7 +23,6 @@ import androidx.appcompat.widget.Toolbar;
 import java.util.ArrayList;
 import java.util.List;
 import yuku.afw.App;
-import yuku.alkitab.base.S;
 import yuku.alkitab.base.ac.base.BaseActivity;
 import yuku.alkitab.debug.R;
 
@@ -342,10 +341,10 @@ public class SongListActivity extends BaseActivity {
 		public List<SongInfo> loadInBackground() {
 			List<SongInfo> res;
 			if (!deepSearch) {
-				List<SongInfo> songInfos = S.getSongDb().listSongInfosByBookName(getSelectedBookName());
+				List<SongInfo> songInfos = yuku.alkitab.base.App.services.storage.getSongDb().listSongInfosByBookName(getSelectedBookName());
 				res = SongFilter.filterSongInfosByString(songInfos, filter_string);
 			} else {
-				res = S.getSongDb().listSongInfosByBookNameAndDeepFilter(getSelectedBookName(), filter_string);
+				res = yuku.alkitab.base.App.services.storage.getSongDb().listSongInfosByBookNameAndDeepFilter(getSelectedBookName(), filter_string);
 			}
 			return res;
 		}

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongViewActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongViewActivity.kt
@@ -34,7 +34,6 @@ import java.io.IOException
 import java.util.Locale
 import yuku.afw.storage.Preferences
 import yuku.alkitab.base.App
-import yuku.alkitab.base.S
 import yuku.alkitab.base.ac.AlertDialogActivity
 import yuku.alkitab.base.ac.HelpActivity
 import yuku.alkitab.base.ac.PatchTextActivity
@@ -203,7 +202,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
         val currentSong = currentSong ?: return
 
         val codes = cache_codes.getOrPut(currentBookName) {
-            val songInfos = S.songDb.listSongInfosByBookName(currentBookName)
+            val songInfos = App.services.storage.songDb.listSongInfosByBookName(currentBookName)
             val codes = mutableListOf<String>()
             for (songInfo in songInfos) {
                 codes.add(songInfo.code)
@@ -225,7 +224,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
         }
 
         val newCode = codes[newPos]
-        val newSong = S.songDb.getSong(currentBookName, newCode) ?: return // should not happen
+        val newSong = App.services.storage.songDb.getSong(currentBookName, newCode) ?: return // should not happen
 
         displaySong(currentBookName, newSong)
     }
@@ -262,7 +261,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
         bDownload.setOnClickListener { openDownloadSongBookPage() }
 
         // if no song books is downloaded, open download page immediately
-        if (S.songDb.countSongBookInfos() == 0) {
+        if (App.services.storage.songDb.countSongBookInfos() == 0) {
             openDownloadSongBookPage()
         }
 
@@ -300,7 +299,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
     override fun onStart() {
         super.onStart()
 
-        val applied = S.applied()
+        val applied = App.services.uiDimensions.applied()
 
         // apply background color, and clear window background to prevent overdraw
         window.setBackgroundDrawableResource(android.R.color.transparent)
@@ -333,7 +332,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
         if (bookName == null || code == null) {
             displaySong(null, null, true)
         } else {
-            displaySong(bookName, S.songDb.getSong(bookName, code), true)
+            displaySong(bookName, App.services.storage.songDb.getSong(bookName, code), true)
         }
 
         window.decorView.keepScreenOn = Preferences.getBoolean(getString(R.string.pref_keepScreenOn_key), resources.getBoolean(R.bool.pref_keepScreenOn_default))
@@ -343,7 +342,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
      * Used after deleting a song, and the current song is no longer available
      */
     private fun displayAnySongOrFinish() {
-        val pair = S.songDb.anySong
+        val pair = App.services.storage.songDb.anySong
         if (pair == null) {
             finish()
         } else {
@@ -546,7 +545,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
         val songBookInfo = SongBookUtil.getSongBookInfo(currentBookName)
 
         val currentSongCode = currentSong.code
-        val dataFormatVersion = S.songDb.getDataFormatVersionForSongs(currentBookName)
+        val dataFormatVersion = App.services.storage.songDb.getDataFormatVersionForSongs(currentBookName)
 
         SongBookUtil.downloadSongBook(this@SongViewActivity, songBookInfo, dataFormatVersion, object : SongBookUtil.OnDownloadSongBookListener {
             override fun onFailedOrCancelled(songBookInfo: SongBookUtil.SongBookInfo, e: Exception?) {
@@ -554,7 +553,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
             }
 
             override fun onDownloadedAndInserted(songBookInfo: SongBookUtil.SongBookInfo) {
-                val song = S.songDb.getSong(songBookInfo.name, currentSongCode)
+                val song = App.services.storage.songDb.getSong(songBookInfo.name, currentSongCode)
                 cache_codes.remove(songBookInfo.name)
                 displaySong(songBookInfo.name, song)
             }
@@ -587,7 +586,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
         val bookName = currentBookName
 
         Background.run {
-            val count = S.songDb.deleteSongBook(bookName)
+            val count = App.services.storage.songDb.deleteSongBook(bookName)
 
             runOnUiThread {
                 pd.dismiss()
@@ -753,7 +752,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
             if (bookId < 0) {
                 AppLog.w(TAG, "osisBookName invalid: $bookName in $line")
             } else {
-                val book = S.activeVersion().getBook(bookId)
+                val book = App.services.versions.activeVersion().getBook(bookId)
 
                 if (book != null) {
                     var full = true
@@ -857,7 +856,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
                 if (resultCode == RESULT_OK) {
                     val result = SongListActivity.obtainResult(data)
                     if (result != null) {
-                        displaySong(result.bookName, S.songDb.getSong(result.bookName, result.code))
+                        displaySong(result.bookName, App.services.storage.songDb.getSong(result.bookName, result.code))
                         // store this for next search
                         last_searchState = result.last_searchState
                     }
@@ -928,7 +927,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
         SongBookUtil.downloadSongBook(this, info, dataFormatVersion, object : SongBookUtil.OnDownloadSongBookListener {
             override fun onDownloadedAndInserted(songBookInfo: SongBookUtil.SongBookInfo) {
                 val name = songBookInfo.name
-                val song = S.songDb.getFirstSongFromBook(name)
+                val song = App.services.storage.songDb.getFirstSongFromBook(name)
                 displaySong(name, song)
             }
 
@@ -954,7 +953,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
 
                 if (song != null) {
                     // do not proceed if the song is too old
-                    val updateTime = S.songDb.getSongUpdateTime(currentBookName, song.code)
+                    val updateTime = App.services.storage.songDb.getSongUpdateTime(currentBookName, song.code)
                     if (updateTime == 0 || Sqlitil.nowDateTime() - updateTime > 21 * 86400) {
                         MaterialAlertDialogBuilder(this)
                             .setMessage(TextUtils.expandTemplate(getText(R.string.sn_update_book_because_too_old), SongBookUtil.escapeSongBookName(currentBookName)))
@@ -1017,10 +1016,10 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
         fun updateHandle() {
             handle.setCode(state_tempCode)
 
-            handle.setOkButtonEnabled(S.songDb.songExists(currentBookName, state_tempCode))
-            handle.setAButtonEnabled(state_tempCode.length <= 3 && S.songDb.songExists(currentBookName, state_tempCode + "A"))
-            handle.setBButtonEnabled(state_tempCode.length <= 3 && S.songDb.songExists(currentBookName, state_tempCode + "B"))
-            handle.setCButtonEnabled(state_tempCode.length <= 3 && S.songDb.songExists(currentBookName, state_tempCode + "C"))
+            handle.setOkButtonEnabled(App.services.storage.songDb.songExists(currentBookName, state_tempCode))
+            handle.setAButtonEnabled(state_tempCode.length <= 3 && App.services.storage.songDb.songExists(currentBookName, state_tempCode + "A"))
+            handle.setBButtonEnabled(state_tempCode.length <= 3 && App.services.storage.songDb.songExists(currentBookName, state_tempCode + "B"))
+            handle.setCButtonEnabled(state_tempCode.length <= 3 && App.services.storage.songDb.songExists(currentBookName, state_tempCode + "C"))
         }
 
         when (val num = keypadViewToNumConverter(v)) {
@@ -1055,7 +1054,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
 
             21 -> { // OK
                 if (state_tempCode.isNotEmpty()) {
-                    val song = S.songDb.getSong(currentBookName, state_tempCode)
+                    val song = App.services.storage.songDb.getSong(currentBookName, state_tempCode)
                     if (song != null) {
                         displaySong(currentBookName, song)
                     } else {
@@ -1070,7 +1069,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
     }
 
     override fun songBookSelected(name: String) {
-        val song = S.songDb.getFirstSongFromBook(name)
+        val song = App.services.storage.songDb.getFirstSongFromBook(name)
 
         if (song != null) {
             displaySong(name, song)

--- a/Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionListFragment.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionListFragment.kt
@@ -34,7 +34,6 @@ import java.util.Locale
 import java.util.regex.Matcher
 import kotlinx.coroutines.launch
 import yuku.alkitab.base.App
-import yuku.alkitab.base.S
 import yuku.alkitab.base.config.VersionConfig
 import yuku.alkitab.base.events.AppEvents
 import yuku.alkitab.base.model.MVersion
@@ -230,7 +229,7 @@ class VersionListFragment : Fragment(), QueryTextReceiver {
             button_count++
             b.setNeutralButton(R.string.buang_dari_daftar) { _, _ ->
                 val filename = mv.filename
-                S.db.deleteVersion(mv)
+                App.services.storage.db.deleteVersion(mv)
                 AppEvents.emitVersionListReload()
                 File(filename).delete()
             }
@@ -282,7 +281,7 @@ class VersionListFragment : Fragment(), QueryTextReceiver {
                 MaterialAlertDialogBuilder(requireActivity())
                     .setMessage(getString(R.string.the_file_for_this_version_is_no_longer_available_file, mv.filename))
                     .setPositiveButton(R.string.delete) { _, _ ->
-                        S.db.deleteVersion(mv)
+                        App.services.storage.db.deleteVersion(mv)
                         AppEvents.emitVersionListReload()
                     }
                     .setNegativeButton(R.string.no, null)
@@ -343,12 +342,12 @@ class VersionListFragment : Fragment(), QueryTextReceiver {
         fun reload() {
             val items = mutableListOf<Item>()
             // internal
-            items.add(Item(S.getMVersionInternal()))
+            items.add(Item(App.services.versions.getMVersionInternal()))
 
             val presetsInDb = mutableMapOf<String, MVersionDb>()
 
             // db
-            for (mv in S.db.listAllVersions()) {
+            for (mv in App.services.storage.db.listAllVersions()) {
                 items.add(Item(mv))
                 if (mv.preset_name != null) {
                     presetsInDb[mv.preset_name] = mv
@@ -594,7 +593,7 @@ class VersionListFragment : Fragment(), QueryTextReceiver {
 
             val fromItem = snapshot[startPos]
             val toItem = snapshot[endPos]
-            S.db.reorderVersions(fromItem.mv, toItem.mv)
+            App.services.storage.db.reorderVersions(fromItem.mv, toItem.mv)
             AppEvents.emitVersionListReload()
         }
     }

--- a/Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionsActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionsActivity.kt
@@ -18,7 +18,6 @@ import com.google.android.material.tabs.TabLayout
 import java.io.File
 import java.io.IOException
 import yuku.alkitab.base.App
-import yuku.alkitab.base.S
 import yuku.alkitab.base.ac.base.BaseActivity
 import yuku.alkitab.base.events.AppEvents
 import yuku.alkitab.base.model.MVersionDb
@@ -196,7 +195,7 @@ class VersionsActivity : BaseActivity() {
             val reader = YesReaderFactory.createYesReader(localYesFile.absolutePath)
                 ?: throw IOException("Local file $localYesFile is not a valid YES file.")
 
-            var maxOrdering = S.db.versionMaxOrdering
+            var maxOrdering = App.services.storage.db.versionMaxOrdering
             if (maxOrdering == 0) maxOrdering = MVersionDb.DEFAULT_ORDERING_START
 
             val mvDb = MVersionDb().apply {
@@ -209,7 +208,7 @@ class VersionsActivity : BaseActivity() {
                 preset_name = null
             }
 
-            S.db.insertOrUpdateVersionWithActive(mvDb, true)
+            App.services.storage.db.insertOrUpdateVersionWithActive(mvDb, true)
             MVersionDb.clearVersionImplCache()
 
             AppEvents.emitVersionListReload()

--- a/docs/tech-debt-remediation.md
+++ b/docs/tech-debt-remediation.md
@@ -216,12 +216,17 @@ Coroutines and `lifecycleScope` were already on the classpath transitively throu
 
 ---
 
-### REM-24: Refactor S.kt Service Locator — Steps 24a–24d landed 2026-05-12
+### REM-24: Refactor S.kt Service Locator — Steps 24a–24d complete 2026-05-12
 **Addresses:** TD-15  
 **Module:** Cross-cutting (50 files)  
 **BRICE:** B=4 R=2 I=2 C=3 E=5 → **3.2**
 
-**Status:** Steps 24a (interface extraction), 24b (UI dialog removal), 24c (thread-safety fix) and 24d's bootstrap (AppServices container initialized in `App.staticInit()`) shipped on 2026-05-12. The bulk of 24d — migrating the ~50 existing `S.xxx` call sites to depend on `App.services.*` — remains as ongoing incremental work and is not blocking. 24e (Hilt) is still optional/deferred.
+**Status:** Steps 24a (interface extraction), 24b (UI dialog removal), 24c (thread-safety fix), and 24d (AppServices container + caller migration) all complete as of 2026-05-12. ~216 direct `S.xxx` references across 44 files migrated to `App.services.*`. The `S` adapter properties (`S.storage`, `S.versions`, `S.uiDimensions`) and the legacy `@JvmStatic` accessors are retained so any new caller written against `S.foo` keeps compiling; new code should prefer `App.services`. 24e (Hilt) is still optional/deferred.
+
+**24d caller-migration follow-up shipped 2026-05-12:**
+- `App.services` is now initialized eagerly at the static field declaration in `App.java` rather than only inside `staticInit()`. This keeps `App.services.*` non-null for callers that exercise migrated code in tests that deliberately bypass `App.onCreate()` / `App.staticInit()` (e.g. `ProviderTest`, `VerseRendererTest`'s setup). The adapter objects on `S` only touch context/preferences when their methods are invoked, so eager init is safe before `App.context` is set.
+- `AppServices`'s `storage` / `versions` / `uiDimensions` fields are annotated `@JvmField` so Java callers can write `App.services.versions.activeVersion()` (matching Kotlin syntax) instead of `App.services.getVersions().activeVersion()`.
+- One deliberately un-migrated call site remains: the `S.db.listAllVersions().isEmpty()` check inside `IsiActivity.openVersionsDialog`. The rest of that method already uses `App.services.versions`; the single `S.db` line is left for the next person touching that method to migrate, to keep diffs cohesive.
 
 **What shipped on 2026-05-12:**
 - New `yuku.alkitab.base.services` package with `StorageProvider`, `VersionManager`, `UiDimensionsProvider`, and `AppServices` (see `Alkitab/src/main/java/yuku/alkitab/base/services/`).
@@ -724,7 +729,7 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 | REM-12 | ~~Replace DragSortListView~~ ✅ | **3.4** | 2 |
 | REM-14 | ~~Replace material-dialogs~~ ✅ | **3.4** | 2 |
 | REM-18 | Add test coverage | **3.4** | 2 |
-| REM-24 | Refactor S.kt service locator (steps 24a–24d shipped; caller migration ongoing) | **3.2** | 2 |
+| REM-24 | ~~Refactor S.kt service locator (steps 24a–24d complete)~~ ✅ | **3.2** | 2 |
 | REM-08 | ~~Extract split view manager~~ ✅ | **3.2** | 2 |
 | REM-11 | Room migration (Version) | **3.2** | 2 |
 | REM-15 | Introduce coroutines | **3.2** | 3 |


### PR DESCRIPTION
## Summary

Completes REM-24 step 24d: migrates direct `S.xxx` references in production code to the equivalent `App.services.<accessor>.xxx` so callers depend on the narrow service interfaces extracted in [#181](https://github.com/yukuku/androidbible/pull/181) instead of reaching into the `S` service locator.

44 files, ~216 call sites — mostly mechanical search-and-replace per the mapping table in the task spec. Build (`assemblePlainDebug`) and unit tests (`testPlainDebugUnitTest testPlainReleaseUnitTest`) both pass locally.

Commits are organized one-per-subsystem for review (in this order):

1. **`eager-init App.services and @JvmField on AppServices`** — infrastructure prerequisite. Moves `App.services` initialization to the field declaration in `App.java` so tests that bypass `App.staticInit()` (e.g. `ProviderTest`, `VerseRendererTest`'s reflection setup) still see a non-null services container. Adds `@JvmField` to AppServices's `storage`/`versions`/`uiDimensions` so Java callers can write `App.services.versions.foo()` instead of `App.services.getVersions().foo()`.
2. **`migrate small-and-mechanical callers`** — datatransfer, util, actionmode, compose/goto, audio, cp, appwidget (12 files).
3. **`migrate widget/verses/dialog callers`** — UI rendering subsystems (14 files).
4. **`migrate songs and versionmanager callers`** — 5 files.
5. **`migrate sync/* and MVersionDb callers`** — 9 files.
6. **`migrate base/ac and related callers`** — activities + devotion downloader + reading plan manager + version download receiver (12 files).
7. **`migrate IsiActivity callers`** — 1 file, ~24 call sites. One deliberately un-migrated line (`S.db.listAllVersions().isEmpty()` inside `openVersionsDialog`) is left to migrate together with the next change that touches the rest of that method, per the task spec.
8. **`mark step 24d complete in tech-debt-remediation.md`** — strikes through the entry in the summary table and updates the status header.

(If you'd prefer this split into multiple stacked PRs, happy to cherry-pick each commit onto its own branch off develop.)

## Notes / non-obvious choices

- **`yuku.afw.App` clash** — three files (`DailyVerseData.java`, `SongListActivity.java`, `TextAppearancePanel.java`) already import `yuku.afw.App` for `App.context`, so `yuku.alkitab.base.App.services.…` is used as a fully qualified reference instead of adding a clashing single-type import. Surgical; doesn't touch unrelated lines.
- **`S.CalculatedDimensions` type stays on `S`** — per task spec. `NoteActivity.java`, `PatchTextActivity.java`, `DevotionActivity.java` still reference the type, so their `import yuku.alkitab.base.S` is retained while just the `S.applied()` / `S.getDb()` call sites swap to `App.services.*`.
- **Reflection-based tests untouched** — `VerseRendererTest.kt` and `VerseRendererGoldenGen.kt` reach into `S$CalculatedDimensionsHolder` via reflection. They continue to work because `App.services.uiDimensions.applied()` delegates back to `S.applied()` (which reads the same holder field the tests overwrite). The eager-init change in commit 1 is what keeps these tests passing — without it, `App.services` is null at test time and the migrated `VerseRenderer.kt` would NPE.
- **`@JvmField` rationale** — the task spec asserted that `App.services.versions.activeVersion()` works from Java. That requires either `getVersions()` (Java-style) or `@JvmField` (Kotlin field access from Java). I went with `@JvmField` to match the spec's stated idiom; otherwise every Java migration would have read `App.services.getVersions().activeVersion()`.

## Test plan
- [x] `./gradlew assemblePlainDebug` — passes
- [x] `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` — passes (Develocity output trimmed, real test counts unchanged)
- [ ] Smoke-test the app on a device after merge: open a chapter, switch versions, search, browse markers, set a highlight, add a progress mark, look at songs / devotions / reading plan / daily verse widget — covers the migrated subsystems.