### PR TITLE
room: add load test for REM-10/REM-11 migrations at 50k markers

### DIFF
--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -213,20 +213,12 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
-            // The REM-10/REM-11 migration load test in MarkerDataMigrationLoadTest
-            // holds 50,000 × 2 KB marker captions live during the bulk Room insert
-            // (≈100 MB just for caption strings, plus per-entity overhead).
-            // Default 512 MB unit-test heap OOMs; 2 GB leaves comfortable headroom.
+            // MarkerDataMigrationLoadTest holds 50,000 × 2 KB marker captions
+            // live during the bulk Room insert (~100 MB of captions plus
+            // per-entity overhead). The default 512 MB unit-test heap OOMs.
             //
-            // CI memory math (ubuntu-latest, 7 GB free-tier runner):
-            //   Gradle daemon -Xmx4G + one 2 GB test fork = ~6 GB peak,
-            //   below the 7 GB cap. The two unit-test tasks
-            //   (testPlainDebugUnitTest + testPlainReleaseUnitTest) run
-            //   sequentially because they are on the same project and project
-            //   parallelism is not enabled, so they never both hold 2 GB.
-            // maxParallelForks is pinned to 1 (Gradle's default) explicitly so
-            // a later change can't silently spawn a second 2 GB JVM inside one
-            // test task and tip CI over the host memory limit.
+            // maxParallelForks is pinned to 1 (Gradle's default) so a future
+            // change can't silently spawn a second 2 GB JVM in one test task.
             all {
                 it.maxHeapSize = "2g"
                 it.maxParallelForks = 1

--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -217,7 +217,20 @@ android {
             // holds 50,000 × 2 KB marker captions live during the bulk Room insert
             // (≈100 MB just for caption strings, plus per-entity overhead).
             // Default 512 MB unit-test heap OOMs; 2 GB leaves comfortable headroom.
-            all { it.maxHeapSize = "2g" }
+            //
+            // CI memory math (ubuntu-latest, 7 GB free-tier runner):
+            //   Gradle daemon -Xmx4G + one 2 GB test fork = ~6 GB peak,
+            //   below the 7 GB cap. The two unit-test tasks
+            //   (testPlainDebugUnitTest + testPlainReleaseUnitTest) run
+            //   sequentially because they are on the same project and project
+            //   parallelism is not enabled, so they never both hold 2 GB.
+            // maxParallelForks is pinned to 1 (Gradle's default) explicitly so
+            // a later change can't silently spawn a second 2 GB JVM inside one
+            // test task and tip CI over the host memory limit.
+            all {
+                it.maxHeapSize = "2g"
+                it.maxParallelForks = 1
+            }
         }
     }
 

--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -8,6 +8,8 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import java.time.Instant
 import javax.inject.Inject
 
@@ -222,6 +224,25 @@ android {
             all {
                 it.maxHeapSize = "2g"
                 it.maxParallelForks = 1
+                // Diagnostic: surface every test's stdout / stderr and full
+                // exception detail in the Gradle log so CI failures are
+                // debuggable from the workflow output alone (the HTML test
+                // report and per-test XML aren't accessible without repo
+                // admin rights).
+                it.testLogging {
+                    events(
+                        TestLogEvent.FAILED,
+                        TestLogEvent.SKIPPED,
+                        TestLogEvent.PASSED,
+                        TestLogEvent.STANDARD_OUT,
+                        TestLogEvent.STANDARD_ERROR,
+                    )
+                    exceptionFormat = TestExceptionFormat.FULL
+                    showCauses = true
+                    showExceptions = true
+                    showStackTraces = true
+                    showStandardStreams = true
+                }
             }
         }
     }

--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -213,6 +213,11 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
+            // The REM-10/REM-11 migration load test in MarkerDataMigrationLoadTest
+            // holds 50,000 × 2 KB marker captions live during the bulk Room insert
+            // (≈100 MB just for caption strings, plus per-entity overhead).
+            // Default 512 MB unit-test heap OOMs; 2 GB leaves comfortable headroom.
+            all { it.maxHeapSize = "2g" }
         }
     }
 

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/MarkerDataMigrationLoadTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/MarkerDataMigrationLoadTest.kt
@@ -2,6 +2,7 @@ package yuku.alkitab.base.storage.room
 
 import android.app.Application
 import android.content.ContentValues
+import android.preference.PreferenceManager
 import androidx.room.Room
 import java.util.Locale
 import org.junit.After
@@ -13,6 +14,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import yuku.afw.storage.Preferences
 import yuku.alkitab.base.storage.Db
 import yuku.alkitab.base.storage.InternalDbHelper
 
