### PR TITLE
ci: fetch tags before release changelog git log

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -188,6 +188,13 @@ jobs:
           # array) and "release missing tagName" to an empty string, so the
           # `-n` check below correctly takes the first-run branch.
           last_tag=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""' || true)
+          # Fetch tags now (not just at checkout time) so we can resolve a tag
+          # that another CI run may have created after our checkout step ran.
+          # Without this, two PRs merged back-to-back race: the second run's
+          # `gh release list` sees the tag the first run just published, but
+          # the local clone never fetched it, and `git log <tag>..HEAD` fails
+          # with "unknown revision".
+          git fetch --tags --no-recurse-submodules
           {
             echo "## Changes"
             echo


### PR DESCRIPTION
## Summary

Fix a CI race in the `signed-release` job's "Create GitHub Pre-Release" step. The script does:

```bash
last_tag=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""' || true)
# ...
git log "${last_tag}..HEAD" --pretty=format:"- %s (%h)"
```

`gh release list` hits the live GitHub API and sees fresh tags. `git log` reads the local clone, which was pinned at `actions/checkout` time. When two PRs merge back to back, the second run can see a tag the first run published *after* checkout ran, so the local clone doesn't know about it and `git log <tag>..HEAD` fails with:

```
fatal: ambiguous argument 'v21894170..HEAD': unknown revision
```

`fetch-depth: 0` doesn't help — the race is about tags created after checkout. Adding `git fetch --tags --no-recurse-submodules` right before the `git log` call always refreshes the local tag set to whatever `gh release list` just returned.

## Test plan

- [ ] Next merge to `develop` should produce a successful `signed-release` run, with a changelog that walks back to the most recent release tag.
- [ ] Verify that two rapid back-to-back merges to `develop` (whenever they happen organically) both succeed.

## Background

- Failure on this PR's parent merge: https://github.com/yukuku/androidbible/actions/runs/25735897928 — created tag `v21894170` was published by PR #184's run ~30 seconds before PR #182's release step queried it; PR #182's checkout never had that tag.
- A similar earlier failure on PR #180's run looks like the same root cause.