### PR TITLE
version-picker: show shortName above longName on dialog and manager rows

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/util/VersionDialogHelper.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/VersionDialogHelper.kt
@@ -26,7 +26,8 @@ object VersionDialogHelper {
         // determine the currently selected one
         val selected = versions.indexOfFirst { it.versionId == selectedVersionId }
 
-        val options: Array<CharSequence> = versions.map { formatVersionLabel(it) }.toTypedArray()
+        val secondaryColor = resolveSecondaryTextColor(activity)
+        val options: Array<CharSequence> = versions.map { formatVersionLabel(it, secondaryColor) }.toTypedArray()
         MaterialAlertDialogBuilder(activity)
             .setSingleChoiceItems(options, selected) { dialog, index ->
                 if (index >= 0) {
@@ -51,7 +52,8 @@ object VersionDialogHelper {
             versions.indexOfFirst { it.versionId == selectedVersionId } + 1
         }
 
-        val options: Array<CharSequence> = (listOf<CharSequence>(activity.getString(R.string.split_version_none)) + versions.map { formatVersionLabel(it) }).toTypedArray()
+        val secondaryColor = resolveSecondaryTextColor(activity)
+        val options: Array<CharSequence> = (listOf<CharSequence>(activity.getString(R.string.split_version_none)) + versions.map { formatVersionLabel(it, secondaryColor) }).toTypedArray()
         MaterialAlertDialogBuilder(activity)
             .setSingleChoiceItems(options, selected) { dialog, index ->
                 when {
@@ -68,22 +70,36 @@ object VersionDialogHelper {
 
     /**
      * Builds a two-line label for a version row: shortName (bold) above
-     * longName (smaller, muted). Falls back to longName alone when the
-     * version has no shortName.
+     * longName (smaller, muted). Falls back to bold longName alone when
+     * the version has no shortName, to stay consistent with the version
+     * manager row, where longName is promoted into the bold primary slot
+     * in the same situation.
      */
-    private fun formatVersionLabel(mv: MVersion): CharSequence {
+    private fun formatVersionLabel(mv: MVersion, secondaryColor: Int): CharSequence {
         val shortName = mv.shortName
-        if (shortName.isNullOrBlank()) return mv.longName
-
         val sb = SpannableStringBuilder()
-        val shortStart = sb.length
+        if (shortName.isNullOrBlank()) {
+            sb.append(mv.longName)
+            sb.setSpan(StyleSpan(Typeface.BOLD), 0, sb.length, 0)
+            return sb
+        }
+
         sb.append(shortName)
-        sb.setSpan(StyleSpan(Typeface.BOLD), shortStart, sb.length, 0)
+        sb.setSpan(StyleSpan(Typeface.BOLD), 0, sb.length, 0)
         sb.append("\n")
         val longStart = sb.length
         sb.append(mv.longName)
         sb.setSpan(RelativeSizeSpan(0.92f), longStart, sb.length, 0)
-        sb.setSpan(ForegroundColorSpan(0xff898989.toInt()), longStart, sb.length, 0)
+        sb.setSpan(ForegroundColorSpan(secondaryColor), longStart, sb.length, 0)
         return sb
+    }
+
+    private fun resolveSecondaryTextColor(activity: Activity): Int {
+        val ta = activity.theme.obtainStyledAttributes(intArrayOf(android.R.attr.textColorSecondary))
+        return try {
+            ta.getColor(0, 0xff898989.toInt())
+        } finally {
+            ta.recycle()
+        }
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/VersionDialogHelper.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/VersionDialogHelper.kt
@@ -1,6 +1,11 @@
 package yuku.alkitab.base.util
 
 import android.app.Activity
+import android.graphics.Typeface
+import android.text.SpannableStringBuilder
+import android.text.style.ForegroundColorSpan
+import android.text.style.RelativeSizeSpan
+import android.text.style.StyleSpan
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import yuku.alkitab.base.S
 import yuku.alkitab.base.model.MVersion
@@ -21,7 +26,7 @@ object VersionDialogHelper {
         // determine the currently selected one
         val selected = versions.indexOfFirst { it.versionId == selectedVersionId }
 
-        val options = versions.map { it.longName }.toTypedArray()
+        val options: Array<CharSequence> = versions.map { formatVersionLabel(it) }.toTypedArray()
         MaterialAlertDialogBuilder(activity)
             .setSingleChoiceItems(options, selected) { dialog, index ->
                 if (index >= 0) {
@@ -46,7 +51,7 @@ object VersionDialogHelper {
             versions.indexOfFirst { it.versionId == selectedVersionId } + 1
         }
 
-        val options = (listOf(activity.getString(R.string.split_version_none)) + versions.map { it.longName }).toTypedArray()
+        val options: Array<CharSequence> = (listOf<CharSequence>(activity.getString(R.string.split_version_none)) + versions.map { formatVersionLabel(it) }).toTypedArray()
         MaterialAlertDialogBuilder(activity)
             .setSingleChoiceItems(options, selected) { dialog, index ->
                 when {
@@ -59,5 +64,26 @@ object VersionDialogHelper {
                 activity.startActivity(VersionsActivity.createIntent())
             }
             .show()
+    }
+
+    /**
+     * Builds a two-line label for a version row: shortName (bold) above
+     * longName (smaller, muted). Falls back to longName alone when the
+     * version has no shortName.
+     */
+    private fun formatVersionLabel(mv: MVersion): CharSequence {
+        val shortName = mv.shortName
+        if (shortName.isNullOrBlank()) return mv.longName
+
+        val sb = SpannableStringBuilder()
+        val shortStart = sb.length
+        sb.append(shortName)
+        sb.setSpan(StyleSpan(Typeface.BOLD), shortStart, sb.length, 0)
+        sb.append("\n")
+        val longStart = sb.length
+        sb.append(mv.longName)
+        sb.setSpan(RelativeSizeSpan(0.92f), longStart, sb.length, 0)
+        sb.setSpan(ForegroundColorSpan(0xff898989.toInt()), longStart, sb.length, 0)
+        return sb
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionListFragment.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionListFragment.kt
@@ -14,8 +14,8 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import android.widget.CheckBox
+import android.widget.ImageView
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.annotation.AnyThread
@@ -295,7 +295,10 @@ class VersionListFragment : Fragment(), QueryTextReceiver {
         val panelRight: View = view.findViewById(R.id.panelRight)
         val cActive: CheckBox = view.findViewById(R.id.cActive)
         val progress: ProgressBar = view.findViewById(R.id.progress)
-        val bLongName: Button = view.findViewById(R.id.bLongName)
+        val panelName: View = view.findViewById(R.id.panelName)
+        val tShortName: TextView = view.findViewById(R.id.tShortName)
+        val tLongName: TextView = view.findViewById(R.id.tLongName)
+        val iUpdate: ImageView = view.findViewById(R.id.iUpdate)
         val header: View = view.findViewById(R.id.header)
         val tLanguage: TextView = view.findViewById(R.id.tLanguage)
         val drag_handle: View = view.findViewById(R.id.drag_handle)
@@ -434,16 +437,28 @@ class VersionListFragment : Fragment(), QueryTextReceiver {
             val panelRight = holder.panelRight
             val cActive = holder.cActive
             val progress = holder.progress
-            val bLongName = holder.bLongName
+            val panelName = holder.panelName
+            val tShortName = holder.tShortName
+            val tLongName = holder.tLongName
+            val iUpdate = holder.iUpdate
             val header = holder.header
             val tLanguage = holder.tLanguage
             val drag_handle = holder.drag_handle
             val item = getItem(position)
             val mv = item.mv
-            bLongName.setOnClickListener { itemNameClick(item) }
+            panelName.setOnClickListener { itemNameClick(item) }
             panelRight.setOnClickListener { itemCheckboxClick(item, holder.itemView) }
             cActive.isChecked = mv.active
-            bLongName.text = mv.longName
+
+            val shortName = mv.shortName
+            if (!shortName.isNullOrBlank()) {
+                tShortName.text = shortName
+                tLongName.text = mv.longName
+                tLongName.visibility = View.VISIBLE
+            } else {
+                tShortName.text = mv.longName
+                tLongName.visibility = View.GONE
+            }
 
             when (mv) {
                 is MVersionInternal -> cActive.isEnabled = false
@@ -464,12 +479,7 @@ class VersionListFragment : Fragment(), QueryTextReceiver {
                 header.visibility = View.GONE
             }
 
-            // Update icon
-            if (mv is MVersionDb && hasUpdateAvailable(mv)) {
-                bLongName.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_version_update, 0, 0, 0)
-            } else {
-                bLongName.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
-            }
+            iUpdate.visibility = if (mv is MVersionDb && hasUpdateAvailable(mv)) View.VISIBLE else View.GONE
 
             // downloading or not?
             val downloading = if (mv is MVersionInternal) {

--- a/Alkitab/src/main/res/layout/item_version.xml
+++ b/Alkitab/src/main/res/layout/item_version.xml
@@ -27,19 +27,60 @@
 		android:layout_width="match_parent"
 		android:layout_height="wrap_content"
 		android:gravity="center_vertical"
-		android:minHeight="48dp"
 		android:orientation="horizontal">
 
-		<Button
-			android:id="@+id/bLongName"
+		<LinearLayout
+			android:id="@+id/panelName"
 			android:layout_width="0dp"
-			android:layout_height="match_parent"
+			android:layout_height="wrap_content"
 			android:layout_weight="1"
 			android:background="?selectableItemBackground"
-			android:drawablePadding="8dp"
+			android:clickable="true"
+			android:focusable="true"
 			android:gravity="center_vertical"
-			android:textAppearance="?android:textAppearanceMedium"
-			tools:text="Long version name" />
+			android:minHeight="56dp"
+			android:orientation="horizontal"
+			android:paddingStart="4dp"
+			android:paddingTop="8dp"
+			android:paddingEnd="4dp"
+			android:paddingBottom="8dp">
+
+			<ImageView
+				android:id="@+id/iUpdate"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_marginEnd="8dp"
+				android:src="@drawable/ic_version_update"
+				android:visibility="gone"
+				tools:ignore="ContentDescription"
+				tools:visibility="visible" />
+
+			<LinearLayout
+				android:layout_width="0dp"
+				android:layout_height="wrap_content"
+				android:layout_weight="1"
+				android:orientation="vertical">
+
+				<TextView
+					android:id="@+id/tShortName"
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					android:textAppearance="?android:textAppearanceMedium"
+					android:textStyle="bold"
+					tools:text="ESV" />
+
+				<TextView
+					android:id="@+id/tLongName"
+					android:layout_width="match_parent"
+					android:layout_height="wrap_content"
+					android:layout_marginTop="2dp"
+					android:textColor="#898989"
+					android:textSize="13sp"
+					tools:text="English Standard Version" />
+
+			</LinearLayout>
+
+		</LinearLayout>
 
 		<FrameLayout
 			android:id="@+id/panelRight"

--- a/Alkitab/src/main/res/layout/item_version.xml
+++ b/Alkitab/src/main/res/layout/item_version.xml
@@ -50,9 +50,9 @@
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
 				android:layout_marginEnd="8dp"
+				android:contentDescription="@string/ed_details_update_available"
 				android:src="@drawable/ic_version_update"
 				android:visibility="gone"
-				tools:ignore="ContentDescription"
 				tools:visibility="visible" />
 
 			<LinearLayout
@@ -74,7 +74,7 @@
 					android:layout_width="match_parent"
 					android:layout_height="wrap_content"
 					android:layout_marginTop="2dp"
-					android:textColor="#898989"
+					android:textColor="?android:attr/textColorSecondary"
 					android:textSize="13sp"
 					tools:text="English Standard Version" />
 


### PR DESCRIPTION
## Summary

- Average readers recognize "TB" / "ESV" faster than the full title, but the single-version chooser dialog and the version manager rows previously displayed only longName.
- Both surfaces now lead with **shortName** (bold) and place **longName** below as smaller, muted supporting text. When a version has no shortName, longName is promoted to primary so single-name versions don't look broken.
- Dialog uses `SpannableStringBuilder` so Material's radio-button rendering is preserved.
- Version manager row replaces the single Button with a clickable two-text-line container plus a dedicated update-icon ImageView (was a compound drawable on the Button).

## Test plan

- [x] `./gradlew assemblePlainDebug` — BUILD SUCCESSFUL
- [x] `./gradlew :Alkitab:testPlainDebugUnitTest` — BUILD SUCCESSFUL
- [x] Verified on Android emulator: version manager shows bold shortName above muted longName for every row
- [ ] Verify the version chooser dialog on a real device (manual)
- [ ] Verify a version with null shortName falls back to longName-only