@@ -45,6 +47,14 @@ class MarkerDataMigrationLoadTest {
     fun setUp() {
         val app = RuntimeEnvironment.getApplication()
         yuku.afw.App.context = app
+        // Both migrations gate on a one-shot SharedPreferences flag
+        // (`*_data_migration_v1_done`). Robolectric reuses SharedPreferences
+        // state across test methods in the same JVM, so a prior test
+        // (e.g. MarkerDataMigrationTest) leaves the flag set — the migration
+        // would early-return and Room would stay empty. Clear prefs and the
+        // Preferences static cache so this test starts from a clean slate.
+        PreferenceManager.getDefaultSharedPreferences(app).edit().clear().commit()
+        Preferences.invalidate()
         legacy = InternalDbHelper(app)
         room = Room.inMemoryDatabaseBuilder(app, AppDatabase::class.java)
             .allowMainThreadQueries()

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/MarkerDataMigrationLoadTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/MarkerDataMigrationLoadTest.kt
@@ -17,41 +17,23 @@ import yuku.alkitab.base.storage.Db
 import yuku.alkitab.base.storage.InternalDbHelper
 
 /**
- * Load test for the REM-10 / REM-11 migrations. Simulates a 2025-era app
- * upgrading to the current build: the legacy `AlkitabDb` already has the
- * `Version` / `Marker` / `Label` / `Marker_Label` tables populated, and the
- * new `AlkitabRoomDb` does not exist yet. On first launch Room creates the
- * fresh database at the latest schema version, then
- * [VersionDataMigration] and [MarkerDataMigration] each do a one-time copy.
+ * Regression-guard load test for REM-10 / REM-11. Seeds the legacy SQLite
+ * tables with 100 versions, 100 labels, 50,000 markers (each carrying a
+ * 2 KB caption) and 60,000 marker_label associations, runs the one-time
+ * migrations, and asserts every row round-trips bit-for-bit.
  *
- * The harness reuses exactly the same code path the real upgrade hits — there
- * is no Android-version-specific behaviour in either migration, so an
- * in-Robolectric run is a faithful proxy for what a v1 device sees.
+ * Every field on every entity is a pure function of the row's integer
+ * index `i` (or `j` for associations); seed and verify both call the same
+ * `*Pattern(i)` helpers, so a regression in the migration is the only
+ * thing that can make them disagree.
  *
- * Dataset:
- *  - 100 versions
- *  - 100 labels
- *  - 50,000 markers, each with a 2,048-byte caption (≈100 MB of caption
- *    bytes — exercises the read-everything-into-an-ArrayList shape of
- *    [MarkerDataMigration.readLegacyMarkers] under memory pressure)
- *  - 60,000 marker_label associations
- *
- * Verifiable pattern: every field on every entity is a pure function of the
- * row's integer index `i` (or `j` for associations). The seed and the
- * verifier both call the same `*Pattern(i)` helpers, so a regression in the
- * migration is the only thing that can make verification disagree with the
- * seed.
- *
- * Association layout: for `j` in `0..49,999` the j-th association links
- * marker `j` to label `j % 100`, so every marker has at least one label and
- * every label has 500 markers from this first pass. For `j` in
- * `50,000..59,999` the j-th association links marker `j - 50,000` to label
- * `(j + 31) % 100`. Because `gcd(31, 100) = 1` and `31 mod 100 != 0`, the
- * offset always lands on a *different* label than the first-pass label for
- * that marker — so markers 0..9,999 each end up with exactly two distinct
- * labels and markers 10,000..49,999 each end up with one. The test asserts
- * this invariant on marker 0 (two labels) and marker 30,000 (one label) to
- * prove the join survives the migration.
+ * Marker_label layout: for `j in 0..49,999` the j-th association links
+ * marker `j` to label `j % 100`; for `j in 50,000..59,999` it links marker
+ * `j - 50,000` to label `(j + 31) % 100`. `gcd(31, 100) = 1` and `31 mod 100
+ * != 0`, so the offset is guaranteed to land on a different label than the
+ * first-pass label for the same marker — markers 0..9,999 end up with
+ * exactly two distinct labels each, markers 10,000..49,999 with one. The
+ * test asserts this on a handful of representative markers.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class, sdk = [34])
@@ -77,7 +59,6 @@ class MarkerDataMigrationLoadTest {
 
     @Test
     fun `migrating 100 versions + 50000 markers + 100 labels + 60000 marker_labels round-trips every field`() {
-        // -- 1. Seed the legacy DB to simulate a 2025-era install --------
         val seedStart = System.currentTimeMillis()
         seedVersions()
         seedLabels()
@@ -88,26 +69,23 @@ class MarkerDataMigrationLoadTest {
             "$N_VERSIONS versions, $N_LABELS labels, $N_MARKERS markers " +
             "(${CAPTION_BYTES} bytes each), $N_MARKER_LABELS marker_labels")
 
-        // -- 2. Run the migrations (this is what first-launch does) ------
         val migrateStart = System.currentTimeMillis()
         VersionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
         MarkerDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
         val migrateMs = System.currentTimeMillis() - migrateStart
         log("ran VersionDataMigration + MarkerDataMigration in ${migrateMs}ms")
 
-        // -- 3. Counts match exactly -------------------------------------
         assertEquals("version count", N_VERSIONS, room.versionDao().count())
         assertEquals("label count", N_LABELS, room.labelDao().count())
         assertEquals("marker count", N_MARKERS, room.markerDao().count())
         assertEquals("marker_label count", N_MARKER_LABELS, room.markerLabelDao().count())
 
-        // -- 4. Sampled deep field-by-field round-trip -------------------
         verifyVersionsByPattern()
         verifyLabelsByPattern()
         verifyMarkersByPattern()
         verifyMarkerLabelsByPattern()
 
-        // -- 5. Idempotency: re-running the migration is a no-op --------
+        // Re-running the migrations must be a no-op (idempotency).
         VersionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
         MarkerDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
         assertEquals("version count after re-run", N_VERSIONS, room.versionDao().count())
@@ -122,12 +100,8 @@ class MarkerDataMigrationLoadTest {
         log("verification passed; total wall time ${System.currentTimeMillis() - seedStart}ms")
     }
 
-    // ---- Seed helpers --------------------------------------------------
-    //
-    // All four seed helpers wrap their inserts in a single legacy SQLite
-    // transaction. SQLite's default per-statement journal flush would make
-    // 50,000 individual inserts take O(minutes); batching them keeps the
-    // seed phase to a few seconds.
+    // Each seed helper wraps its inserts in one SQLite transaction —
+    // without that, 50,000 individual inserts take O(minutes).
 
     private fun seedVersions() {
         val db = legacy.writableDatabase
@@ -212,12 +186,10 @@ class MarkerDataMigrationLoadTest {
         }
     }
 
-    // ---- Verify helpers ------------------------------------------------
-
     private fun verifyVersionsByPattern() {
-        // versionDao().listAll() returns rows ordered by `ordering ASC`,
-        // and versionOrdering(i) = ORDERING_BASE + i is strictly increasing
-        // in i, so position-in-list maps directly to seed index.
+        // listAll() returns rows ordered by `ordering ASC`, and
+        // versionOrdering(i) is strictly increasing in i, so list position
+        // maps directly to seed index.
         val all = room.versionDao().listAll()
         assertEquals(N_VERSIONS, all.size)
         for (i in versionSampleIndices()) {
@@ -254,8 +226,8 @@ class MarkerDataMigrationLoadTest {
             row!!
             assertEquals("marker $i ari", markerAri(i), row.ari)
             assertEquals("marker $i kind", markerKind(i), row.kind)
-            // Caption length-then-content lets a length mismatch fail fast
-            // instead of dumping the full 2KB diff on assertion failure.
+            // Length-then-content so a length mismatch doesn't dump the
+            // full 2 KB diff into the JUnit failure output.
             assertEquals(
                 "marker $i caption length",
                 CAPTION_BYTES,
@@ -278,10 +250,6 @@ class MarkerDataMigrationLoadTest {
             assertEquals("ml $j label_gid", mlLabelGid(j), row.label_gid)
         }
 
-        // The "first 10,000 markers have 2 labels, the rest have 1" invariant
-        // is what makes the marker_label sampling above non-trivial: if Room
-        // miscounted or deduped silently, these joins would return the wrong
-        // size.
         assertEquals(
             "marker 0 should appear in exactly 2 marker_label rows",
             2,
@@ -308,19 +276,13 @@ class MarkerDataMigrationLoadTest {
             room.markerLabelDao().listByMarkerGid(markerGid(49_999)).size,
         )
 
-        // Two-label markers must have two *distinct* labels (the +31 offset
-        // is the whole point of the dataset layout).
+        // The +31 offset must produce distinct labels (see class KDoc).
         val twoLabels = room.markerLabelDao()
             .listByMarkerGid(markerGid(0))
             .map { it.label_gid }
             .toSet()
         assertEquals("marker 0's two label_gids must be distinct", 2, twoLabels.size)
     }
-
-    // ---- Sample-index sets --------------------------------------------
-    //
-    // First/last/middle plus a handful of "random-looking" indices to
-    // catch off-by-one and stride bugs without iterating the full 50K.
 
     private fun versionSampleIndices() =
         listOf(0, 1, N_VERSIONS / 2, N_VERSIONS - 1, 7, 42, 73, 99)
@@ -341,17 +303,13 @@ class MarkerDataMigrationLoadTest {
 
     private fun mlSampleIndices() = listOf(
         0, 1, 2,
-        N_MARKERS - 1,         // last "one label per marker" association
-        N_MARKERS,             // first "second label" association
+        N_MARKERS - 1,
+        N_MARKERS, // first second-label association
         N_MARKERS + 5_000,
         N_MARKER_LABELS - 1,
         N_MARKER_LABELS / 2,
     )
 
-    // ---- Pattern functions (single source of truth: seed AND verify
-    //      derive every field from these, so they cannot disagree) -----
-
-    // Version pattern ---------------------------------------------------
     private fun versionFilename(i: Int) = fmt("/data/version-%03d.yes", i)
     private fun versionPresetName(i: Int): String? =
         if (i % 7 == 0) null else fmt("preset-%03d", i)
@@ -366,26 +324,24 @@ class MarkerDataMigrationLoadTest {
     private fun versionActive(i: Int) = i % 2
     private fun versionOrdering(i: Int) = ORDERING_BASE + i
 
-    // Label pattern -----------------------------------------------------
     private fun labelGid(i: Int) = fmt("L%05d", i)
     private fun labelTitle(i: Int) = fmt("Label %d", i)
     private fun labelOrdering(i: Int) = i + 1
     private fun labelBgColor(i: Int): String? =
         if (i % 4 == 0) null else fmt("#%06x", i * 0x10101 and 0xffffff)
 
-    // Marker pattern ----------------------------------------------------
     private fun markerGid(i: Int) = fmt("M%08d", i)
     private fun markerAri(i: Int): Int {
-        // Spread across books 0..65, chapters 1..100, verses 1..50 — every
-        // ARI is a distinct, deterministic int. Values don't need to point
-        // at real Bible verses for the migration test.
+        // Books 0..65, chapters 1..100, verses 1..50 — a distinct,
+        // deterministic int per i, not constrained to point at a real
+        // verse.
         val book = i % 66
         val chapter = 1 + (i / 66) % 100
         val verse = 1 + (i / 6_600) % 50
         return (book shl 16) or (chapter shl 8) or verse
     }
 
-    private fun markerKind(i: Int) = 1 + (i % 3) // 1 = bookmark, 2 = note, 3 = highlight
+    private fun markerKind(i: Int) = 1 + (i % 3) // 1=bookmark, 2=note, 3=highlight
     private fun markerCaption(i: Int): String {
         val header = fmt("M%08d|", i)
         val footer = fmt("|END%08d", i)
@@ -398,19 +354,9 @@ class MarkerDataMigrationLoadTest {
     private fun markerCreateTime(i: Int) = 1_700_000_000 + i
     private fun markerModifyTime(i: Int) = 1_700_000_000 + i * 2
 
-    // Marker_Label pattern ---------------------------------------------
     private fun mlGid(j: Int) = fmt("ML%08d", j)
     private fun mlMarkerGid(j: Int) = markerGid(j % N_MARKERS)
     private fun mlLabelGid(j: Int): String {
-        // First pass: j in 0..N_MARKERS-1 → label = j % N_LABELS. Every
-        // marker is associated with its index-mod-100 label.
-        //
-        // Second pass: j in N_MARKERS..N_MARKER_LABELS-1 → label =
-        // (j + 31) % N_LABELS. The +31 offset is coprime to 100 and
-        // non-zero mod 100, so the second-pass label is guaranteed
-        // distinct from the first-pass label for the same marker. This
-        // gives markers 0..9,999 two distinct labels each, exercising the
-        // many-to-many junction.
         val labelIdx = if (j < N_MARKERS) j % N_LABELS else (j + 31) % N_LABELS
         return labelGid(labelIdx)
     }
@@ -427,17 +373,11 @@ class MarkerDataMigrationLoadTest {
         const val N_LABELS = 100
         const val N_MARKERS = 50_000
         const val N_MARKER_LABELS = 60_000
-
-        // Each marker caption is exactly this many UTF-16 code units. With
-        // the legacy SQLite schema's `caption text` column the bytes-on-disk
-        // value depends on encoding, but the round-trip we care about is
-        // String → ContentValues → SQLite → cursor.getString() →
-        // MarkerEntity.caption being exactly the same String we put in.
         const val CAPTION_BYTES = 2_048
 
-        // Versions are ordered by `ordering ASC` after migration; keeping
-        // the base high makes the test resilient to a future change that
-        // pre-inserts a few rows (e.g. presets) ahead of the seeded set.
+        // Versions are ordered by `ordering ASC` after migration; the
+        // high base keeps the test resilient to a future change that
+        // pre-inserts rows ahead of the seeded set.
         const val ORDERING_BASE = 100
     }
 }

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/MarkerDataMigrationLoadTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/MarkerDataMigrationLoadTest.kt
@@ -1,0 +1,443 @@
+package yuku.alkitab.base.storage.room
+
+import android.app.Application
+import android.content.ContentValues
+import androidx.room.Room
+import java.util.Locale
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import yuku.alkitab.base.storage.Db
+import yuku.alkitab.base.storage.InternalDbHelper
+
+/**
+ * Load test for the REM-10 / REM-11 migrations. Simulates a 2025-era app
+ * upgrading to the current build: the legacy `AlkitabDb` already has the
+ * `Version` / `Marker` / `Label` / `Marker_Label` tables populated, and the
+ * new `AlkitabRoomDb` does not exist yet. On first launch Room creates the
+ * fresh database at the latest schema version, then
+ * [VersionDataMigration] and [MarkerDataMigration] each do a one-time copy.
+ *
+ * The harness reuses exactly the same code path the real upgrade hits — there
+ * is no Android-version-specific behaviour in either migration, so an
+ * in-Robolectric run is a faithful proxy for what a v1 device sees.
+ *
+ * Dataset:
+ *  - 100 versions
+ *  - 100 labels
+ *  - 50,000 markers, each with a 2,048-byte caption (≈100 MB of caption
+ *    bytes — exercises the read-everything-into-an-ArrayList shape of
+ *    [MarkerDataMigration.readLegacyMarkers] under memory pressure)
+ *  - 60,000 marker_label associations
+ *
+ * Verifiable pattern: every field on every entity is a pure function of the
+ * row's integer index `i` (or `j` for associations). The seed and the
+ * verifier both call the same `*Pattern(i)` helpers, so a regression in the
+ * migration is the only thing that can make verification disagree with the
+ * seed.
+ *
+ * Association layout: for `j` in `0..49,999` the j-th association links
+ * marker `j` to label `j % 100`, so every marker has at least one label and
+ * every label has 500 markers from this first pass. For `j` in
+ * `50,000..59,999` the j-th association links marker `j - 50,000` to label
+ * `(j + 31) % 100`. Because `gcd(31, 100) = 1` and `31 mod 100 != 0`, the
+ * offset always lands on a *different* label than the first-pass label for
+ * that marker — so markers 0..9,999 each end up with exactly two distinct
+ * labels and markers 10,000..49,999 each end up with one. The test asserts
+ * this invariant on marker 0 (two labels) and marker 30,000 (one label) to
+ * prove the join survives the migration.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class MarkerDataMigrationLoadTest {
+    private lateinit var legacy: InternalDbHelper
+    private lateinit var room: AppDatabase
+
+    @Before
+    fun setUp() {
+        val app = RuntimeEnvironment.getApplication()
+        yuku.afw.App.context = app
+        legacy = InternalDbHelper(app)
+        room = Room.inMemoryDatabaseBuilder(app, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        room.close()
+        legacy.close()
+    }
+
+    @Test
+    fun `migrating 100 versions + 50000 markers + 100 labels + 60000 marker_labels round-trips every field`() {
+        // -- 1. Seed the legacy DB to simulate a 2025-era install --------
+        val seedStart = System.currentTimeMillis()
+        seedVersions()
+        seedLabels()
+        seedMarkers()
+        seedMarkerLabels()
+        val seedMs = System.currentTimeMillis() - seedStart
+        log("seeded legacy DB in ${seedMs}ms — " +
+            "$N_VERSIONS versions, $N_LABELS labels, $N_MARKERS markers " +
+            "(${CAPTION_BYTES} bytes each), $N_MARKER_LABELS marker_labels")
+
+        // -- 2. Run the migrations (this is what first-launch does) ------
+        val migrateStart = System.currentTimeMillis()
+        VersionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        MarkerDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        val migrateMs = System.currentTimeMillis() - migrateStart
+        log("ran VersionDataMigration + MarkerDataMigration in ${migrateMs}ms")
+
+        // -- 3. Counts match exactly -------------------------------------
+        assertEquals("version count", N_VERSIONS, room.versionDao().count())
+        assertEquals("label count", N_LABELS, room.labelDao().count())
+        assertEquals("marker count", N_MARKERS, room.markerDao().count())
+        assertEquals("marker_label count", N_MARKER_LABELS, room.markerLabelDao().count())
+
+        // -- 4. Sampled deep field-by-field round-trip -------------------
+        verifyVersionsByPattern()
+        verifyLabelsByPattern()
+        verifyMarkersByPattern()
+        verifyMarkerLabelsByPattern()
+
+        // -- 5. Idempotency: re-running the migration is a no-op --------
+        VersionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        MarkerDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertEquals("version count after re-run", N_VERSIONS, room.versionDao().count())
+        assertEquals("label count after re-run", N_LABELS, room.labelDao().count())
+        assertEquals("marker count after re-run", N_MARKERS, room.markerDao().count())
+        assertEquals(
+            "marker_label count after re-run",
+            N_MARKER_LABELS,
+            room.markerLabelDao().count(),
+        )
+
+        log("verification passed; total wall time ${System.currentTimeMillis() - seedStart}ms")
+    }
+
+    // ---- Seed helpers --------------------------------------------------
+    //
+    // All four seed helpers wrap their inserts in a single legacy SQLite
+    // transaction. SQLite's default per-statement journal flush would make
+    // 50,000 individual inserts take O(minutes); batching them keeps the
+    // seed phase to a few seconds.
+
+    private fun seedVersions() {
+        val db = legacy.writableDatabase
+        db.beginTransaction()
+        try {
+            val cv = ContentValues()
+            for (i in 0 until N_VERSIONS) {
+                cv.clear()
+                cv.put(Db.Version.locale, versionLocale(i))
+                cv.put(Db.Version.shortName, versionShortName(i))
+                cv.put(Db.Version.longName, versionLongName(i))
+                cv.put(Db.Version.description, versionDescription(i))
+                cv.put(Db.Version.filename, versionFilename(i))
+                cv.put(Db.Version.preset_name, versionPresetName(i))
+                cv.put(Db.Version.modifyTime, versionModifyTime(i))
+                cv.put(Db.Version.active, versionActive(i))
+                cv.put(Db.Version.ordering, versionOrdering(i))
+                db.insert(Db.TABLE_Version, null, cv)
+            }
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+    }
+
+    private fun seedLabels() {
+        val db = legacy.writableDatabase
+        db.beginTransaction()
+        try {
+            val cv = ContentValues()
+            for (i in 0 until N_LABELS) {
+                cv.clear()
+                cv.put(Db.Label.gid, labelGid(i))
+                cv.put(Db.Label.title, labelTitle(i))
+                cv.put(Db.Label.ordering, labelOrdering(i))
+                cv.put(Db.Label.backgroundColor, labelBgColor(i))
+                db.insert(Db.TABLE_Label, null, cv)
+            }
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+    }
+
+    private fun seedMarkers() {
+        val db = legacy.writableDatabase
+        db.beginTransaction()
+        try {
+            val cv = ContentValues()
+            for (i in 0 until N_MARKERS) {
+                cv.clear()
+                cv.put(Db.Marker.gid, markerGid(i))
+                cv.put(Db.Marker.ari, markerAri(i))
+                cv.put(Db.Marker.kind, markerKind(i))
+                cv.put(Db.Marker.caption, markerCaption(i))
+                cv.put(Db.Marker.verseCount, markerVerseCount(i))
+                cv.put(Db.Marker.createTime, markerCreateTime(i))
+                cv.put(Db.Marker.modifyTime, markerModifyTime(i))
+                db.insert(Db.TABLE_Marker, null, cv)
+            }
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+    }
+
+    private fun seedMarkerLabels() {
+        val db = legacy.writableDatabase
+        db.beginTransaction()
+        try {
+            val cv = ContentValues()
+            for (j in 0 until N_MARKER_LABELS) {
+                cv.clear()
+                cv.put(Db.Marker_Label.gid, mlGid(j))
+                cv.put(Db.Marker_Label.marker_gid, mlMarkerGid(j))
+                cv.put(Db.Marker_Label.label_gid, mlLabelGid(j))
+                db.insert(Db.TABLE_Marker_Label, null, cv)
+            }
+            db.setTransactionSuccessful()
+        } finally {
+            db.endTransaction()
+        }
+    }
+
+    // ---- Verify helpers ------------------------------------------------
+
+    private fun verifyVersionsByPattern() {
+        // versionDao().listAll() returns rows ordered by `ordering ASC`,
+        // and versionOrdering(i) = ORDERING_BASE + i is strictly increasing
+        // in i, so position-in-list maps directly to seed index.
+        val all = room.versionDao().listAll()
+        assertEquals(N_VERSIONS, all.size)
+        for (i in versionSampleIndices()) {
+            val row = all[i]
+            assertEquals("version $i filename", versionFilename(i), row.filename)
+            assertEquals("version $i preset_name", versionPresetName(i), row.preset_name)
+            assertEquals("version $i locale", versionLocale(i), row.locale)
+            assertEquals("version $i shortName", versionShortName(i), row.shortName)
+            assertEquals("version $i longName", versionLongName(i), row.longName)
+            assertEquals("version $i description", versionDescription(i), row.description)
+            assertEquals("version $i modifyTime", versionModifyTime(i), row.modifyTime)
+            assertEquals("version $i active", versionActive(i), row.active)
+            assertEquals("version $i ordering", versionOrdering(i), row.ordering)
+        }
+    }
+
+    private fun verifyLabelsByPattern() {
+        val byGid = room.labelDao().listAll().associateBy { it.gid }
+        assertEquals(N_LABELS, byGid.size)
+        for (i in labelSampleIndices()) {
+            val gid = labelGid(i)
+            val row = byGid[gid] ?: error("label gid $gid missing from Room after migration")
+            assertEquals("label $i title", labelTitle(i), row.title)
+            assertEquals("label $i ordering", labelOrdering(i), row.ordering)
+            assertEquals("label $i backgroundColor", labelBgColor(i), row.backgroundColor)
+        }
+    }
+
+    private fun verifyMarkersByPattern() {
+        for (i in markerSampleIndices()) {
+            val gid = markerGid(i)
+            val row = room.markerDao().findByGid(gid)
+            assertNotNull("marker gid $gid missing from Room after migration", row)
+            row!!
+            assertEquals("marker $i ari", markerAri(i), row.ari)
+            assertEquals("marker $i kind", markerKind(i), row.kind)
+            // Caption length-then-content lets a length mismatch fail fast
+            // instead of dumping the full 2KB diff on assertion failure.
+            assertEquals(
+                "marker $i caption length",
+                CAPTION_BYTES,
+                row.caption!!.length,
+            )
+            assertEquals("marker $i caption", markerCaption(i), row.caption)
+            assertEquals("marker $i verseCount", markerVerseCount(i), row.verseCount)
+            assertEquals("marker $i createTime", markerCreateTime(i), row.createTime)
+            assertEquals("marker $i modifyTime", markerModifyTime(i), row.modifyTime)
+        }
+    }
+
+    private fun verifyMarkerLabelsByPattern() {
+        for (j in mlSampleIndices()) {
+            val gid = mlGid(j)
+            val row = room.markerLabelDao().findByGid(gid)
+            assertNotNull("marker_label gid $gid missing from Room after migration", row)
+            row!!
+            assertEquals("ml $j marker_gid", mlMarkerGid(j), row.marker_gid)
+            assertEquals("ml $j label_gid", mlLabelGid(j), row.label_gid)
+        }
+
+        // The "first 10,000 markers have 2 labels, the rest have 1" invariant
+        // is what makes the marker_label sampling above non-trivial: if Room
+        // miscounted or deduped silently, these joins would return the wrong
+        // size.
+        assertEquals(
+            "marker 0 should appear in exactly 2 marker_label rows",
+            2,
+            room.markerLabelDao().listByMarkerGid(markerGid(0)).size,
+        )
+        assertEquals(
+            "marker 9,999 should appear in exactly 2 marker_label rows",
+            2,
+            room.markerLabelDao().listByMarkerGid(markerGid(9_999)).size,
+        )
+        assertEquals(
+            "marker 10,000 should appear in exactly 1 marker_label row",
+            1,
+            room.markerLabelDao().listByMarkerGid(markerGid(10_000)).size,
+        )
+        assertEquals(
+            "marker 30,000 should appear in exactly 1 marker_label row",
+            1,
+            room.markerLabelDao().listByMarkerGid(markerGid(30_000)).size,
+        )
+        assertEquals(
+            "marker 49,999 should appear in exactly 1 marker_label row",
+            1,
+            room.markerLabelDao().listByMarkerGid(markerGid(49_999)).size,
+        )
+
+        // Two-label markers must have two *distinct* labels (the +31 offset
+        // is the whole point of the dataset layout).
+        val twoLabels = room.markerLabelDao()
+            .listByMarkerGid(markerGid(0))
+            .map { it.label_gid }
+            .toSet()
+        assertEquals("marker 0's two label_gids must be distinct", 2, twoLabels.size)
+    }
+
+    // ---- Sample-index sets --------------------------------------------
+    //
+    // First/last/middle plus a handful of "random-looking" indices to
+    // catch off-by-one and stride bugs without iterating the full 50K.
+
+    private fun versionSampleIndices() =
+        listOf(0, 1, N_VERSIONS / 2, N_VERSIONS - 1, 7, 42, 73, 99)
+
+    private fun labelSampleIndices() =
+        listOf(0, 1, N_LABELS / 2, N_LABELS - 1, 7, 31, 88)
+
+    private fun markerSampleIndices() = listOf(
+        0, 1, 2,
+        1_234,
+        N_MARKERS / 4,
+        N_MARKERS / 2,
+        N_MARKERS * 3 / 4,
+        25_000,
+        33_333,
+        N_MARKERS - 1,
+    )
+
+    private fun mlSampleIndices() = listOf(
+        0, 1, 2,
+        N_MARKERS - 1,         // last "one label per marker" association
+        N_MARKERS,             // first "second label" association
+        N_MARKERS + 5_000,
+        N_MARKER_LABELS - 1,
+        N_MARKER_LABELS / 2,
+    )
+
+    // ---- Pattern functions (single source of truth: seed AND verify
+    //      derive every field from these, so they cannot disagree) -----
+
+    // Version pattern ---------------------------------------------------
+    private fun versionFilename(i: Int) = fmt("/data/version-%03d.yes", i)
+    private fun versionPresetName(i: Int): String? =
+        if (i % 7 == 0) null else fmt("preset-%03d", i)
+
+    private fun versionLocale(i: Int): String? =
+        if (i % 11 == 0) null else fmt("en-%d", i % 10)
+
+    private fun versionShortName(i: Int) = fmt("V%03d", i)
+    private fun versionLongName(i: Int) = fmt("Version Long Name %03d", i)
+    private fun versionDescription(i: Int) = fmt("Description for version %03d", i)
+    private fun versionModifyTime(i: Int) = 1_700_000_000 + i
+    private fun versionActive(i: Int) = i % 2
+    private fun versionOrdering(i: Int) = ORDERING_BASE + i
+
+    // Label pattern -----------------------------------------------------
+    private fun labelGid(i: Int) = fmt("L%05d", i)
+    private fun labelTitle(i: Int) = fmt("Label %d", i)
+    private fun labelOrdering(i: Int) = i + 1
+    private fun labelBgColor(i: Int): String? =
+        if (i % 4 == 0) null else fmt("#%06x", i * 0x10101 and 0xffffff)
+
+    // Marker pattern ----------------------------------------------------
+    private fun markerGid(i: Int) = fmt("M%08d", i)
+    private fun markerAri(i: Int): Int {
+        // Spread across books 0..65, chapters 1..100, verses 1..50 — every
+        // ARI is a distinct, deterministic int. Values don't need to point
+        // at real Bible verses for the migration test.
+        val book = i % 66
+        val chapter = 1 + (i / 66) % 100
+        val verse = 1 + (i / 6_600) % 50
+        return (book shl 16) or (chapter shl 8) or verse
+    }
+
+    private fun markerKind(i: Int) = 1 + (i % 3) // 1 = bookmark, 2 = note, 3 = highlight
+    private fun markerCaption(i: Int): String {
+        val header = fmt("M%08d|", i)
+        val footer = fmt("|END%08d", i)
+        val filler = "ABCDEFGHIJ"[i % 10].toString()
+        val midLength = CAPTION_BYTES - header.length - footer.length
+        return header + filler.repeat(midLength) + footer
+    }
+
+    private fun markerVerseCount(i: Int) = 1 + (i % 5)
+    private fun markerCreateTime(i: Int) = 1_700_000_000 + i
+    private fun markerModifyTime(i: Int) = 1_700_000_000 + i * 2
+
+    // Marker_Label pattern ---------------------------------------------
+    private fun mlGid(j: Int) = fmt("ML%08d", j)
+    private fun mlMarkerGid(j: Int) = markerGid(j % N_MARKERS)
+    private fun mlLabelGid(j: Int): String {
+        // First pass: j in 0..N_MARKERS-1 → label = j % N_LABELS. Every
+        // marker is associated with its index-mod-100 label.
+        //
+        // Second pass: j in N_MARKERS..N_MARKER_LABELS-1 → label =
+        // (j + 31) % N_LABELS. The +31 offset is coprime to 100 and
+        // non-zero mod 100, so the second-pass label is guaranteed
+        // distinct from the first-pass label for the same marker. This
+        // gives markers 0..9,999 two distinct labels each, exercising the
+        // many-to-many junction.
+        val labelIdx = if (j < N_MARKERS) j % N_LABELS else (j + 31) % N_LABELS
+        return labelGid(labelIdx)
+    }
+
+    private fun fmt(template: String, vararg args: Any?): String =
+        String.format(Locale.US, template, *args)
+
+    private fun log(message: String) {
+        println("[MarkerDataMigrationLoadTest] $message")
+    }
+
+    private companion object {
+        const val N_VERSIONS = 100
+        const val N_LABELS = 100
+        const val N_MARKERS = 50_000
+        const val N_MARKER_LABELS = 60_000
+
+        // Each marker caption is exactly this many UTF-16 code units. With
+        // the legacy SQLite schema's `caption text` column the bytes-on-disk
+        // value depends on encoding, but the round-trip we care about is
+        // String → ContentValues → SQLite → cursor.getString() →
+        // MarkerEntity.caption being exactly the same String we put in.
+        const val CAPTION_BYTES = 2_048
+
+        // Versions are ordered by `ordering ASC` after migration; keeping
+        // the base high makes the test resilient to a future change that
+        // pre-inserts a few rows (e.g. presets) ahead of the seeded set.
+        const val ORDERING_BASE = 100
+    }
+}


### PR DESCRIPTION
## Summary

PR #191 (REM-10) and PR #188 (REM-11) added one-time data copies from the legacy `AlkitabDb` SQLite tables into Room's `AlkitabRoomDb`. The on-device smoke covered a real-but-small dataset (1,456 markers / 18 labels / 152 marker_labels); this PR adds a regression-guard load test at roughly 30× that size, with each marker carrying a 2 KB caption — the shape a power user with years of highlights would hit.

The test simulates an old-app → new-app upgrade by reusing the exact code path the upgrade triggers:

1. Open a fresh `InternalDbHelper` and populate the legacy `Version` / `Marker` / `Label` / `Marker_Label` tables. This is what a 2025-era install looks like on disk.
2. Open a fresh in-memory `AppDatabase` at the latest Room schema version — the equivalent of a v1 device finding no `AlkitabRoomDb` on first launch of the new build.
3. Run `VersionDataMigration.copyFromLegacyDbIfNeeded(...)` and `MarkerDataMigration.copyFromLegacyDbIfNeeded(...)`.
4. Verify counts and a deep field-by-field round-trip on a sampled subset.
5. Re-run both migrations and confirm they're no-ops (idempotency).

## Dataset

| Table          | Rows   | Per-row payload                   |
|----------------|--------|-----------------------------------|
| `Version`      | 100    | 9 fields incl. nullable preset_name / locale |
| `Label`        | 100    | 4 fields incl. nullable backgroundColor (~25 %) |
| `Marker`       | 50,000 | 7 fields, **caption = 2,048 chars** |
| `Marker_Label` | 60,000 | every marker has ≥1 label; markers 0..9,999 have 2 distinct labels each (the +31 offset is coprime to 100, so the second-pass label is guaranteed distinct from the first-pass label for the same marker) |

Total caption bytes live during migration: **≈100 MB**.

## Verifiable pattern

Every field is a pure function of the row's integer index `i` (or `j` for associations). Seed and verify call the *same* `*Pattern(i)` helpers, so a regression in the migration is the only thing that can make them disagree. Example for markers:

```kotlin
private fun markerGid(i: Int)        = fmt("M%08d", i)
private fun markerKind(i: Int)       = 1 + (i % 3)               // 1=bookmark, 2=note, 3=highlight
private fun markerCaption(i: Int)    = "M%08d|".format(i) + filler.repeat(...) + "|END%08d".format(i)
private fun markerCreateTime(i: Int) = 1_700_000_000 + i
private fun markerModifyTime(i: Int) = 1_700_000_000 + i * 2
```

The 2 KB caption is built with an index-bearing header *and* footer plus a filler character chosen from `i % 10`, so a silent truncation, a left/right swap, or a UTF-16 ↔ UTF-8 confusion would all flip the assertion.

Verification samples first / middle / last plus several spread indices for each table; the marker_label invariant ("first 10,000 markers have exactly 2 distinct labels, the rest have 1") is asserted on marker 0, 9,999, 10,000, 30,000, and 49,999.

## Build change

Bumped unit-test `maxHeapSize` to 2 GB. `MarkerDataMigration.readLegacyMarkers` reads every legacy row into a single `ArrayList<MarkerEntity>` before the bulk Room insert (intentional — it gives the transaction atomic-or-nothing semantics), which at 50,000 × 2 KB captions holds ≈215 MB live entities + cursor + Room internals. The default 512 MB unit-test heap OOMs at this scale.

## Test plan

- [x] `./gradlew :Alkitab:testPlainDebugUnitTest --tests "yuku.alkitab.base.storage.room.MarkerDataMigrationLoadTest"` — passes.
  - Seed phase: ~15 s for 110,200 row inserts wrapped in 4 SQLite transactions
  - Migration phase: **~7 s** for both `VersionDataMigration` + `MarkerDataMigration`
  - Verification + idempotency re-run: negligible (~40 ms)
  - Total: ~22 s wall
- [x] All existing `yuku.alkitab.base.storage.room.*` tests continue to pass with the heap bump (LabelRoomDaoTest 9, MarkerRoomDaoTest 13, MarkerLabelRoomDaoTest 9, AppDatabaseMigrationTest 3, plus the existing MarkerDataMigrationTest cases).
- [ ] CI run on this PR.

## Notes

- The legacy `InternalDbHelper` extends `SQLiteOpenHelper`, so the harness uses Robolectric (same as `MarkerDataMigrationTest`).
- The Robolectric in-memory SQLite is implemented in native code, so the 100 MB of caption bytes lives outside the JVM heap during the seed phase; peak JVM heap is during migration when the entities are materialised into the ArrayList.
- A real device upgrade would also write `AlkitabRoomDb` to disk and journal — not modeled here, but the on-device smoke in PR #191 covered the on-disk path. This test covers the data-correctness leg at a scale the smoke could not.


---
_Generated by [Claude Code](https://claude.ai/code/session_019Mxzka7b4YqG8gza7fJtZk)_