### PR TITLE
docs: refresh tech docs to reflect REM-06/07/08/10/11/16/19/20/24

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,14 +133,15 @@ The project is a multi-module Gradle build. The main app module is **`:Alkitab`*
 | `Afw` | Base Android framework (preferences wrapper, adapter base, app context) |
 | `Snappy` | JNI Snappy compression (native C++ via NDK) |
 | `FlowLayout` | Flow layout widget |
-| `PrDownloaderFixed` | Patched PRDownloader for HTTP file downloads |
 | `ImportedDesktopVerseUtil` | Desktop verse reference finder/parser |
+
+Bible-version downloads run inside `VersionDownloadWorker` (a `CoroutineWorker`) using the shared OkHttp client; the previous `PrDownloaderFixed` module was deleted in REM-19.
 
 ### Key Singletons and Entry Points
 
-- **`App.java`** — Application class, extends `yuku.afw.App`. Initializes Firebase, PRDownloader, preference defaults, extension receivers.
-- **`S.kt`** — Central service locator. Holds lazy references to `InternalDb`, `SongDb`, active Bible version, calculated UI dimensions. All global state access goes through `S`.
-- **`IsiActivity.kt`** (~2900 lines) — Main Bible reader activity. Manages verse display, split view, navigation history, action mode (copy/share/bookmark), gestures (pinch zoom, swipe), and volume button navigation.
+- **`App.java`** — Application class, extends `yuku.afw.App`. Initializes Firebase, FCM registration, preference defaults, extension receivers. Holds the eagerly-initialized `App.services` (`AppServices` container) introduced by REM-24.
+- **`S.kt`** — Legacy service locator (~317 lines). Holds lazy references to `InternalDb`, `SongDb`, active Bible version state, and calculated UI dimensions. New code should depend on the narrower `StorageProvider` / `VersionManager` / `UiDimensionsProvider` interfaces via `App.services.*`; existing `S.foo` call sites are being migrated incrementally (REM-24).
+- **`IsiActivity.kt`** (~2170 lines, at `yuku/alkitab/base/IsiActivity.kt`) — Main Bible reader activity. Verse display, navigation history, and volume-button navigation still live here; gesture handling, the action-mode callback, and split-view management have been extracted into `ReaderGestureHandler` (REM-06), `VerseActionModeController` (REM-07), and `SplitViewManager` (REM-08) respectively.
 
 ### Data Flow: Bible Text Rendering
 
@@ -166,16 +167,21 @@ Used everywhere: database storage, intent extras, sync protocol, content provide
 
 ### Database Schema
 
-`InternalDb` (SQLite) has these core tables:
-- **Marker** — bookmarks, notes, highlights (distinguished by `kind` column). Each row has a `gid` (globally unique ID) for sync.
-- **Label** — bookmark categories with custom background colors.
-- **Marker_Label** — many-to-many junction between markers and labels.
-- **Version** — metadata for downloaded Bible versions (filename, locale, active flag, ordering).
-- **ProgressMark** — 5 reading progress pins with ARI positions.
-- **ReadingPlan** / **ReadingPlanProgress** — reading plan data and daily completion tracking.
-- **Devotion** — cached devotional articles.
-- **SyncShadow** / **SyncLog** — sync state tracking.
-- **PerVersion** — per-version settings.
+The app uses two SQLite files:
+
+- **`AlkitabRoomDb`** — Room database (`yuku.alkitab.base.storage.room.AppDatabase`, currently at `@Database(version = 2)`). Holds the tables migrated as part of the REM-10/REM-11 plan:
+  - **version** (REM-11) — metadata for downloaded Bible versions (filename, locale, active flag, ordering).
+  - **marker** (REM-10) — bookmarks, notes, highlights (distinguished by `kind` column). Each row has a `gid` (globally unique ID) for sync.
+  - **label** (REM-10) — bookmark categories with custom background colors.
+  - **marker_label** (REM-10) — many-to-many junction between markers and labels.
+- **`AlkitabDb`** — legacy hand-rolled `SQLiteOpenHelper` (`InternalDbHelper`). Still owns the not-yet-migrated tables:
+  - **ProgressMark** — 5 reading progress pins with ARI positions.
+  - **ReadingPlan** / **ReadingPlanProgress** — reading plan data and daily completion tracking.
+  - **Devotion** — cached devotional articles.
+  - **SyncShadow** / **SyncLog** — sync state tracking.
+  - **PerVersion** — per-version settings.
+
+The legacy `Marker` / `Label` / `Marker_Label` / `Version` tables are still created in `AlkitabDb` as a rollback safety net; a one-time copy in `MarkerDataMigration` / `VersionDataMigration` (wired from `S.db`'s lazy initializer) moves their rows into Room on first launch with the migrated code. `InternalDb` plus the per-table facades (`MarkerDao`, `LabelDao`, `Marker_LabelDao`, `VersionDao`, etc.) preserve the public surface so callers don't change; the facades route through Room for the migrated tables and through raw SQL for the rest.
 
 ### Verse Text Formatting Codes
 
@@ -270,7 +276,7 @@ Detailed documentation for each major feature module:
 
 ## Important Caveats
 
-- `IsiActivity.kt` is ~2900 lines — the monolithic main activity handles Bible reading, split view, navigation, gestures, and action mode. Changes here require careful testing.
+- `IsiActivity.kt` is ~2170 lines — still large, but no longer monolithic: gesture handling, the action-mode callback, and split-view management were extracted (REM-06/07/08) into `ReaderGestureHandler`, `VerseActionModeController`, and `SplitViewManager` under `widget/`. Bible reading, navigation history, and volume-button handling are still inline; changes here require careful testing.
 - `KpriModel.Song` uses `Parcelable` serialization for database storage (acknowledged as a bad design decision in the code).
 - The `Snappy` module has native C++ code — NDK must be installed for builds.
 - A placeholder `Alkitab/google-services.json` is checked in so `plainDebug` works out of the box; Firebase features won't actually function with it. For production flavors, the real `google-services.json` is sourced from `$ALKITAB_PROPRIETARY_DIR/google-services.json` at build time and copied into the gitignored `Alkitab/src/<flavor>/google-services.json` (where the GMS plugin's source-set lookup finds it).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,16 +2,18 @@
 
 ## Singleton & Service Locator Pattern
 
-The app does not use dependency injection. Instead, it relies on singletons accessed through `S.kt`:
+The app does not use a DI framework. State is reached through two layers:
 
 ```
-S.db         → InternalDb (lazy)     — main database
-S.songDb     → SongDb (lazy)         — songs database
-S.activeVersion()                     — currently selected Bible version
-S.applied()  → CalculatedDimensions  — computed UI metrics from preferences
+App.services.storage.db       → InternalDb (lazy)     — main database (markers, labels, etc.)
+App.services.storage.songDb   → SongDb (lazy)         — songs database
+App.services.versions.activeVersion()                 — currently selected Bible version
+App.services.uiDimensions.applied() → CalculatedDimensions
 ```
 
-`App.staticInit()` must be called before any `S` access. This is done in `App.onCreate()` and also defensively in the `ContentProvider.onCreate()`.
+`App.services` is an `AppServices` container holding three interfaces — `StorageProvider`, `VersionManager`, `UiDimensionsProvider` — introduced by REM-24. In production all three are implemented by adapter properties on `S` (`S.storage`, `S.versions`, `S.uiDimensions`). The original `S.db` / `S.applied()` / `S.activeVersion()` accessors still work for legacy callers, and `App.services` is initialized eagerly at the class-load of `App.java` so it is non-null even from tests that bypass `App.onCreate()` / `App.staticInit()`.
+
+`App.staticInit()` must be called before features that depend on Firebase, FCM, extensions, or feedback senders. It is invoked from `App.onCreate()` and defensively from `ContentProvider.onCreate()`.
 
 ## Module Dependency Graph
 
@@ -31,22 +33,24 @@ Alkitab (main app)
 ├── KpriModel (song data model)
 ├── FlowLayout
 ├── Afw (base framework: Preferences, EasyAdapter, App context)
-├── ImportedDesktopVerseUtil (verse reference parser)
-└── PrDownloaderFixed (HTTP file downloader)
+└── ImportedDesktopVerseUtil (verse reference parser)
 ```
+
+HTTP file downloads (Bible versions) run inside `VersionDownloadWorker` (`CoroutineWorker`) using OkHttp; the previous `PrDownloaderFixed` module was deleted in REM-19, and the `AmbilWarna` color-picker module was deleted in REM-20.
 
 ## Activity Architecture
 
-The app uses traditional Activity/Fragment architecture (no Navigation Component, no Jetpack Compose):
+The app uses traditional Activity/Fragment architecture for the reader, with some screens (notably `GotoActivity` and the new color picker) ported to Jetpack Compose (REM-20, REM-22):
 
-- **IsiActivity** — main reader (monolithic, ~2900 lines). Handles:
+- **IsiActivity** — main reader (~2170 lines, down from ~2900). After REM-06/07/08 it still owns:
   - Bible text display via `VersesControllerImpl` (RecyclerView)
-  - Split-screen parallel version comparison
   - Navigation history (`BackForwardListController`)
-  - Action mode for verse selection (copy, share, bookmark, etc.)
-  - Two-finger gestures (pinch zoom, chapter swipe)
-  - Volume button navigation
+  - Volume-button navigation
   - Extension integration
+  Extracted siblings (under `yuku.alkitab.base.widget`):
+  - `ReaderGestureHandler` — two-finger pinch zoom, chapter swipe, goto-button floater drag
+  - `VerseActionModeController` — copy/share/bookmark action mode
+  - `SplitViewManager` — split-screen parallel version comparison
 
 - **GotoActivity** — verse navigation (book/chapter/verse picker)
 - **SearchActivity** — full-text search with results
@@ -60,10 +64,10 @@ The app uses traditional Activity/Fragment architecture (no Navigation Component
 
 ## Split View System
 
-`IsiActivity` supports displaying two Bible versions simultaneously:
-- `activeSplit0` (primary, always present) — `ActiveSplit0(mv, version)` data class
-- `activeSplit1` (secondary, optional) — `ActiveSplit1(mv, version)` data class
-- Layout toggles between horizontal and vertical via `splitHandleButton`
+Split-pane display of two Bible versions is owned by `SplitViewManager` (`Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt`), wired into `IsiActivity` via the `SplitViewHost` and `SplitViewActions` interfaces:
+- `activeSplit0` (primary, always present) — `ActiveSplit0(mv, version)` data class still on `IsiActivity`
+- `activeSplit1` (secondary, optional) — `ActiveSplit1` data class lives in `yuku.alkitab.base.widget`; the manager owns the mutable state and `IsiActivity.activeSplit1` is a read-only getter that delegates
+- Layout toggles between horizontal and vertical via `splitHandleButton`; the manager persists `lastSplitOrientation` / `lastSplitProp` / `lastSplitVersionId` across launches
 - Verse scroll position and selection are synchronized between splits
 - Each split has its own `VersesControllerImpl` instance (`lsSplit0`, `lsSplit1`)
 
@@ -100,10 +104,10 @@ MVersion.getVersion()
 ## Threading Model
 
 - UI thread for all display and user interaction
-- Background threads for:
-  - Sync operations (via WorkManager)
-  - Devotion downloads (`DevotionDownloader` — dedicated thread with queue)
-  - Song book downloads
-  - File imports
-  - Widget updates
-- No RxJava or coroutines for async — uses traditional threads, `AsyncTask` remnants, and WorkManager
+- Background work:
+  - Sync operations run as a `WorkManager` worker (`SyncAdapter`)
+  - Bible-version downloads run as a `CoroutineWorker` (`VersionDownloadWorker`) using OkHttp + Range-based resume; observed via `WorkManager.getWorkInfoByIdFlow` in `DownloadMapper` (REM-19)
+  - `DevotionDownloader` uses a single-thread `ExecutorService` with a `LinkedBlockingDeque` queue and a clean shutdown path (REM-05)
+  - Song-book downloads use raw OkHttp via `Connections.downloadCall(...)`
+  - File imports and widget updates
+- Coroutines are used in the migrated paths above (workers, gesture-flow collectors, the `AppEvents` `SharedFlow` buses introduced by REM-03) but the codebase still has `Thread` / `Handler` remnants — see `docs/tech-debt.md`

--- a/docs/backend-communication.md
+++ b/docs/backend-communication.md
@@ -16,7 +16,7 @@ All network requests use OkHttp3 (v5.1.0) configured in `Connections.kt`:
 
 ### Bible Version Downloads
 
-Version files are downloaded via `PRDownloader` (patched library in `PrDownloaderFixed` module). The download URL and metadata come from `VersionConfig`.
+Version files are downloaded by `VersionDownloadWorker` (a `CoroutineWorker` using the shared OkHttp client). The worker reports progress via `setProgress(Data)`; `DownloadMapper` observes `WorkManager.getWorkInfoByIdFlow(uuid)` on a `MainScope` coroutine and mirrors `WorkInfo.State` into `DownloadManager.STATUS_*` constants for the version-list UI. Resume support: the worker checks the destination file's existing length and, if non-zero, sends `Range: bytes=N-` (the worker explicitly sends `Accept-Encoding: identity` so OkHttp does not transparently strip Content-Length on a gzip response). The download URL and metadata come from `VersionConfig`. The previous `PRDownloader`-based implementation (and the `PrDownloaderFixed` module) were removed in REM-19.
 
 ### Sync API
 
@@ -30,7 +30,7 @@ Request body contains `simpleToken`, `installation_id`, `fcm_token`, and per-ent
 ```
 GET /devotion/get?name={kind}&date={yyyymmdd}
 ```
-Returns devotional article text. Downloaded by `DevotionDownloader` on a background thread.
+Returns devotional article text. Downloaded by `DevotionDownloader` (REM-05: a single-thread `ExecutorService` with a `LinkedBlockingDeque` queue and a clean `shutdown()` path).
 
 ### Song Book Downloads
 
@@ -51,19 +51,16 @@ Firebase Cloud Functions hosted at `us-central1-pulau-ribka.cloudfunctions.net`:
 
 - **Cloud Messaging (FCM)**: Push notifications to trigger sync on other devices
 - **Crashlytics**: Crash reporting (release builds only)
-- FCM token managed by `Fcm.java`, registered with backend on app start
-- `google-services.json` is gitignored — not available in open-source build
+- FCM token managed by `Fcm.java`, registered with backend on app start. A failed registration sets `Prefkey.fcm_registration_pending = true`; `Sync.sendFcmRegistrationId` retries up to three times on a daemon `ScheduledExecutorService` (1 min / 5 min / 30 min), and `App.staticInit()` re-enters `retryPendingFcmRegistrationIfNeeded` on next launch when the flag is set (REM-04).
+- A placeholder `Alkitab/google-services.json` is committed so `plainDebug` builds out of the box. The real `google-services.json` (covering all production applicationIds) lives at `$ALKITAB_PROPRIETARY_DIR/google-services.json` and is copied per-flavor into the gitignored `Alkitab/src/<flavor>/google-services.json` at build time.
 
 ## File Downloads
 
-`PRDownloader` (patched as `PrDownloaderFixed`) handles file downloads with:
-- Progress callbacks
-- Resume support
-- Configured in `App.staticInit()`
+Bible-version downloads run inside `VersionDownloadWorker` (see "Bible Version Downloads" above). Song-book downloads use raw OkHttp via `Connections.downloadCall(...)`. There is no shared "downloader" abstraction — each path uses the appropriate primitive.
 
 ## Content Provider (Outgoing)
 
-The app exposes a read-only `ContentProvider` (`yuku.alkitab.base.cp.Provider`) for other apps to query Bible verses. This is outgoing communication — other apps query Alkitab, not the reverse.
+The app exposes a read-only `ContentProvider` (`yuku.alkitab.base.cp.Provider`, ported to Kotlin in REM-16) for other apps to query Bible verses. This is outgoing communication — other apps query Alkitab, not the reverse.
 
 See `AlkitabIntegration` module for the client-side API that other apps use.
 

--- a/docs/modules/devotions.md
+++ b/docs/modules/devotions.md
@@ -7,7 +7,7 @@ Provides daily devotional reading content from multiple sources (primarily Indon
 ## Key Files
 
 - `Alkitab/src/main/java/yuku/alkitab/base/ac/DevotionActivity.java` — Devotion reader UI
-- `Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionDownloader.kt` — Background downloader (ported to Kotlin in REM-16; single-thread `ExecutorService` + `LinkedBlockingDeque` queue with clean shutdown, REM-05)
+- `Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionDownloader.kt` — Background downloader (single-thread `ExecutorService` + `LinkedBlockingDeque` queue with clean shutdown)
 - `Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionArticle.java` — Abstract base class
 - Article implementations: `ArticleMorningEveningEnglish`, `ArticleFromSabda`, `ArticleMeidA`, `ArticleRoc`, `ArticleRenunganHarian`, `ArticleSantapanHarian`
 
@@ -19,7 +19,7 @@ Provides daily devotional reading content from multiple sources (primarily Indon
 - `shutdown()` sets a `volatile` flag and calls `executor.shutdownNow()`; the loop handles `InterruptedException` by re-interrupting and breaking
 - Articles cached in the `Devotion` database table
 - `touchTime` tracks access for cache management
-- On completion the downloader emits an `AppEvents` `SharedFlow` event (replaced the `LocalBroadcastManager` broadcast in REM-03)
+- On completion the downloader emits an `AppEvents` `SharedFlow` event
 
 ## Article Parsing
 

--- a/docs/modules/devotions.md
+++ b/docs/modules/devotions.md
@@ -7,17 +7,19 @@ Provides daily devotional reading content from multiple sources (primarily Indon
 ## Key Files
 
 - `Alkitab/src/main/java/yuku/alkitab/base/ac/DevotionActivity.java` — Devotion reader UI
-- `Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionDownloader.java` — Background thread downloader with prioritizable queue
+- `Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionDownloader.kt` — Background downloader (ported to Kotlin in REM-16; single-thread `ExecutorService` + `LinkedBlockingDeque` queue with clean shutdown, REM-05)
 - `Alkitab/src/main/java/yuku/alkitab/base/devotion/DevotionArticle.java` — Abstract base class
 - Article implementations: `ArticleMorningEveningEnglish`, `ArticleFromSabda`, `ArticleMeidA`, `ArticleRoc`, `ArticleRenunganHarian`, `ArticleSantapanHarian`
 
 ## Download System
 
-`DevotionDownloader` runs on a background thread with a queue:
-- **Endpoint**: `GET /devotion/get?name={kind}&date={yyyymmdd}`
-- Queue supports both LIFO and FIFO prioritization
+`DevotionDownloader` runs work on a single-thread `ExecutorService`, fed by a `LinkedBlockingDeque` (so a `take()` provides natural backpressure):
+- **Endpoint**: `GET /devotion/get?name={kind}&date={yyyymmdd}` via `Connections.downloadString(url)`
+- Queue supports both LIFO (front) and FIFO (back) insertion for prioritization
+- `shutdown()` sets a `volatile` flag and calls `executor.shutdownNow()`; the loop handles `InterruptedException` by re-interrupting and breaking
 - Articles cached in the `Devotion` database table
 - `touchTime` tracks access for cache management
+- On completion the downloader emits an `AppEvents` `SharedFlow` event (replaced the `LocalBroadcastManager` broadcast in REM-03)
 
 ## Article Parsing
 

--- a/docs/modules/markers.md
+++ b/docs/modules/markers.md
@@ -31,7 +31,7 @@ Marker {
 }
 ```
 
-Storage: the `marker`, `label`, and `marker_label` tables live in the Room database (`AlkitabRoomDb`, `@Database(version = 2)`). The `MarkerDao` / `LabelDao` / `Marker_LabelDao` facades preserve a stable public surface for callers, mapping Room entities to the `Marker` / `Label` / `Marker_Label` model classes. A one-time idempotent `MarkerDataMigration` copy from the legacy `AlkitabDb` tables runs from `S.db`'s lazy initializer; the legacy tables are still created by `InternalDbHelper.onCreate` as a rollback safety net.
+Storage: the `marker`, `label`, and `marker_label` tables live in the Room database `AlkitabRoomDb` (`AppDatabase` at `@Database(version = 2)`). The `MarkerDao` / `LabelDao` / `Marker_LabelDao` facades expose a `Marker` / `Label` / `Marker_Label` model surface for callers and map to/from Room entities internally.
 
 ## Labels
 
@@ -44,7 +44,7 @@ Highlights use a JSON encoding in the `caption` field supporting:
 - Partial highlights (character range within a verse)
 - Hash-based verification to detect when verse text has changed
 
-The `Highlights` utility (`Highlights.kt`) handles encoding/decoding and color management. `Highlights.alphaMix()` masks the input to 24-bit RGB before OR-ing the fixed alpha, so callers may pass either RGB or pre-tinted ARGB ints without bleeding the original alpha into the result.
+The `Highlights` utility handles encoding/decoding and color management. `Highlights.alphaMix()` masks the input to 24-bit RGB before OR-ing the fixed alpha, so callers may pass either RGB or pre-tinted ARGB ints and the output alpha is always `0xA0`.
 
 Color selection in `TypeHighlightDialog` and the label color editor uses the iOS-style Compose color picker at `yuku.alkitab.base.compose.colorpicker.IosColorPicker` / `ColorPickerDialog`, hosted inside a `ModalBottomSheet`.
 

--- a/docs/modules/markers.md
+++ b/docs/modules/markers.md
@@ -7,12 +7,14 @@
 ## Key Files
 
 - `Alkitab/src/main/java/yuku/alkitab/base/ac/MarkerListActivity.kt` — Filtered list of markers with search and sorting
-- `Alkitab/src/main/java/yuku/alkitab/base/ac/MarkersActivity.java` — Label management (create, rename, delete, reorder via drag-sort)
+- `Alkitab/src/main/java/yuku/alkitab/base/ac/MarkersActivity.java` — Label management (create, rename, delete, reorder via `ItemTouchHelper` drag — REM-12)
 - `Alkitab/src/main/java/yuku/alkitab/base/ac/NoteActivity.java` — Note editor with verse link detection
-- `Alkitab/src/main/java/yuku/alkitab/base/util/Highlights.java` — JSON-based highlight encoding
+- `Alkitab/src/main/java/yuku/alkitab/base/util/Highlights.kt` — JSON-based highlight encoding (ported to Kotlin in REM-16)
 - `Alkitab/src/main/java/yuku/alkitab/base/widget/AttributeView.java` — Icon drawing for bookmark/note/highlight indicators
 - `Alkitab/src/main/java/yuku/alkitab/base/verses/VersesAttributes.kt` — Per-verse attribute maps
 - `Alkitab/src/main/java/yuku/alkitab/base/verses/VerseAttributeLoader.kt` — Loads attributes from DB and content providers
+- `Alkitab/src/main/java/yuku/alkitab/base/storage/MarkerDao.kt` / `LabelDao.kt` / `Marker_LabelDao.kt` — Facade DAOs that route through Room (REM-10)
+- `Alkitab/src/main/java/yuku/alkitab/base/storage/room/MarkerEntity.kt` / `LabelEntity.kt` / `MarkerLabelEntity.kt` (+ matching `*RoomDao.kt`) — Room entities/DAOs
 
 ## Marker Model
 
@@ -29,9 +31,11 @@ Marker {
 }
 ```
 
+Storage: the `marker`, `label`, and `marker_label` tables now live in the Room database (`AlkitabRoomDb`, `@Database(version = 2)`), migrated from the legacy `AlkitabDb` in REM-10. The `MarkerDao` / `LabelDao` / `Marker_LabelDao` facades preserve the legacy public surface, mapping Room entities to the `Marker` / `Label` / `Marker_Label` model classes. A one-time idempotent `MarkerDataMigration` copy runs from `S.db`'s lazy initializer the first time the migrated code launches.
+
 ## Labels
 
-Labels are user-created categories for organizing bookmarks. Each label has a `title`, `ordering`, and `backgroundColor`. The `Marker_Label` junction table creates many-to-many relationships. Labels also have GIDs for sync.
+Labels are user-created categories for organizing bookmarks. Each label has a `title`, `ordering`, and `backgroundColor`. The `marker_label` junction table creates many-to-many relationships. Labels also have GIDs for sync.
 
 ## Highlights
 
@@ -40,7 +44,9 @@ Highlights use a JSON encoding in the `caption` field supporting:
 - Partial highlights (character range within a verse)
 - Hash-based verification to detect when verse text has changed
 
-The `Highlights` utility class handles encoding/decoding and color management.
+The `Highlights` utility (`Highlights.kt`, ported to Kotlin in REM-16) handles encoding/decoding and color management. `Highlights.alphaMix()` was fixed in REM-18a to mask the input to 24-bit RGB before OR-ing the fixed alpha, eliminating an ARGB-leak when callers passed already-alpha-tinted colors.
+
+Color selection in `TypeHighlightDialog` and the label color editor uses the iOS-style Compose color picker introduced in REM-20 (`yuku.alkitab.base.compose.colorpicker.IosColorPicker` / `ColorPickerDialog`). The old `AmbilWarna` module was deleted.
 
 ## Attribute Display
 

--- a/docs/modules/markers.md
+++ b/docs/modules/markers.md
@@ -7,13 +7,13 @@
 ## Key Files
 
 - `Alkitab/src/main/java/yuku/alkitab/base/ac/MarkerListActivity.kt` — Filtered list of markers with search and sorting
-- `Alkitab/src/main/java/yuku/alkitab/base/ac/MarkersActivity.java` — Label management (create, rename, delete, reorder via `ItemTouchHelper` drag — REM-12)
+- `Alkitab/src/main/java/yuku/alkitab/base/ac/MarkersActivity.java` — Label management (create, rename, delete, reorder via `ItemTouchHelper` drag)
 - `Alkitab/src/main/java/yuku/alkitab/base/ac/NoteActivity.java` — Note editor with verse link detection
-- `Alkitab/src/main/java/yuku/alkitab/base/util/Highlights.kt` — JSON-based highlight encoding (ported to Kotlin in REM-16)
+- `Alkitab/src/main/java/yuku/alkitab/base/util/Highlights.kt` — JSON-based highlight encoding
 - `Alkitab/src/main/java/yuku/alkitab/base/widget/AttributeView.java` — Icon drawing for bookmark/note/highlight indicators
 - `Alkitab/src/main/java/yuku/alkitab/base/verses/VersesAttributes.kt` — Per-verse attribute maps
 - `Alkitab/src/main/java/yuku/alkitab/base/verses/VerseAttributeLoader.kt` — Loads attributes from DB and content providers
-- `Alkitab/src/main/java/yuku/alkitab/base/storage/MarkerDao.kt` / `LabelDao.kt` / `Marker_LabelDao.kt` — Facade DAOs that route through Room (REM-10)
+- `Alkitab/src/main/java/yuku/alkitab/base/storage/MarkerDao.kt` / `LabelDao.kt` / `Marker_LabelDao.kt` — Facade DAOs that route through Room
 - `Alkitab/src/main/java/yuku/alkitab/base/storage/room/MarkerEntity.kt` / `LabelEntity.kt` / `MarkerLabelEntity.kt` (+ matching `*RoomDao.kt`) — Room entities/DAOs
 
 ## Marker Model
@@ -31,7 +31,7 @@ Marker {
 }
 ```
 
-Storage: the `marker`, `label`, and `marker_label` tables now live in the Room database (`AlkitabRoomDb`, `@Database(version = 2)`), migrated from the legacy `AlkitabDb` in REM-10. The `MarkerDao` / `LabelDao` / `Marker_LabelDao` facades preserve the legacy public surface, mapping Room entities to the `Marker` / `Label` / `Marker_Label` model classes. A one-time idempotent `MarkerDataMigration` copy runs from `S.db`'s lazy initializer the first time the migrated code launches.
+Storage: the `marker`, `label`, and `marker_label` tables live in the Room database (`AlkitabRoomDb`, `@Database(version = 2)`). The `MarkerDao` / `LabelDao` / `Marker_LabelDao` facades preserve a stable public surface for callers, mapping Room entities to the `Marker` / `Label` / `Marker_Label` model classes. A one-time idempotent `MarkerDataMigration` copy from the legacy `AlkitabDb` tables runs from `S.db`'s lazy initializer; the legacy tables are still created by `InternalDbHelper.onCreate` as a rollback safety net.
 
 ## Labels
 
@@ -44,9 +44,9 @@ Highlights use a JSON encoding in the `caption` field supporting:
 - Partial highlights (character range within a verse)
 - Hash-based verification to detect when verse text has changed
 
-The `Highlights` utility (`Highlights.kt`, ported to Kotlin in REM-16) handles encoding/decoding and color management. `Highlights.alphaMix()` was fixed in REM-18a to mask the input to 24-bit RGB before OR-ing the fixed alpha, eliminating an ARGB-leak when callers passed already-alpha-tinted colors.
+The `Highlights` utility (`Highlights.kt`) handles encoding/decoding and color management. `Highlights.alphaMix()` masks the input to 24-bit RGB before OR-ing the fixed alpha, so callers may pass either RGB or pre-tinted ARGB ints without bleeding the original alpha into the result.
 
-Color selection in `TypeHighlightDialog` and the label color editor uses the iOS-style Compose color picker introduced in REM-20 (`yuku.alkitab.base.compose.colorpicker.IosColorPicker` / `ColorPickerDialog`). The old `AmbilWarna` module was deleted.
+Color selection in `TypeHighlightDialog` and the label color editor uses the iOS-style Compose color picker at `yuku.alkitab.base.compose.colorpicker.IosColorPicker` / `ColorPickerDialog`, hosted inside a `ModalBottomSheet`.
 
 ## Attribute Display
 

--- a/docs/modules/search.md
+++ b/docs/modules/search.md
@@ -7,8 +7,8 @@ Full-text search across Bible verses with token-based intersection, book/testame
 ## Key Files
 
 - `Alkitab/src/main/java/yuku/alkitab/base/ac/SearchActivity.kt` — Search UI with history autocomplete
-- `Alkitab/src/main/java/yuku/alkitab/base/util/SearchEngine.java` — Core search engine (grep-based, token intersection)
-- `Alkitab/src/main/java/yuku/alkitab/base/util/QueryTokenizer.java` — Tokenizes queries with quote and plus-sign support
+- `Alkitab/src/main/java/yuku/alkitab/base/util/SearchEngine.kt` — Core search engine (grep-based, token intersection; ported to Kotlin in REM-16)
+- `Alkitab/src/main/java/yuku/alkitab/base/util/QueryTokenizer.kt` — Tokenizes queries with quote and plus-sign support (ported to Kotlin in REM-16)
 - `Alkitab/src/main/java/yuku/alkitab/base/util/SearchEngineQuery.kt` — Data class holding query string and optional book filter (`bookIds: SparseBooleanArray?`)
 
 ## Query Tokenization

--- a/docs/modules/search.md
+++ b/docs/modules/search.md
@@ -7,8 +7,8 @@ Full-text search across Bible verses with token-based intersection, book/testame
 ## Key Files
 
 - `Alkitab/src/main/java/yuku/alkitab/base/ac/SearchActivity.kt` — Search UI with history autocomplete
-- `Alkitab/src/main/java/yuku/alkitab/base/util/SearchEngine.kt` — Core search engine (grep-based, token intersection; ported to Kotlin in REM-16)
-- `Alkitab/src/main/java/yuku/alkitab/base/util/QueryTokenizer.kt` — Tokenizes queries with quote and plus-sign support (ported to Kotlin in REM-16)
+- `Alkitab/src/main/java/yuku/alkitab/base/util/SearchEngine.kt` — Core search engine (grep-based, token intersection)
+- `Alkitab/src/main/java/yuku/alkitab/base/util/QueryTokenizer.kt` — Tokenizes queries with quote and plus-sign support
 - `Alkitab/src/main/java/yuku/alkitab/base/util/SearchEngineQuery.kt` — Data class holding query string and optional book filter (`bookIds: SparseBooleanArray?`)
 
 ## Query Tokenization

--- a/docs/modules/songs.md
+++ b/docs/modules/songs.md
@@ -9,7 +9,7 @@ The songs module provides hymn/worship song browsing, searching, and audio playb
 - `Alkitab/src/main/java/yuku/alkitab/songs/SongListActivity.java` — Main song list with search and filtering
 - `Alkitab/src/main/java/yuku/alkitab/songs/SongViewActivity.kt` — Individual song viewer
 - `Alkitab/src/main/java/yuku/alkitab/songs/SongFragment.kt` — WebView-based song rendering with JavaScript
-- `Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.kt` — Song book download, installation, metadata (ported to Kotlin in REM-16)
+- `Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.kt` — Song book download, installation, metadata
 - `Alkitab/src/main/java/yuku/alkitab/songs/SongFilter.java` — Search/filter with regex and tokenized queries
 - `Alkitab/src/main/java/yuku/alkitab/songs/SongInfo.kt` — Lightweight song record (bookName, code, title, title_original)
 - `KpriModel/` — Song data model (`Song`, `Verse`, `Lyric`, `VerseKind`)
@@ -24,7 +24,7 @@ The songs module provides hymn/worship song browsing, searching, and audio playb
 
 Songs are stored in `SongDb` (separate SQLite database from the main `InternalDb`). Song books are downloaded as serialized `List<Song>` objects via `ObjectInputStream`, optionally gzip-compressed. Data format version is currently 3.
 
-Deserialization was hardened in REM-01: `SongBookUtil` now uses a `SafeObjectInputStream` with a class whitelist (`java.util.*`, `java.lang.*`, Song model classes only), an `instanceof` check before casting, a 50MB response size limit, and try-with-resources for streams.
+`SongBookUtil` uses a `SafeObjectInputStream` with a class whitelist (`java.util.*`, `java.lang.*`, Song model classes only) and an `instanceof` check before casting to guard against deserialization gadgets; the response body is capped at 50MB; and the `Response` plus all derived streams are wrapped in try-with-resources.
 
 ## Search
 

--- a/docs/modules/songs.md
+++ b/docs/modules/songs.md
@@ -9,7 +9,7 @@ The songs module provides hymn/worship song browsing, searching, and audio playb
 - `Alkitab/src/main/java/yuku/alkitab/songs/SongListActivity.java` — Main song list with search and filtering
 - `Alkitab/src/main/java/yuku/alkitab/songs/SongViewActivity.kt` — Individual song viewer
 - `Alkitab/src/main/java/yuku/alkitab/songs/SongFragment.kt` — WebView-based song rendering with JavaScript
-- `Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.java` — Song book download, installation, metadata
+- `Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.kt` — Song book download, installation, metadata (ported to Kotlin in REM-16)
 - `Alkitab/src/main/java/yuku/alkitab/songs/SongFilter.java` — Search/filter with regex and tokenized queries
 - `Alkitab/src/main/java/yuku/alkitab/songs/SongInfo.kt` — Lightweight song record (bookName, code, title, title_original)
 - `KpriModel/` — Song data model (`Song`, `Verse`, `Lyric`, `VerseKind`)
@@ -23,6 +23,8 @@ The songs module provides hymn/worship song browsing, searching, and audio playb
 ## Storage
 
 Songs are stored in `SongDb` (separate SQLite database from the main `InternalDb`). Song books are downloaded as serialized `List<Song>` objects via `ObjectInputStream`, optionally gzip-compressed. Data format version is currently 3.
+
+Deserialization was hardened in REM-01: `SongBookUtil` now uses a `SafeObjectInputStream` with a class whitelist (`java.util.*`, `java.lang.*`, Song model classes only), an `instanceof` check before casting, a 50MB response size limit, and try-with-resources for streams.
 
 ## Search
 

--- a/docs/modules/sync.md
+++ b/docs/modules/sync.md
@@ -47,7 +47,7 @@ The sync uses a shadow table (`SyncShadow`) to track the last-synced state. When
 2. If the entity changed locally → server wins (last-write-wins for most fields)
 3. Partial sync threshold: 100 operations per batch
 
-Known limitation tracked in `docs/tech-debt.md` (PB-03): the client-side patch is last-write-wins for every Mabel entity and for progress pins, so concurrent edits to the same highlight color or pin position on two devices silently discard one side. Notes and bookmark captions are merged server-side before deltas are emitted.
+The client-side patch is last-write-wins for every Mabel entity and for progress pins: concurrent edits to the same highlight color or pin position on two devices silently discard one side. Notes and bookmark captions are merged server-side before deltas are emitted.
 
 ## FCM Integration
 

--- a/docs/modules/sync.md
+++ b/docs/modules/sync.md
@@ -47,11 +47,15 @@ The sync uses a shadow table (`SyncShadow`) to track the last-synced state. When
 2. If the entity changed locally → server wins (last-write-wins for most fields)
 3. Partial sync threshold: 100 operations per batch
 
+Known limitation tracked in `docs/tech-debt.md` (PB-03): the client-side patch is last-write-wins for every Mabel entity and for progress pins, so concurrent edits to the same highlight color or pin position on two devices silently discard one side. Notes and bookmark captions are merged server-side before deltas are emitted.
+
 ## FCM Integration
 
 When a sync completes on one device, the server sends an FCM message to other registered devices. `FcmMessagingService` receives the push and triggers a sync via `SyncAdapter`.
 
 FCM configuration differs between debug (uses `RIBKA_FUNCTIONS_HOST_DEBUG` at `10.0.3.2:5001`) and release builds.
+
+Registration retry (REM-04): a failed FCM token send sets `Prefkey.fcm_registration_pending = true`. In-process, `Sync.sendFcmRegistrationId` retries up to three times on a daemon `ScheduledExecutorService` (`fcmRetryExecutor`) at 1 min / 5 min / 30 min, clearing the flag on success. Cross-launch, `App.staticInit()` calls `Sync.retryPendingFcmRegistrationIfNeeded(registrationId)` to re-enter the send when the flag is still set after a process death.
 
 ## Authentication
 

--- a/docs/modules/sync.md
+++ b/docs/modules/sync.md
@@ -55,7 +55,7 @@ When a sync completes on one device, the server sends an FCM message to other re
 
 FCM configuration differs between debug (uses `RIBKA_FUNCTIONS_HOST_DEBUG` at `10.0.3.2:5001`) and release builds.
 
-Registration retry (REM-04): a failed FCM token send sets `Prefkey.fcm_registration_pending = true`. In-process, `Sync.sendFcmRegistrationId` retries up to three times on a daemon `ScheduledExecutorService` (`fcmRetryExecutor`) at 1 min / 5 min / 30 min, clearing the flag on success. Cross-launch, `App.staticInit()` calls `Sync.retryPendingFcmRegistrationIfNeeded(registrationId)` to re-enter the send when the flag is still set after a process death.
+Registration retry: a failed FCM token send sets `Prefkey.fcm_registration_pending = true`. In-process, `Sync.sendFcmRegistrationId` retries up to three times on a daemon `ScheduledExecutorService` (`fcmRetryExecutor`) at 1 min / 5 min / 30 min, clearing the flag on success. Cross-launch, `App.staticInit()` calls `Sync.retryPendingFcmRegistrationIfNeeded(registrationId)` to re-enter the send when the flag is still set after a process death.
 
 ## Authentication
 

--- a/docs/modules/versions.md
+++ b/docs/modules/versions.md
@@ -7,10 +7,14 @@ The app supports 100+ downloadable Bible versions across many languages. Version
 ## Key Files
 
 - `Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionsActivity.kt` — Version management UI
-- `Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionListFragment.kt` — Lists downloadable and installed versions
+- `Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionListFragment.kt` — Lists downloadable and installed versions (`RecyclerView` + `ItemTouchHelper` for downloaded reorder — REM-12)
 - `Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionFileImporter.kt` — Imports .yes, .pdb, .yes.gz, .pdb.gz files
 - `Alkitab/src/main/java/yuku/alkitab/base/config/VersionConfig.java` — JSON catalog of available versions
 - `Alkitab/src/main/java/yuku/alkitab/base/storage/YesReaderFactory.java` — Factory for loading YES1/YES2 readers
+- `Alkitab/src/main/java/yuku/alkitab/base/util/VersionDownloadWorker.kt` — `CoroutineWorker` (OkHttp + Range-based resume) used to download `.yes` files (REM-19)
+- `Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt` — In-process tracker that observes `WorkManager.getWorkInfoByIdFlow` and mirrors state into `DownloadManager.STATUS_*` constants for the list UI
+- `Alkitab/src/main/java/yuku/alkitab/base/storage/VersionDao.kt` — Facade DAO routing through Room (REM-11)
+- `Alkitab/src/main/java/yuku/alkitab/base/storage/room/VersionEntity.kt` / `VersionRoomDao.kt` — Room entity/DAO
 
 ## MVersion Hierarchy
 
@@ -21,7 +25,7 @@ MVersion (abstract)
 └── MVersionPreset — Metadata for versions available to download (not yet installed)
 ```
 
-`S.getAvailableVersions()` merges internal + DB versions, filtering for active ones. Version instances (`VersionImpl`) are cached in a `ConcurrentHashMap` with `SoftReference` for memory-efficient GC.
+`App.services.versions.getAvailableVersions()` (or the legacy `S.getAvailableVersions()`) merges internal + DB versions, filtering for active ones. Version instances (`VersionImpl`) are cached in a `ConcurrentHashMap` with `SoftReference` for memory-efficient GC.
 
 ## Version IDs
 
@@ -33,13 +37,20 @@ MVersion (abstract)
 
 `version_config.json` (44KB, bundled in assets) contains metadata for all downloadable versions: locale, short/long names, modify times, group ordering. This config is periodically updated from the server and cached locally at `files/version_config.json`.
 
-## Import Flow
+## Import / Download Flow
 
+For downloads from the preset catalog:
+1. User picks a preset in `VersionListFragment`
+2. `DownloadMapper.enqueue(...)` builds a `OneTimeWorkRequest` for `VersionDownloadWorker` and starts a `MainScope` observer on `WorkManager.getWorkInfoByIdFlow(uuid)`
+3. The worker streams the file via OkHttp (`Accept-Encoding: identity`, `Range: bytes=N-` on resume) into a temp file under `cacheDir/DownloadMapper-tmp/`, reporting progress via `setProgress(Data)`
+4. On `SUCCEEDED`, `VersionDownloadCompleteReceiver.onReceive(id)` finalizes the file (decompresses gzip via `OptionalGzipInputStream` if needed), moves it into app storage, and inserts a row into the `version` table
+
+For local imports (`.yes` / `.pdb`):
 1. User selects a `.yes` or `.pdb` file (via file manager or intent)
 2. `VersionFileImporter` detects format and handles gzip decompression
-3. PDB files are converted to YES2 via `BiblePlus` module, saved as `pdb-{name}.yes`
+3. PDB files are converted to YES2 via the `BiblePlus` module, saved as `pdb-{name}.yes`
 4. YES2 files are copied to app storage
-5. A `Version` row is inserted into the database
+5. A row is inserted into the `version` table
 6. Import size limit: 100MB
 
 ## YES2 Format Details

--- a/docs/modules/versions.md
+++ b/docs/modules/versions.md
@@ -25,7 +25,7 @@ MVersion (abstract)
 └── MVersionPreset — Metadata for versions available to download (not yet installed)
 ```
 
-`App.services.versions.getAvailableVersions()` (or the legacy `S.getAvailableVersions()`) merges internal + DB versions, filtering for active ones. Version instances (`VersionImpl`) are cached in a `ConcurrentHashMap` with `SoftReference` for memory-efficient GC.
+`App.services.versions.getAvailableVersions()` merges internal + DB versions, filtering for active ones. Version instances (`VersionImpl`) are cached in a `ConcurrentHashMap` with `SoftReference` for memory-efficient GC.
 
 ## Version IDs
 

--- a/docs/modules/versions.md
+++ b/docs/modules/versions.md
@@ -7,13 +7,13 @@ The app supports 100+ downloadable Bible versions across many languages. Version
 ## Key Files
 
 - `Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionsActivity.kt` — Version management UI
-- `Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionListFragment.kt` — Lists downloadable and installed versions (`RecyclerView` + `ItemTouchHelper` for downloaded reorder — REM-12)
+- `Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionListFragment.kt` — Lists downloadable and installed versions; `RecyclerView` + `ItemTouchHelper` for the downloaded-tab reorder
 - `Alkitab/src/main/java/yuku/alkitab/versionmanager/VersionFileImporter.kt` — Imports .yes, .pdb, .yes.gz, .pdb.gz files
 - `Alkitab/src/main/java/yuku/alkitab/base/config/VersionConfig.java` — JSON catalog of available versions
 - `Alkitab/src/main/java/yuku/alkitab/base/storage/YesReaderFactory.java` — Factory for loading YES1/YES2 readers
-- `Alkitab/src/main/java/yuku/alkitab/base/util/VersionDownloadWorker.kt` — `CoroutineWorker` (OkHttp + Range-based resume) used to download `.yes` files (REM-19)
+- `Alkitab/src/main/java/yuku/alkitab/base/util/VersionDownloadWorker.kt` — `CoroutineWorker` (OkHttp + Range-based resume) used to download `.yes` files
 - `Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt` — In-process tracker that observes `WorkManager.getWorkInfoByIdFlow` and mirrors state into `DownloadManager.STATUS_*` constants for the list UI
-- `Alkitab/src/main/java/yuku/alkitab/base/storage/VersionDao.kt` — Facade DAO routing through Room (REM-11)
+- `Alkitab/src/main/java/yuku/alkitab/base/storage/VersionDao.kt` — Facade DAO routing through Room
 - `Alkitab/src/main/java/yuku/alkitab/base/storage/room/VersionEntity.kt` / `VersionRoomDao.kt` — Room entity/DAO
 
 ## MVersion Hierarchy

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -2,55 +2,72 @@
 
 ## SQLite Databases
 
-### InternalDb (Main Database)
+The app stores data in two separate SQLite files:
 
-Managed by `InternalDbHelper` with version-based schema migrations (current version 50+).
+- **`AlkitabRoomDb`** — Room database (`AppDatabase` at `@Database(version = 2)`). Owns the tables migrated as part of REM-10/REM-11.
+- **`AlkitabDb`** — legacy hand-rolled `SQLiteOpenHelper` (`InternalDbHelper`). Owns the tables not yet migrated to Room.
 
-#### Core Tables
+`InternalDb` plus per-table facade DAOs (`MarkerDao`, `LabelDao`, `Marker_LabelDao`, `VersionDao`, etc.) preserve the legacy public surface — callers don't need to know which file backs which table.
 
-**Marker** — bookmarks, notes, highlights
+### AlkitabRoomDb (Room)
+
+`yuku.alkitab.base.storage.room.AppDatabase`. Schema JSONs are exported under `Alkitab/schemas/`. Migration history:
+
+- v1 (REM-11) — introduced the `version` table
+- v2 (REM-10) — added `marker`, `label`, `marker_label` tables and their indexes via `MIGRATION_1_2`
+
+The legacy `Marker` / `Label` / `Marker_Label` / `Version` tables are still created in `AlkitabDb` as a rollback safety net; a one-time idempotent copy (`MarkerDataMigration` and `VersionDataMigration`, wired from `S.db`'s lazy initializer) moves their rows into Room on first launch with the migrated code.
+
+#### Room Tables
+
+**marker** — bookmarks, notes, highlights
 ```sql
-_id          INTEGER PRIMARY KEY
-gid          TEXT UNIQUE       -- globally unique ID for sync
-ari          INTEGER           -- verse reference (ARI encoding)
-kind         INTEGER           -- 0=bookmark, 1=note, 2=highlight
+_id          INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
+gid          TEXT              -- globally unique ID for sync
+ari          INTEGER NOT NULL  -- verse reference (ARI encoding)
+kind         INTEGER NOT NULL  -- 0=bookmark, 1=note, 2=highlight
 caption      TEXT              -- title/content/highlight JSON
-verseCount   INTEGER           -- number of verses covered
-createTime   TEXT              -- ISO timestamp
-modifyTime   TEXT              -- ISO timestamp
--- Indices on: ari, (kind, ari), (kind, modifyTime), gid
+verseCount   INTEGER NOT NULL
+createTime   INTEGER NOT NULL  -- epoch seconds
+modifyTime   INTEGER NOT NULL  -- epoch seconds
+-- Indices: ari, (kind, ari), (kind, modifyTime), (kind, createTime), gid
 ```
 
-**Label** — bookmark categories
+**label** — bookmark categories
 ```sql
-_id              INTEGER PRIMARY KEY
-gid              TEXT UNIQUE
+_id              INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
+gid              TEXT
 title            TEXT
-ordering         INTEGER
-backgroundColor  TEXT         -- hex color string
+ordering         INTEGER NOT NULL
+backgroundColor  TEXT
 ```
 
-**Marker_Label** — junction table
+**marker_label** — junction table
 ```sql
-_id        INTEGER PRIMARY KEY
-gid        TEXT UNIQUE
+_id        INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
+gid        TEXT
 marker_gid TEXT
 label_gid  TEXT
+-- Unique index on gid; indices on marker_gid and label_gid
 ```
 
-**Version** — downloaded Bible versions
+**version** — downloaded Bible versions
 ```sql
-_id          INTEGER PRIMARY KEY
+_id          INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL
 locale       TEXT
 shortName    TEXT
 longName     TEXT
 description  TEXT
 filename     TEXT
 preset_name  TEXT
-modifyTime   INTEGER
-active       INTEGER          -- 0 or 1
-ordering     INTEGER
+modifyTime   INTEGER NOT NULL
+active       INTEGER NOT NULL  -- 0 or 1
+ordering     INTEGER NOT NULL
 ```
+
+### AlkitabDb (legacy SQLiteOpenHelper)
+
+Managed by `InternalDbHelper` with version-based schema migrations keyed off the app `versionCode`. Owns the not-yet-migrated tables below.
 
 **ProgressMark** — 5 reading progress pins
 ```sql
@@ -153,12 +170,12 @@ The app previously supported reading `.yes` files from external storage (`READ_E
 
 ## Database Access Patterns
 
-All database access goes through `InternalDb` (accessed via `S.db`). Common patterns:
+All database access goes through `InternalDb` (accessed via `App.services.storage.db`, or the legacy `S.db`). Common patterns:
 
-- **Markers**: `insertOrUpdateMarker()`, `deleteMarkerById()`, `listMarkersForAriKind()`
-- **Highlights**: `updateOrInsertHighlights()` — manages per-verse highlight data
-- **Attributes**: `putAttributes()` — loads bookmark/note/highlight counts for verse display
-- **Versions**: `listAllVersions()` — retrieves all versions sorted by ordering
-- **Devotions**: `storeArticleToDevotions()` — caches downloaded articles
+- **Markers**: `insertOrUpdateMarker()`, `deleteMarkerById()`, `listMarkersForAriKind()` — route through `MarkerDao` → Room
+- **Highlights**: `updateOrInsertHighlights()` — manages per-verse highlight data; routes through Room
+- **Attributes**: `putAttributes()` — loads bookmark/note/highlight counts for verse display; routes through Room
+- **Versions**: `listAllVersions()` — retrieves all versions sorted by ordering; routes through `VersionDao` → Room
+- **Devotions**: `storeArticleToDevotions()` — caches downloaded articles; still routes through `InternalDb`'s raw-SQL path (legacy `AlkitabDb`)
 
-Database operations are generally synchronous on the calling thread. No Room, no DAO layer — direct SQLite via `SQLiteOpenHelper` and `Cursor` operations.
+Database operations are generally synchronous on the calling thread; the Room database explicitly enables `allowMainThreadQueries()` so the migration is a drop-in replacement for the existing synchronous facade. Migrating individual operations to coroutines/`Flow` is tracked under REM-15 in `docs/tech-debt-remediation.md`.

--- a/docs/tech-debt-remediation.md
+++ b/docs/tech-debt-remediation.md
@@ -1,6 +1,6 @@
 # Tech Debt Remediation Plan
 
-This document provides a prioritized remediation plan for each tech debt item identified in [tech-debt.md](tech-debt.md). Each task is scoped to a specific module or subsystem, evaluated using the BRICE framework.
+This document is an index over the prioritized remediation plan for each tech debt item identified in [tech-debt.md](tech-debt.md). Each task has its own file under [`tech-debt-remediation/`](tech-debt-remediation/), scoped to a specific module or subsystem and evaluated using the BRICE framework.
 
 ## BRICE Evaluation Framework
 
@@ -18,712 +18,40 @@ This document provides a prioritized remediation plan for each tech debt item id
 
 ## Phase 1: Quick Wins & Safety Fixes (BRICE ≥ 4.0)
 
-### REM-01: Fix SongBookUtil Resource Leak & Unsafe Deserialization ✅ COMPLETED
-**Addresses:** TD-04, PB-06  
-**Module:** Songs  
-**BRICE:** B=4 R=5 I=4 C=5 E=5 → **4.6**
-
-**Completed in:** `1b9b74d9` (2026-04-11)
-
-**What was done (steps 1-3):**
-1. ✅ Wrapped `Response` and streams in try-with-resources to prevent leaks
-2. ✅ Added response body size validation (rejects >50MB)
-3. ✅ Introduced `SafeObjectInputStream` with class whitelist (`java.util.*`, `java.lang.*`, and Song model classes only) to prevent deserialization attacks. Also added `instanceof` check before casting.
-4. ⬜ Long-term: Migrate song download format from Java serialization to JSON (Kotlinx Serialization) — not yet started, requires server change
-
-**Tests added:** 7 unit tests in `SongBookUtilTest.java` covering single/multiple songs, empty list, gzip, Unicode, multiple lyrics, and null fields.
-
----
-
-### REM-02: Fix Preferences hold()/unhold() Safety ✅ COMPLETED
-**Addresses:** TD-09, PB-07  
-**Module:** Afw  
-**BRICE:** B=3 R=4 I=5 C=5 E=4 → **4.2**
-
-**Completed in:** `0b61084a`, `cffe49ad`, `80cd9f34` (2026-04-10/11)
-
-**What was done:**
-1. ✅ Added `Preferences.withTransaction(Runnable)` method that wraps `hold()/unhold()` in try/finally
-2. ✅ Migrated all 6 existing `hold()`/`unhold()` call sites to `withTransaction` (`CurrentReading.java`, `DailyVerseData.java`, `SyncSettingsActivity.java`, `IsiActivity.kt`, `InternalDbHelper.java`, `SecretSyncDebugActivity.kt`)
-3. ✅ Made `hold()` and `unhold()` private — stronger than a safety timeout since external code can no longer call them directly, eliminating the misuse risk entirely
-
-**Note:** Two call sites (`SyncSettingsActivity`, `SecretSyncDebugActivity`) were previously missing try/finally, meaning an exception would have buffered preference writes indefinitely. This bug is now fixed.
-
----
-
-### ~~REM-03: Replace LocalBroadcastManager~~ ✅ COMPLETED (2026-04-22)
-**Addresses:** TD-03 (LocalBroadcastManager)  
-**Module:** Cross-cutting  
-**BRICE:** B=3 R=3 I=3 C=4 E=5 → **3.8**
-
-**Outcome:** All 24 files that used `App.getLbm()` now talk through a single Kotlin event-bus object at `yuku.alkitab.base.events.AppEvents`. Each former `ACTION_*` broadcast became a named `MutableSharedFlow` (most `<Unit>`, one `<Boolean>` for the version-list refreshing spinner, and one `<DevotionDownloadedEvent>` data-class-typed bus carrying the kind name + `yyyyMMdd` date). Buses are configured with `extraBufferCapacity = 16, onBufferOverflow = DROP_OLDEST` — `tryEmit` is guaranteed to succeed regardless of buffer pressure, and when bursts exceed the buffer the oldest queued "reload" signal is dropped rather than the newest (which is what a collector catching up actually needs). Preserves LBM's fire-and-forget, in-process, no-replay semantics.
-
-**What was done:**
-
-1. **Senders** — every `App.getLbm().sendBroadcast(new Intent(ACTION_*))` replaced with a `@JvmStatic` emit helper on `AppEvents` (e.g. `AppEvents.emitAttributeMapChanged()`). Touched: `IsiActivity`, `SyncAdapter` (9 call sites), `MarkerListActivity` (4 call sites), `SecretSyncDebugActivity`, `VersionListFragment` (5 call sites), `VersionsActivity`, `VersionConfigUpdaterService`, `VersionDownloadCompleteReceiver`, `DownloadMapper`, `DevotionDownloader`, `ProgressMarkRenameDialog`, `DataTransferFragment`, `DisplayFragment`, `CurrentReading`.
-
-2. **Receivers (Kotlin activities/fragments)** — replaced `BroadcastReceiver` + `registerReceiver`/`unregisterReceiver` with `lifecycleScope.launch { AppEvents.foo.collect { ... } }` in `IsiActivity`, `MarkerListActivity`, `VersionListFragment`. The associated `onDestroy` overrides (only doing `unregisterReceiver`) became no-ops and were deleted.
-
-3. **Receivers (Java activities/fragments)** — added two Java-friendly helpers on `AppEvents`: `observe(LifecycleOwner, Flow<*>, Runnable)` collects until `DESTROYED`, and `observeWhileStarted` (+ typed `observeWhileStartedWithValue`) uses `repeatOnLifecycle(STARTED)` for onStart/onStop-scoped flows. Migrated `MarkersActivity`, `ReadingPlanActivity`, `SyncSettingsActivity.SyncSettingsFragment`, `DailyVerseAppWidgetConfigurationActivity` (lifecycle = DESTROYED) and `DevotionActivity` (lifecycle = STARTED, typed value consumer).
-
-4. **Receivers (Java custom views)** — `LabeledSplitHandleButton.init()` and `LeftDrawer.Text.onFinishInflate` call a third helper, `AppEvents.observeOnView(view, flow, runnable)`. The helper installs an `OnAttachStateChangeListener`: collection starts on attach (launching a fresh `MainScope` job each time) and is cancelled on detach, so a view that's inflated but never attached does not leak a live collector, and a re-attached view automatically resubscribes. Contract: call once per view instance — calling from `onAttachedToWindow` would accumulate a listener per attach cycle.
-
-5. **Stale constants removed** — `IsiActivity.ACTION_ATTRIBUTE_MAP_CHANGED` / `ACTION_ACTIVE_VERSION_CHANGED` / `ACTION_NIGHT_MODE_CHANGED` / `ACTION_NEEDS_RESTART`, `MarkersActivity.ACTION_RELOAD`, `MarkerListActivity.ACTION_RELOAD`, `ReadingPlanActivity.ACTION_READING_PLAN_PROGRESS_CHANGED`, `SyncSettingsActivity.ACTION_RELOAD`, `CurrentReading.ACTION_CURRENT_READING_CHANGED`, `DevotionDownloader.ACTION_DOWNLOADED`, `VersionListFragment.ACTION_RELOAD` / `ACTION_UPDATE_REFRESHING_STATUS` / `EXTRA_refreshing`, plus the private `DevotionDownloader.broadcastDownloaded` helper.
-
-6. **Dependency removed** — `androidx-localbroadcastmanager` deleted from `gradle/libs.versions.toml` and `Alkitab/build.gradle.kts`. `App.getLbm()` helper and the `LocalBroadcastManager` import removed from `App.java`.
-
-Coroutines and `lifecycleScope` were already on the classpath transitively through `androidx.fragment:fragment-ktx:1.8.9` (pulling `kotlinx-coroutines-android:1.9.0` and `lifecycle-runtime-ktx:2.7.0`); no new dependency was needed.
-
-**Verified:** `./gradlew :Alkitab:assemblePlainDebug` plus `testPlainDebugUnitTest testPlainReleaseUnitTest` — all 313 unit tests pass.
-
----
-
-### ~~REM-04: Fix FCM Token Re-registration Retry~~ ✅ COMPLETED (2026-04-22)
-**Addresses:** PB-04  
-**Module:** Sync  
-**BRICE:** B=4 R=4 I=5 C=4 E=4 → **4.2**
-
-**Outcome:** `Sync.sendFcmRegistrationId` now has a two-tier recovery path. In-process: a failed send schedules up to three retries on a single-thread `ScheduledExecutorService` (`fcmRetryExecutor`, daemon) at 1 min / 5 min / 30 min; any retry that succeeds clears the persistent flag and short-circuits the chain. Cross-launch: every send-failure branch (`!response.success`, `IOException | JsonIOException`, `JsonSyntaxException`) sets `Prefkey.fcm_registration_pending = true`, the success branch sets it to `false`, and `App.staticInit()` calls the new `Sync.retryPendingFcmRegistrationIfNeeded(registrationId)` with the FCM id returned by `Fcm.renewFcmRegistrationIdIfNeeded` — so if the in-process chain never completed (e.g. process died, network was off the whole 30 min), the next launch that already has a stored FCM id re-sends it. If no id is stored yet, the existing listener path (`Fcm.renewFcmRegistrationIdIfNeeded(Sync::notifyNewFcmRegistrationId)`) still fires `notifyNewFcmRegistrationId` once registration completes, which then runs its own retry chain.
-
-**What was done:**
-1. ✅ Added `Prefkey.fcm_registration_pending` to `Prefkey.kt` with a kdoc comment describing the contract.
-2. ✅ Added `FCM_RETRY_DELAYS_MS = {1min, 5min, 30min}`, `fcmRetryExecutor` (single-thread, daemon), `pendingFcmRetry` (`AtomicReference<ScheduledFuture<?>>`), and `scheduleFcmRegistrationRetries(registrationId, attemptIndex)` in `Sync.java`. Each scheduled attempt re-reads `Prefkey.sync_simpleToken` so a mid-chain logout stops retrying.
-3. ✅ `notifyNewFcmRegistrationId` now schedules a retry chain when the inline send fails.
-4. ✅ Public `retryPendingFcmRegistrationIfNeeded(@NonNull String registrationId)` reads the pending flag and (if set) re-enters `notifyNewFcmRegistrationId`. Called once from `App.staticInit()` with the id returned by `Fcm.renewFcmRegistrationIdIfNeeded`.
-5. ✅ Bumped all four send-failure log sites in `sendFcmRegistrationId` from `AppLog.d` to `AppLog.w` and added `Preferences.setBoolean(Prefkey.fcm_registration_pending, …)` on each path (`true` on failure, `false` on success).
-
-**Not retried on:** if the response is valid but `success == false` (server explicitly rejected the registration id), the flag is still set and the retry chain still runs. This is intentional — the plan did not distinguish retriable vs. terminal failures, and rejections are rare enough that the extra requests are harmless. If this turns out to generate noise, a future change can key off `response.message`.
-
-**Verified:** `./gradlew :Alkitab:assemblePlainDebug testPlainDebugUnitTest testPlainReleaseUnitTest` — all 313 unit tests pass.
-
----
-
-### REM-05: Refactor DevotionDownloader threading ✅ COMPLETED
-**Addresses:** TD-06 (DevotionDownloader)  
-**Module:** Devotions  
-**BRICE:** B=2 R=3 I=5 C=5 E=5 → **4.0**
-
-**Completed in:** `758793f5` (2026-04-20)
-
-**What was done:**
-1. ✅ Replaced `extends Thread` with a single-thread `ExecutorService` (`Executors.newSingleThreadExecutor()`)
-2. ✅ Replaced `queue_.wait()/notify()` with `LinkedBlockingDeque.take()` — blocking take provides natural backpressure
-3. ✅ Added `shutdown()` method that sets a `volatile boolean shutdown_` flag and calls `executor_.shutdownNow()`; the download loop checks the flag and propagates `InterruptedException` by re-interrupting and breaking out
-4. ✅ Hardcoded `SystemClock.sleep(50)` removed
-5. ✅ HTTP response handling now goes through `Connections.downloadString(url)`, which handles stream cleanup internally
-
-**Remaining:** The broadcast at the end of `downloadLoop` still uses `App.getLbm()` (LocalBroadcastManager). That is tracked separately under REM-03.
-
----
+- [REM-01: Fix SongBookUtil Resource Leak & Unsafe Deserialization](tech-debt-remediation/REM-01-songbookutil-deserialization.md) ✅ **4.6**
+- [REM-02: Fix Preferences hold()/unhold() Safety](tech-debt-remediation/REM-02-preferences-hold-unhold.md) ✅ **4.2**
+- [REM-03: Replace LocalBroadcastManager](tech-debt-remediation/REM-03-localbroadcastmanager.md) ✅ **3.8**
+- [REM-04: Fix FCM Token Re-registration Retry](tech-debt-remediation/REM-04-fcm-token-retry.md) ✅ **4.2**
+- [REM-05: Refactor DevotionDownloader threading](tech-debt-remediation/REM-05-devotion-downloader-threading.md) ✅ **4.0**
 
 ## Phase 2: Architecture Improvements (BRICE 3.0–3.9)
 
-### REM-06: Extract IsiActivity Gesture Handling ✅ COMPLETED
-**Addresses:** TD-01 (gesture cluster)  
-**Module:** Main reader  
-**BRICE:** B=4 R=3 I=3 C=3 E=4 → **3.4**
-
-**What was done:**
-1. ✅ Created `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHandler.kt` (~125 lines). The class implements **three** listener interfaces in one place: `TwofingerLinearLayout.Listener` (split-root pinch + swipe), `GotoButton.FloaterDragListener` (drag-from-goto-button), and `Floater.Listener` (final ari selection).
-2. ✅ Moved the three inline lambda objects out of `IsiActivity.kt`: the `splitRoot_listener` (75 lines, two-finger pinch/scale/dragX/dragY/end + one-finger left/right), `bGoto_floaterDrag` (18 lines, floater drag-start/move/complete), and `floater_listener` (3 lines, ari selection).
-3. ✅ Defined two interfaces following the REM-07 pattern: `ReaderGestureHost.kt` (read-only state — `chapter_1`, `activeSplit0Book`, `activeSplit0Version`, `floater`, `textAppearancePanel`, plus pre-computed `gestureDisplayDensity` and `defaultUkuranHuruf2` to avoid forcing the handler to hold a `Resources` reference) and `ReaderGestureActions.kt` (write-side triggers — `onFloaterAriSelected`, `goToPreviousChapter`, `goToNextChapter`, `applyPreferences`, `setFullScreenWithDrawerHandle`).
-4. ✅ `IsiActivity` now implements both interfaces, holds a `gestureHandler` lazy field, and wires the handler into `splitRoot.setListener`, `bGoto.setFloaterDragListener`, and `floater.setListener` (was previously three different objects).
-5. ✅ Behavior preserved verbatim: split-pane drag, pinch zoom (with the 2f–42f clamp), one-finger left/right chapter swipe, two-finger horizontal drag for multi-chapter skip, two-finger vertical drag toggling fullscreen (paired with `leftDrawer.handle.setFullScreen` under a single new action). Gesture state (`startFontSize`, `startDx`, `moreSwipeYAllowed`, `chapterSwipeCellWidth`, `floaterLocationOnScreen`) now lives on the handler instead of inline objects.
-
-**Result:** `IsiActivity.kt` shrank from 2452 → 2371 lines (−81 lines). Gesture-state fields and 96 lines of listener code are gone from the activity; 13 lines of host/actions implementations remain as the seam between the activity and the new handler.
-
-**What stayed in `IsiActivity`:** the gesture-triggered Activity methods themselves (`bLeft_click`, `bRight_click`, `jumpToAri`, `applyPreferences`, `setFullScreen`) and the existing `leftDrawer.handle.setFullScreen` follow-up call — all wrapped in thin action overrides.
-
-**Files touched:**
-- `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHandler.kt` (new, 125 lines)
-- `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHost.kt` (new, 38 lines)
-- `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureActions.kt` (new, 27 lines)
-- `Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt` (modified: −81 lines, class signature gains two interfaces, four import lines added)
-
-**Difficulty:** Medium (actually 2-3 hours, came in well under the 4-6 hour estimate).
-
----
-
-### REM-07: Extract IsiActivity Action Mode ✅ COMPLETED
-**Addresses:** TD-01 (action mode cluster)  
-**Module:** Main reader  
-**BRICE:** B=4 R=3 I=3 C=3 E=4 → **3.4**
-
-**Completed in:** `89a1894e` (REM-07 refactor) + `716eb1ce` (follow-up split-1 fix, 2026-04-16)
-
-**What was done:**
-1. ✅ Created `VerseActionModeController.kt` (~593 lines) implementing `ActionMode.Callback`. Moved the entire ~500-line `actionMode_callback` object from `IsiActivity.kt` into this class.
-2. ✅ Defined two interfaces: `VerseActionModeHost` (queries activity state — selected verses, versions, book data, chapter) and `VerseActionModeActions` (callbacks back into the activity — navigate, show toasts, etc.)
-3. ✅ Extracted pure text-building logic into `VerseTextFormatter` (no Android dependencies, purely testable under plain JUnit)
-4. ✅ Moved `RibkaEligibility` to a standalone top-level file `RibkaEligibility.kt`
-5. ✅ Added `mockk` to the test classpath. Added 26 unit tests: 11 pure-JUnit tests for `VerseTextFormatterTest`, 15 Robolectric tests for `VerseActionModeControllerTest` (menu visibility rules, click routing)
-6. ✅ Follow-up PR `716eb1ce` fixed the split-1 share URL metadata bug (PB-08) that had been preserved verbatim in the REM-07 refactor. Four regression tests added for copy/share split-0/1 metadata routing.
-
-**Result:** `IsiActivity.kt` shrank from 2894 → 2320 lines (−574 lines). Action mode is now independently testable without instantiating the Activity.
-
-**Difficulty:** Medium (6-8 hours). Risk: action mode references many Activity-level fields and methods.
-
----
-
-### REM-08: Extract IsiActivity Split View Manager ✅ COMPLETED
-**Addresses:** TD-01 (split view cluster)  
-**Module:** Main reader  
-**BRICE:** B=3 R=2 I=3 C=4 E=4 → **3.2**
-
-**What was done:**
-1. ✅ Created `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt` (~367 lines) that owns `activeSplit1` and the split-pane UI: `openSplitDisplay()`, `closeSplitDisplay()`, `configureSplitSizes()`, `displaySplitFollowingMaster()`, `loadSplitVersion()`, `disableSplitVersion()`, `openSplitVersionsDialog()`, `configureTextAppearancePanelForSplitVersion()`, plus `restoreFromPreferences(verse_1)` / `saveToPreferences()` for the `lastSplitVersionId` / `lastSplitOrientation` / `lastSplitProp` round-trip.
-2. ✅ Moved three listener objects out of `IsiActivity.kt`: the `splitRoot_globalLayout` (`OnGlobalLayoutListener` that re-invokes `configureSplitSizes` on bounds change), `splitHandleButton_listener` (drag-prop math + `lastSplitProp` persistence), and `splitHandleButton_labelPressed` (rotate / start / end label-button dispatch).
-3. ✅ Defined two interfaces following the REM-06 / REM-07 pattern: `SplitViewHost.kt` (read-only state — `splitRoot`, `splitHandleButton`, `lsSplit0`, `lsSplit1`, `bVersion`, `leftDrawer`, `textAppearancePanel`, `actionMode`, `chapter_1`, `activeSplit0Book`, `activeSplit0Version`, plus `getVerse_1BasedOnScrolls()`) and `SplitViewActions.kt` (write-side triggers — `applyPreferences`, `openPrimaryVersionsDialog`, `loadChapterIntoSplit1`, `setSplit1DataModel`).
-4. ✅ `IsiActivity` now implements both interfaces, holds a `splitViewManager by lazy { SplitViewManager(this, this) }`, and `onCreate` calls `splitViewManager.installListeners()` (replaces the inline `addOnGlobalLayoutListener` + two handle-button listener setups) and `splitViewManager.restoreFromPreferences(...)` (replaces the 17-line `Preferences.getString(Prefkey.lastSplitVersionId)` restore block). `display(...)` delegates to `splitViewManager.displaySplitFollowingMaster(...)`; `onStop` to `splitViewManager.saveToPreferences()`; `cSplitVersion_checkedChange` to the manager's open/disable methods.
-5. ✅ Moved `ActiveSplit1` from a nested data class inside `IsiActivity` to a top-level data class in `yuku.alkitab.base.widget`. `IsiActivity.activeSplit1` is now a read-only `val` getter that delegates to `splitViewManager.activeSplit1` — every existing call site (audio bar host, action mode host overrides, `applyPreferences` padding logic, `consumeKey` split scrolling, `VerseInlineLinkSpan` xref/footnote routing, Ribka eligibility, etc.) keeps reading `activeSplit1?.version` unchanged.
-6. ✅ Behavior preserved verbatim: split-pane open/close transitions (including `bVersion` show/hide, `leftDrawer.handle.setSplitVersion(...)` toggling, and `actionMode.invalidate()` re-prepare), the split handle drag with proportion clamp and `lastSplitProp` persistence, the rotate-orientation label button, master → split chapter following including the "split version can't display this book" empty-message path, the uncheck-suppression guard around split chapter loads (via the new `loadChapterIntoSplit1` action), text-appearance-panel split version label, and the `lastSplitVersionId` / `lastSplitOrientation` save/restore round-trip across app restarts.
-
-**Result:** `IsiActivity.kt` shrank from 2411 → 2160 lines (−251 lines). Split view is now a self-contained component testable in isolation; `activeSplit1` is read-only from `IsiActivity`'s perspective (all writes happen inside the manager).
-
-**Files touched:**
-- `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt` (new, 367 lines)
-- `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewHost.kt` (new, 43 lines)
-- `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewActions.kt` (new, 28 lines)
-- `Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt` (modified: −251 lines, class signature gains two interfaces, four import lines added, six lateinit vars + `actionMode` + `getVerse_1BasedOnScrolls()` widened to `override`)
-
-**Verification:**
-- `./gradlew assemblePlainDebug` → BUILD SUCCESSFUL in 14s (cold) / 5s (warm)
-- `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` → BUILD SUCCESSFUL, 420 tests pass per variant
-
-**Difficulty:** Medium (came in around the lower end of the 4-6 hour estimate). The fan-out of `activeSplit1` references was the main risk; addressed by keeping a read-through getter on the activity so no call site outside the moved methods had to change.
-
----
-
-### REM-09: Introduce ViewModel for IsiActivity
-**Addresses:** TD-07  
-**Module:** Main reader  
-**BRICE:** B=4 R=3 I=2 C=3 E=5 → **3.4**
-
-**Steps:**
-1. Create `IsiViewModel : ViewModel()` with:
-   - `activeVersion: StateFlow<MVersion>`
-   - `currentAri: StateFlow<Int>`
-   - `versesDataModel: StateFlow<VersesDataModel>`
-   - `selectedVerses: StateFlow<Set<Int>>`
-   - `splitVersion: StateFlow<MVersion?>`
-2. Move version loading, chapter display logic, and verse selection state from `IsiActivity` into `IsiViewModel`
-3. `IsiActivity` observes StateFlows and updates UI
-4. Navigation history moves to ViewModel (survives rotation)
-
-**Prerequisite:** ~~REM-06~~✅, ~~REM-07~~✅, ~~REM-08~~✅ should be done first to reduce IsiActivity size before extracting ViewModel.
-
-**Difficulty:** Hard (2-3 days). Risk: extensive refactoring of the largest file in the codebase.
-
----
-
-### REM-24: Refactor S.kt Service Locator — Steps 24a–24d complete 2026-05-12
-**Addresses:** TD-15  
-**Module:** Cross-cutting (50 files)  
-**BRICE:** B=4 R=2 I=2 C=3 E=5 → **3.2**
-
-**Status:** Steps 24a (interface extraction), 24b (UI dialog removal), 24c (thread-safety fix), and 24d (AppServices container + caller migration) all complete as of 2026-05-12. ~216 direct `S.xxx` references across 44 files migrated to `App.services.*`. The `S` adapter properties (`S.storage`, `S.versions`, `S.uiDimensions`) and the legacy `@JvmStatic` accessors are retained so any new caller written against `S.foo` keeps compiling; new code should prefer `App.services`. 24e (Hilt) is still optional/deferred.
-
-**24d caller-migration follow-up shipped 2026-05-12:**
-- `App.services` is now initialized eagerly at the static field declaration in `App.java` rather than only inside `staticInit()`. This keeps `App.services.*` non-null for callers that exercise migrated code in tests that deliberately bypass `App.onCreate()` / `App.staticInit()` (e.g. `ProviderTest`, `VerseRendererTest`'s setup). The adapter objects on `S` only touch context/preferences when their methods are invoked, so eager init is safe before `App.context` is set.
-- `AppServices`'s `storage` / `versions` / `uiDimensions` fields are annotated `@JvmField` so Java callers can write `App.services.versions.activeVersion()` (matching Kotlin syntax) instead of `App.services.getVersions().activeVersion()`.
-- One deliberately un-migrated call site remains: the `S.db.listAllVersions().isEmpty()` check inside `IsiActivity.openVersionsDialog`. The rest of that method already uses `App.services.versions`; the single `S.db` line is left for the next person touching that method to migrate, to keep diffs cohesive.
-
-**What shipped on 2026-05-12:**
-- New `yuku.alkitab.base.services` package with `StorageProvider`, `VersionManager`, `UiDimensionsProvider`, and `AppServices` (see `Alkitab/src/main/java/yuku/alkitab/base/services/`).
-- `S` exposes three adapter properties (`S.storage`, `S.versions`, `S.uiDimensions`) that implement the new interfaces. `@JvmStatic` is retained on the original `S.db`, `S.applied()`, `S.activeVersion()` etc. so existing Java call sites keep compiling — these are the migration target for the rest of 24d.
-- `openVersionsDialog` / `openVersionsDialogWithNone` moved off `S` into `yuku.alkitab.base.util.VersionDialogHelper`. Callers in `IsiActivity.kt` and `SearchActivity.kt` were updated.
-- `recalculateAppliedValuesBasedOnPreferences()` renamed to `recalculate()` to match the interface (single call site in `IsiActivity.kt`).
-- Active-version state collapsed from three mutable nullable fields to a single `@Volatile var state: ActiveVersionState` data-class reference so all readers see a consistent `(mVersion, version, versionId)` triple.
-- `App.staticInit()` now constructs `App.services = new AppServices(S.storage, S.versions, S.uiDimensions)` before any other init step.
-- `AppServicesTest` (4 cases) demonstrates the new interfaces are fake-implementable in pure JUnit — no Robolectric or Android context required.
-
-**Current state:** `S.kt` (313 lines) is a Kotlin `object` singleton mixing database access (`db`, `songDb`), active version state, and UI dimensions (`CalculatedDimensions`). Imported by 50 files with 161+ call sites. Untestable without a full Android environment.
-
-**Recommended approach: Incremental interface extraction, then manual DI**
-
-Hilt/Dagger adds significant complexity (annotation processing, code generation) for a codebase that doesn't yet use any DI. A lighter approach is to extract interfaces first, then provide them via a simple app-level container.
-
-**Steps:**
-
-**Step 24a: Extract interfaces (no DI yet, no callers change)**
-1. Create `StorageProvider` interface:
-   ```kotlin
-   interface StorageProvider {
-       val db: InternalDb
-       val songDb: SongDb
-   }
-   ```
-2. Create `VersionManager` interface:
-   ```kotlin
-   interface VersionManager {
-       fun activeVersion(): Version
-       fun activeMVersion(): MVersion
-       fun activeVersionId(): String
-       fun setActiveVersion(mv: MVersion)
-       fun getVersionFromVersionId(versionId: String?): MVersion?
-       fun getAvailableVersions(): List<MVersion>
-       fun getMVersionInternal(): MVersionInternal
-   }
-   ```
-3. Create `UiDimensionsProvider` interface:
-   ```kotlin
-   interface UiDimensionsProvider {
-       fun applied(): CalculatedDimensions
-       fun recalculate()
-   }
-   ```
-4. Make `S` implement all three interfaces, delegating to its existing internal holders. This is a no-op refactor — all existing `S.db` / `S.applied()` / `S.activeVersion()` calls keep working.
-
-**Step 24b: Move UI dialogs out of S**
-1. Move `openVersionsDialog()` and `openVersionsDialogWithNone()` (lines 271-320) into a standalone `VersionDialogHelper` object or extension function. These are UI operations that don't belong in a service locator.
-
-**Step 24c: Fix thread safety**
-1. Make `activeVersion()` / `activeMVersion()` / `activeVersionId()` getters `@Synchronized` to match the setter
-2. Or better: replace the three mutable fields with a single `AtomicReference<ActiveVersionState>` data class to ensure atomic reads
-
-**Step 24d: Introduce app-level service container**
-1. Create `AppServices` class initialized in `App.onCreate()`:
-   ```kotlin
-   class AppServices(
-       val storage: StorageProvider,
-       val versions: VersionManager,
-       val uiDimensions: UiDimensionsProvider,
-   )
-   ```
-2. Initialize in `App`: `val services = AppServices(S, S, S)` — initially delegates back to `S`
-3. New code uses `App.services.storage.db` instead of `S.db`
-4. Gradually migrate existing callers (50 files, can be done file-by-file)
-5. In tests, provide fake implementations of the interfaces
-
-**Step 24e: (Optional, later) Migrate to Hilt**
-If the project adopts Hilt for other reasons (e.g., ViewModel injection in REM-09), the interfaces from Step 24a become `@Provides` targets naturally.
-
-**Difficulty:** Medium-Hard (2-3 days for steps 24a-24c, then ongoing migration for 24d). Step 24a is the critical enabler — once interfaces exist, the rest is incremental.
-
----
-
-### REM-10: Migrate InternalDb to Room (Markers Table) ✅ COMPLETED (2026-05-14)
-**Addresses:** TD-02  
-**Module:** Storage — Markers subsystem  
-**BRICE:** B=4 R=3 I=2 C=3 E=5 → **3.4**
-
-**Outcome.** All three legacy hand-rolled SQLite tables — `Marker`, `Label`, `Marker_Label` — are now backed by Room in `AlkitabRoomDb` (the same separate-file Room database REM-11 introduced). `AppDatabase` bumped `version = 1 → 2`; the SQL inside `MIGRATION_1_2` mirrors what Room's entity definitions emit (verified by `MigrationTestHelper.runMigrationsAndValidate` with `validateDroppedTables = true`).
-
-**Shipped:**
-- **Entities:** `MarkerEntity.kt` / `LabelEntity.kt` / `MarkerLabelEntity.kt` mirror the legacy columns. Indexes match the legacy ones with one exception — the legacy `index_Marker_05 (kind, caption COLLATE NOCASE)` is dropped because Room's `@Index` does not support per-column collation; the only caller (`InternalDb.listMarkers` caption sort) falls back to SQLite's in-memory sort, which is negligible at realistic marker volumes (hundreds, max).
-- **Room DAOs:** `MarkerRoomDao.kt` / `LabelRoomDao.kt` / `MarkerLabelRoomDao.kt`. `LabelRoomDao` carries the pair-wise `reorderById` shift inside a `@Transaction`. `MarkerRoomDao` exposes a `@RawQuery` escape hatch (`listMarkersRaw`) for `InternalDb.listMarkers`'s dynamic `ORDER BY` + optional join; the facade whitelists the four valid sort columns (`createTime` / `modifyTime` / `ari` / `caption`) before composing the SQL.
-- **Schema bump:** `AppDatabase.kt` now `@Database(version = 2)` with `@JvmField val MIGRATION_1_2`. `Alkitab/schemas/yuku.alkitab.base.storage.room.AppDatabase/2.json` is checked in alongside the existing `1.json`.
-- **Data migration:** `MarkerDataMigration.kt` — idempotent one-time copy from the legacy three tables into Room, running inside a single `roomDb.runInTransaction { ... }` so the three tables move atomically (Gemini-correct on REM-11). Idempotency uses a combined `marker + label + marker_label` count check so that a legacy state with labels-but-no-markers (or vice versa) doesn't double-copy on retry. Translates the legacy Indonesian column names (`judul` / `urutan` / `warnaLatar`) to the Room schema's English equivalents (`title` / `ordering` / `backgroundColor`). Wired into `S.kt`'s `db` lazy initializer next to `VersionDataMigration`.
-- **Facade preservation:** `MarkerDao.kt` / `LabelDao.kt` / `Marker_LabelDao.kt` rewritten to delegate to the Room DAOs, mapping between Room entities and the `Marker` / `Label` / `Marker_Label` model classes. Public method signatures unchanged — call sites in `IsiActivity`, `MarkerListActivity`, sync code, etc. did not need to be touched.
-- **InternalDb rewrites:** Seven raw-SQL methods rewritten to use Room: `listMarkers`, `deleteMarkerById`, `putAttributes`, `updateOrInsertPartialHighlight`, `updateOrInsertHighlights`, `getHighlightColorRgb` (both overloads), `updateLabels`, `deleteLabelAndMarker_LabelsByLabelId`, `sortLabelsAlphabetically`, `reorderLabels`. Transactional flows that previously used `helper.getWritableDatabase().beginTransactionNonExclusive()` now use `AppDatabase.get(App.context).runInTransaction(...)`. Removed unused imports (`Cursor`, `SQLiteDatabase`, `DatabaseUtils`, `ContentValues`, `Sqlitil`, `Literals.Array`, `Literals.ToStringArray`).
-- **Legacy tables left in place.** `Marker` / `Label` / `Marker_Label` are still created by `InternalDbHelper.onCreate` so the rollback safety net is preserved; a future release can drop them once the Room path has baked.
-
-**Tests (4 new files, 1 updated, 1 InternalDbTest extended):**
-- `MarkerRoomDaoTest.kt` (13 tests) — Room-level primitives: range queries inclusive/exclusive bounds, ordering, `@RawQuery` bridge with and without `marker_label` joins.
-- `LabelRoomDaoTest.kt` (10 tests) — `reorderById` move-up / move-down / no-op, `listByMarkerGid` cross-join order.
-- `MarkerLabelRoomDaoTest.kt` (10 tests) — cascade-helper deletes by marker_gid / label_gid, count-by-label, gid uniqueness.
-- `MarkerDataMigrationTest.kt` (8 tests) — empty/full copies, idempotency, no-stomp-on-existing-Room-rows, fresh `_id` assignment, atomic copy of all three tables.
-- `AppDatabaseMigrationTest.kt` — added the real `migrates1To2` test (replacing the scaffold) plus an end-to-end open-via-Room round-trip after migrating from v1; the existing v1-schema sanity test now passes `MIGRATION_1_2` to the builder so the v1 → current open succeeds.
-- `InternalDbTest.kt` — `@Before` now installs an in-memory `AppDatabase` via `AppDatabase.setForTesting` (necessary harness change because the facade DAOs route through Room), and 4 new tests cover the `listMarkers` `@RawQuery` branches: `label_id == 0`, `label_id == LABELID_noLabel`, label-filtered, and the case-insensitive caption sort.
-
-**Verification.** `./gradlew :Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest` — 494 tests, all green. `./gradlew :Alkitab:assemblePlainDebug` produces a working APK. On-device smoke (Pixel emulator API 35, pre-existing dataset of 1456 markers / 18 labels / 152 marker_label associations from a v1 Room install): installing the new APK ran `MarkerDataMigration` once on first launch (logged `Copied 1456 marker(s), 18 label(s), 152 marker_label row(s) from legacy tables to Room`), counts match the legacy table exactly, second launch is idempotent (no row growth), spot-check confirms `gid` / `ari` / `caption` round-trip verbatim.
-
-**Difficulty:** Hard. Took ~1 day with the REM-11 pattern already established. Subsequent tables (`ReadingPlan`, `Devotion`, `SyncShadow`, `SyncLog`, `PerVersion`, `ProgressMark`) can follow the same pattern.
-
----
-
-### ~~REM-11: Migrate InternalDb to Room (Version Table)~~ ✅ COMPLETED (2026-05-13)
-**Addresses:** TD-02  
-**Module:** Storage — Versions subsystem  
-**BRICE:** B=3 R=2 I=3 C=3 E=5 → **3.2**
-
-**Outcome.** The legacy hand-rolled `Version` table is now backed by Room in a new, separate-file database (`AlkitabRoomDb`) at `yuku.alkitab.base.storage.room.AppDatabase` (`@Database(version = 1)` at landing; later bumped to v2 by REM-10). A separate file avoids the `user_version` collision with `InternalDbHelper`'s versionCode-driven schema — see `docs/superpowers/specs/2026-05-13-rem-11-room-version-table-design.md`.
-
-**Shipped:**
-- **Entities and DAO:** `VersionEntity.kt` mirrors the legacy columns; `VersionRoomDao.kt` exposes `listAllOrderedByOrdering()`, `getById()`, `insertOrUpdate()`, `deleteByPresetName()`, and the active-flag / ordering helpers.
-- **Data migration:** `VersionDataMigration.kt` — idempotent one-time copy from the legacy `Version` table into Room, wired into `S.db`'s lazy initializer.
-- **Facade preservation:** `VersionDao.kt` (under `storage/`) now delegates to Room, mapping `VersionEntity` ↔ `MVersionDb`. `InternalDb.listAllVersions()` and related methods continue to work unchanged.
-- **Legacy table left in place** as a rollback safety net; a future release can drop it once the Room path has baked.
-
-**Verification.** Migration test scaffolding via `MigrationTestHelper` (added separately) plus `VersionRoomDaoTest.kt` and `VersionDataMigrationTest.kt`. Schema JSON checked in at `Alkitab/schemas/yuku.alkitab.base.storage.room.AppDatabase/1.json`.
-
-**Difficulty:** Medium (1-2 days). Lower risk than Markers since the Version table is simpler.
-
----
-
-### REM-12: Replace DragSortListView with ItemTouchHelper ✅ COMPLETED
-**Addresses:** TD-12  
-**Module:** Markers (label management)  
-**BRICE:** B=2 R=2 I=4 C=4 E=5 → **3.4**
-
-**Completed changes:**
-- `MarkersActivity.java` rewritten to use `RecyclerView` + custom `ItemTouchHelper.Callback` (drag-handle initiated via `startDrag`, divider guarded via `getMovementFlags` and `canDropOver`). Native context menu replaced with a `PopupMenu` shown on long-press.
-- `VersionListFragment.kt` converted to `RecyclerView.Adapter<VersionItemHolder>` with `ItemTouchHelper` installed only when `downloadedOnly == true`.
-- DB persistence still uses the existing pair-wise `reorderLabels` / `reorderVersions`. Instead of committing on every `onMove`, the adapter snapshots its item list at drag start and issues a single reorder call in `clearView` using `snapshot[startPos]` and `snapshot[endPos]`.
-- Translucent-white drag overlay (`0x22ffffff`) preserved via `onSelectedChanged` / `clearView`.
-- Three layouts (`activity_markers.xml`, `fragment_versions_all.xml`, `fragment_versions_downloaded.xml`) switched to `androidx.recyclerview.widget.RecyclerView`.
-- `DragSortListView` module removed from `settings.gradle`, `Alkitab/build.gradle`, and the filesystem.
-
-**Difficulty:** Easy-Medium (4-6 hours).
-
----
-
-### ~~REM-14: Replace material-dialogs with Material 3~~ ✅ COMPLETED
-**Addresses:** TD-12  
-**Module:** Cross-cutting UI  
-**BRICE:** B=2 R=3 I=3 C=4 E=5 → **3.4**
-
-**Completed in:** `ca9a9138` (PR #140)
-
-**Outcome:** All `com.afollestad.materialdialogs` usages replaced with `MaterialAlertDialogBuilder` (Material 3). The `material-dialogs` dependencies are gone from the build, and no remaining imports exist in the codebase.
-
----
+- [REM-06: Extract IsiActivity Gesture Handling](tech-debt-remediation/REM-06-isiactivity-gestures.md) ✅ **3.4**
+- [REM-07: Extract IsiActivity Action Mode](tech-debt-remediation/REM-07-isiactivity-action-mode.md) ✅ **3.4**
+- [REM-08: Extract IsiActivity Split View Manager](tech-debt-remediation/REM-08-isiactivity-split-view.md) ✅ **3.2**
+- [REM-09: Introduce ViewModel for IsiActivity](tech-debt-remediation/REM-09-isiactivity-viewmodel.md) — **3.4**
+- [REM-10: Migrate InternalDb to Room (Markers Table)](tech-debt-remediation/REM-10-room-markers.md) ✅ **3.4**
+- [REM-11: Migrate InternalDb to Room (Version Table)](tech-debt-remediation/REM-11-room-version.md) ✅ **3.2**
+- [REM-12: Replace DragSortListView with ItemTouchHelper](tech-debt-remediation/REM-12-itemtouchhelper.md) ✅ **3.4**
+- [REM-14: Replace material-dialogs with Material 3](tech-debt-remediation/REM-14-material-dialogs.md) ✅ **3.4**
+- [REM-18: Add Test Coverage for Core Modules](tech-debt-remediation/REM-18-test-coverage.md) ✅ **3.4**
+- [REM-23: Port ybuild.sh to Gradle](tech-debt-remediation/REM-23-ybuild-gradle.md) ✅ **3.8**
+- [REM-24: Refactor S.kt Service Locator](tech-debt-remediation/REM-24-s-service-locator.md) ✅ (24a–24d done) **3.2**
 
 ## Phase 3: Modernization (BRICE 2.5–3.0)
 
-### REM-15: Introduce Kotlin Coroutines
-**Addresses:** TD-06 (threading)  
-**Module:** Cross-cutting  
-**BRICE:** B=4 R=2 I=2 C=3 E=5 → **3.2**
-
-**Steps — incremental by module:**
-
-**Step 15a: Sync module**
-1. Add `kotlinx-coroutines-android` dependency
-2. Convert `SyncAdapter` (WorkManager `Worker`) to `CoroutineWorker`
-3. Replace `Thread`-based sync execution with `withContext(Dispatchers.IO)`
-4. Add `supervisorScope` for independent entity sync (markers, pins, history can fail independently)
-
-**Step 15b: Devotion downloads**
-1. Replace `DevotionDownloader` thread with a coroutine-based downloader using `Channel`
-2. Use `flow {}` for download progress tracking
-3. Integrate with `DevotionActivity` via `lifecycleScope`
-
-**Step 15c: Search engine**
-1. Wrap `SearchEngine.searchByGrep()` in `withContext(Dispatchers.Default)`
-2. Add `yield()` between book iterations for cancellation support
-3. Return results via `Flow<SearchResult>` for progressive display
-
-**Step 15d: Version loading**
-1. Make `Version.loadChapterText()` suspending or wrap in `Dispatchers.IO`
-2. IsiActivity display pipeline becomes: `viewModelScope.launch { loadAndDisplay() }`
-
-**Difficulty:** Hard (1-2 weeks total, but can be done module-by-module over time).
-
----
-
-### REM-16: Convert Core Java Files to Kotlin
-**Addresses:** TD-11  
-**Module:** Various  
-**BRICE:** B=3 R=1 I=3 C=3 E=5 → **3.0**
-
-**Steps — ordered by value and risk (lowest risk first):**
-
-| Priority | File | Lines | Risk | Notes |
-|----------|------|-------|------|-------|
-| 1 | ~~`Highlights.java`~~ | ~~~200~~ | ~~Low~~ | ✅ ported to `Highlights.kt` (2026-05-12). `object` with `@JvmStatic` methods and `@JvmField` properties to preserve Java call sites; 5 Kotlin callers got `!!` on `Info.partial` (now properly nullable). All 31 `HighlightsTest` cases + full unit-test suite pass. |
-| 2 | ~~`TargetDecoder.java`~~ | ~~~150~~ | ~~Low~~ | ✅ ported to `TargetDecoder.kt` (2026-05-13). `object` with `@JvmStatic decode()`; returns non-nullable `IntArrayList` (empty on error) to preserve call sites. |
-| 3 | ~~`Jumper.java`~~ | ~~~200~~ | ~~Low~~ | ✅ ported to `Jumper.kt` on 2026-05-12; behavior preserved, JumperTest + full unit suite pass |
-| 4 | ~~`QueryTokenizer.java`~~ | ~~~100~~ | ~~Low~~ | ✅ ported to `QueryTokenizer.kt` (2026-05-13). `object` with `@JvmStatic` on all public methods; `tokenize()` accepts `String?` for backwards-compatible null handling. |
-| 5 | ~~`DevotionDownloader.java`~~ | ~~111~~ | ~~Low~~ | ✅ ported to `DevotionDownloader.kt` (2026-05-13). Regular Kotlin class with `@Synchronized`/`@Volatile` annotations, `::downloadLoop` method reference. |
-| 6 | ~~`Provider.java`~~ | ~~~200~~ | ~~Medium~~ | ✅ ported to `Provider.kt` (2026-05-13). `open class` (needed for test anonymous subclass); `companion object` for constants and static `uriMatcher`; `when` replaces `switch`. |
-| 7 | ~~`SongBookUtil.java`~~ | ~~219~~ | ~~Medium~~ | ✅ ported to `SongBookUtil.kt` (2026-05-13). `object` with nested interfaces/classes; `@JvmStatic` on all public methods; `@JvmField` on `SongBookInfo` fields. |
-| 8 | ~~`VerseRenderer.java`~~ | ~~423~~ | ~~Medium~~ | ✅ ported (REM-26) |
-| 9 | ~~`SearchEngine.java`~~ | ~~537~~ | ~~Medium~~ | ✅ ported to `SearchEngine.kt` (2026-05-13). `object` with nested `ReadyTokens` class; `@JvmStatic` on public methods; `searchByGrep()` returns non-nullable `IntArrayList`; `sortWith` replaces `Arrays.sort`. |
-| 10 | `Sync.java` | 508 | High | Threading + network, many call sites |
-| 11 | `InternalDb.java` | 1771 | High | Core database, skip if doing Room migration (REM-10) |
-
-Use Android Studio's "Convert Java File to Kotlin" as a starting point, then manually clean up:
-- Replace `@Nullable`/`@NonNull` with Kotlin nullability
-- Replace `static` methods with top-level or companion object
-- Replace `for` loops with `forEach`/`map`
-- Replace `switch` with `when`
-- Use data classes where appropriate
-
-**Difficulty:** Varies (1 hour to 1 day per file depending on size). Do alongside other changes to avoid merge conflicts.
-
----
-
-### ~~REM-17: Migrate Build to Kotlin DSL & Version Catalogs~~ ✅ COMPLETED (2026-04-20)
-**Addresses:** TD-12 (build system)  
-**Module:** Build  
-**BRICE:** B=2 R=1 I=3 C=4 E=5 → **3.0**
-
-**Outcome:**
-- Created `gradle/libs.versions.toml` centralising all 30+ dependency versions, 20+ library coordinates, and 8 plugin IDs. Firebase BOM dependencies declared without version (BOM-managed). SDK integer versions (`compileSdk`, `minSdk`, `targetSdk`) stored as strings and accessed via `.get().toInt()` in build files.
-- `settings.gradle` → `settings.gradle.kts`: added `pluginManagement` and `dependencyResolutionManagement` (with `FAIL_ON_PROJECT_REPOS`) so all repository declarations are centralised in one place. `jitpack.io` (needed for `FancyShowCaseView`) declared there. Foojay toolchain resolver kept inline (version catalog not yet available at settings `plugins {}` eval time).
-- Root `build.gradle` → `build.gradle.kts`: replaced `buildscript` + `allprojects` with a lean `plugins { ... apply false }` block. The `ext {}` block is gone — all versions live in the catalog.
-- `Alkitab/build.gradle` → `Alkitab/build.gradle.kts`: `CopyProprietaryAssetsTask` converted to Kotlin abstract class with `@Inject constructor(private val fs: FileSystemOperations)`. `firebaseApiKeyProblem` converted to a top-level function with `@Suppress("UNCHECKED_CAST")`. `String.capitalize()` (deprecated in Kotlin 2.x) replaced with `replaceFirstChar { it.uppercaseChar() }`. All `$androidxActivityVersion` ext references replaced with `libs.androidx.activity.ktx` catalog accessors. Server-host constants (`SERVER_HOST`, `RIBKA_FUNCTIONS_HOST`, `RIBKA_FUNCTIONS_HOST_DEBUG`) inlined as `val` in this file and duplicated in `AlkitabFeedback` (only two consumers; no ext lookup needed).
-- All 15 library module `build.gradle` files converted to Kotlin DSL. `apply plugin:` replaced with `alias(libs.plugins.*)`. `compileSdkVersion`/`minSdkVersion`/`targetSdkVersion` methods replaced with `compileSdk`/`minSdk`/`targetSdk` property assignments. `minifyEnabled` → `isMinifyEnabled`, `shrinkResources` → `isShrinkResources`. Stale `repositories {}` blocks in `AlkitabYes2` and `AlkitabFeedback` removed (centralised in settings). `kotlin-android` / `kotlin-parcelize` plugin IDs replaced with their full `org.jetbrains.kotlin.*` IDs.
-- `apply plugin: 'com.google.gms.google-services'` (legacy bottom-of-file pattern) moved to the `plugins {}` block at the top of `Alkitab/build.gradle.kts`.
-
-**Difficulty:** Medium (1-2 days). Mostly mechanical but Groovy-specific constructs need manual translation.
-
----
-
-### ~~REM-18: Add Test Coverage for Core Modules~~ ✅ COMPLETED (2026-05-11)
-**Addresses:** TD-13  
-**Module:** Cross-cutting  
-**BRICE:** B=4 R=3 I=2 C=3 E=5 → **3.4**
-
-**Outcome:** All six sub-steps shipped — see per-step entries below. Cumulatively this added ~170 unit tests across `HighlightsTest`, the four `Sync*Test` files, `InternalDbTest`, `SearchEngineTest`, `Yes2RoundTripTest` + `SnappyStreamRoundTripTest`, and `ProviderTest`, plus latent-bug fixes in `Highlights.alphaMix`, `Sync_Pins.Content.equals/hashCode`, and a flagged `SnappyInputStream` EOF edge. Robolectric (`4.14.1`) is now a `testImplementation` dependency on `Alkitab`, and test-scope shadows for `android.util.Log` / `FirebaseCrashlytics` / `android.util.Pair` unblock further pure-JUnit work on Android-touching code.
-
-**Steps — prioritized by risk coverage:**
-
-**Step 18a: Highlight encoding tests** ✅ COMPLETED
-**Completed in:** `513961b9` / `1ca73821` (2026-04-16)
-1. ✅ Added 31 unit tests in `HighlightsTest.kt`: encode/decode round-trip, hash verification, partial-highlight guard, alphaMix with ARGB input
-2. ✅ Fixed `Highlights.alphaMix()` ARGB leak: changed `0xa0000000 | colorRgb` to `0xa0000000 | (colorRgb & 0x00ffffff)` so the output alpha is always `0xA0` regardless of what the caller passes
-3. ✅ Added test-scope no-op shadows for `android.util.Log` and `com.google.firebase.crashlytics.FirebaseCrashlytics` — these unblock all future Alkitab module unit tests that touch `AppLog`
-
-**Step 18b: Sync protocol tests** ✅ COMPLETED
-**Completed in:** `b4bce934` (2026-04-16)
-1. ✅ Added 101 unit tests across `SyncDeltaTest.kt`, `Sync_MabelTest.kt`, `Sync_PinsTest.kt`, `Sync_RpTest.kt` — covers `SyncAdapter.patchNoConflict` delta application (add/mod/del, missing GIDs, conflict, idempotency), `Sync.entitiesEqual`, `SyncUtils.findEntity/isSameContent`, `Sync_Mabel.updateMarker/Label/Marker_Label`, and `Content equals/hashCode/toString` for all three sync sets
-2. ✅ Fixed `Sync_Pins.Content.equals()`: was sorting copies but comparing the original unsorted lists — now compares sorted copies. Fixed `hashCode()` to match order-insensitive equals (violations would cause misbehavior inside `HashMap`/`HashSet`)
-3. ✅ Added test-scope stub for `android.util.Pair` so `patchNoConflict` runs without Robolectric
-
-**Step 18c: InternalDb tests (or Room DAO tests)** ✅ COMPLETED
-1. ✅ Added Robolectric (`4.14.1`) as a `testImplementation` dependency and enabled `testOptions.unitTests.includeAndroidResources` in `Alkitab/build.gradle` — Robolectric is required because `InternalDbHelper` extends Android's `SQLiteOpenHelper`
-2. ✅ Added `InternalDbTest.kt` under `Alkitab/src/test/java/yuku/alkitab/base/storage/` using `RobolectricTestRunner` with `@Config(application = Application::class)` so `yuku.alkitab.base.App.onCreate` (Firebase / PRDownloader / FCM) doesn't run. Reuses the existing test-scope shadows of `android.util.Log` and `com.google.firebase.crashlytics.FirebaseCrashlytics` (added in REM-18a) so `AppLog`'s static initializer loads without bootstrapping Firebase. `yuku.afw.App.context` is set manually in `@Before`; because no `sync_simpleToken` preference is present, `Sync.notifySyncNeeded` early-returns and no background work fires
-3. ✅ Test names follow the Kotlin backtick-sentence convention from CLAUDE.md. Covers marker CRUD (`insertMarker`, `insertOrUpdateMarker`, `getMarkerById/Gid`, `listMarkersForAriKind`, `listAllMarkers`, `deleteMarkerById` with cascade to `Marker_Label`, `countMarkersForBookChapter`), label ordering (`insertLabel`, `getLabelMaxOrdering`, `reorderLabels` up/down, `sortLabelsAlphabetically`, `listLabelsByMarker` ordering), highlight storage (`updateOrInsertHighlights` insert/update/delete, `updateOrInsertPartialHighlight` including dedup of sync-duplicates, `getHighlightColorRgb` single/multi-verse), and attribute loading (`putAttributes` bookmarks, notes, multi-verse highlight spread, ordering by `modifyTime`, book-chapter filtering)
-
-**Step 18d: SearchEngine tests** ✅ COMPLETED
-1. ✅ Unit tests added in `SearchEngineTest.kt` — covers `ReadyTokens` construction, `satisfiesTokens`, and end-to-end `searchByGrep` against a small in-memory fake `Version`. Exercises single token, multi-token (AND) intersection, whole-word matching, quoted phrases (multiword), book-id filtering, duplicate-token de-duplication, and cross-verse-boundary rejection.
-2. ✅ Runs under `RobolectricTestRunner` so `android.util.SparseBooleanArray` is a real implementation rather than the "not mocked" stub. `AppLog` is kept quiet via the existing test-scope shadows (`android.util.Log`, `FirebaseCrashlytics`) introduced for `HighlightsTest`.
-3. Difficulty: Medium (4-6 hours)
-
-**Step 18e: YES2 reader/writer round-trip tests** ✅ COMPLETED
-1. ✅ Added `Yes2RoundTripTest.kt` (12 tests) and `SnappyStreamRoundTripTest.kt` (4 tests) under `AlkitabYes2/src/test/java/`. Round-trip covers: single-book uncompressed read-back of every verse; multi-book boundaries (Genesis / Exodus / Revelation) preserving book ordering and chapter offsets; BMP UTF-8 content (Indonesian, Greek, Hebrew, extended Latin) — limited to U+FFFF because `Utf8Decoder` is documented as "intentionally incomplete" and does not support 4-byte UTF-8 sequences; `dontSeparateVerses` newline-joined form; `lowercase` flag; out-of-range chapter returns null; pericope round-trip with parallels and ARI-keyed lookup; pericope empty-chapter and no-pericope-section cases; missing xref / footnote sections return null.
-2. ✅ Snappy-compressed text section round-trip: writes multi-block compressed Bible text and verifies every verse decodes identically; separately verifies that a compressed file is strictly smaller than the uncompressed equivalent for highly-repetitive text.
-3. ✅ Direct `SnappyOutputStream` / `SnappyInputStream` round-trip: single-block, multi-block (4 blocks with partial trailing block), mid-block `seek` crossing block boundaries, and compression-ratio check on highly-repetitive input (each 4 KB block compresses to under 400 bytes via the pure-Java codec).
-4. ✅ Added a test-scope `android.util.Log` shadow at `AlkitabYes2/src/test/java/android/util/Log.java` — mirrors the one in the Alkitab module so direct `Log.e` calls in `Yes2Reader`, `SectionIndex`, and the xref/footnote sections don't trigger "Method not mocked" during plain JUnit.
-5. The tests exposed a latent bug in `SnappyInputStream`: after the last byte of the last block is read, calling `read()` again increments `current_block_index` past the end and throws `ArrayIndexOutOfBoundsException` instead of returning -1. Production callers in `Yes2Reader.TextSectionReader.loadVerseText` always read exact-length ranges derived from verse `varuint` lengths, so they never hit EOF this way. Flagged in-file rather than silently worked around; see `SnappyStreamRoundTripTest.kt`.
-
-**Step 18f: Content provider tests** ✅ COMPLETED (2026-05-11)
-1. ✅ Added `ProviderTest.kt` (14 tests) under `Alkitab/src/test/java/yuku/alkitab/base/cp/` exercising every URI path the read-only [`Provider`](../Alkitab/src/main/java/yuku/alkitab/base/cp/Provider.java) supports: single-verse by ARI (with `_id`, `ari`, book short name, and verse-text assertions), single-verse by LID (resolved via `LidToAri`), range by ARI within a single chapter, range by ARI crossing a chapter boundary, range by ARI crossing a book boundary, range by LID, whole-chapter shorthand (`bbcc00-bbcc00` → all verses in that chapter), and the `bible/versions` listing query (asserts the internal version row using `AppConfig.get()` for `shortName` / `longName` / `description`).
-2. ✅ Pinned the contract edges: `formatting=0` (default) strips inline formatting codes via `FormattedVerseText.removeSpecialCodes`, `formatting=1` returns the raw verse text including codes, out-of-range `bookId` (single or range) returns an empty `MatrixCursor` rather than null, an unknown URI path returns null, and `getType` returns null for every URI (production behaviour — `Provider.getType` is hardcoded to null).
-3. ✅ Same Robolectric setup as steps 18c/d: `@Config(application = Application::class)` to skip `App.onCreate`; existing test-scope shadows of `android.util.Log` and `FirebaseCrashlytics` keep `AppLog` quiet; `yuku.afw.App.context` is wired in `@Before`. The fake `MVersion` returns an anonymous `Version` subclass with two books, three chapters, and one verse carrying real `@@` / `@9` / `@7` formatting codes; `S.setActiveVersion(fakeMv)` overwrites the active version after `ActiveVersionHolder`'s init naturally falls back to the placeholder DDD `MVersionInternal` (constructor-only, no asset I/O). The provider is constructed as an anonymous subclass that no-ops `onCreate` to skip `App.staticInit` (FCM / PRDownloader / FeedbackSender) while still running `attachInfo` to set up the static `UriMatcher`.
-
----
-
-### ~~REM-19: Replace PRDownloaderFixed with WorkManager Downloads~~ ✅ COMPLETED (2026-05-13)
-**Addresses:** TD-12  
-**Module:** Downloads  
-**BRICE:** B=2 R=2 I=2 C=3 E=5 → **2.8**
-
-**Outcome:** Bible-version downloads now run inside [VersionDownloadWorker](../Alkitab/src/main/java/yuku/alkitab/base/util/VersionDownloadWorker.kt), a `CoroutineWorker` that uses the shared `Connections.okHttp` client and reports progress via `setProgress(Data)`. [DownloadMapper](../Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt) was rewritten from a Java enum singleton into a Kotlin `class` with a companion `instance`, internally observing `WorkManager.getWorkInfoByIdFlow(uuid)` on a `MainScope` coroutine and mirroring `WorkInfo.State` into `DownloadManager.STATUS_*` constants so the existing `VersionListFragment` polling UI (`getStatus(downloadKey)` / `getDownloadProgress(downloadKey)`) keeps working unchanged. On terminal `SUCCEEDED`, the observer hands off to the existing [VersionDownloadCompleteReceiver.onReceive](../Alkitab/src/main/java/yuku/alkitab/base/br/VersionDownloadCompleteReceiver.java); on `FAILED`, it shows the existing network / server error dialog and calls `remove()`.
-
-Resume support is implemented as documented in the original step 3: the worker checks the destination file's existing length and, if non-zero, sends `Range: bytes=N-`. A 206 Partial Content response appends to the file; a 200 response wipes and restarts. To keep on-disk byte counts in sync with wire byte counts (and so progress reporting and Range offsets remain accurate), the worker explicitly sends `Accept-Encoding: identity` — without this OkHttp would transparently decode any `Content-Encoding: gzip` response and strip Content-Length, breaking both progress reporting and Range-based resume. The `.yes` file itself is still gzip-precompressed at the application layer; `OptionalGzipInputStream` in `VersionDownloadCompleteReceiver` continues to handle that on the receiver side.
-
-Song-book downloads in [SongBookUtil.downloadSongBook](../Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.java) were never routed through PRDownloader — they already use raw OkHttp via `Connections.downloadCall(...)` — so the original step 5 of the plan was a no-op. The full module deletion took the rest of the steps with it: `:PrDownloaderFixed` removed from `settings.gradle.kts`, `implementation(project(":PrDownloaderFixed"))` removed from `Alkitab/build.gradle.kts`, `PRDownloader.initialize(...)` removed from `App.java`, the `PRDownloaderOkHttpClient` adapter deleted, and the entire `PrDownloaderFixed/` directory deleted.
-
-**Verification:** `./gradlew assemblePlainDebug testPlainDebugUnitTest testPlainReleaseUnitTest` all pass. End-to-end smoke test on an Android 15 emulator: BBE (Bible in Basic English) preset downloaded successfully from `api.alkitab.app`, was inserted into the version DB, and the reader correctly switched to it and rendered Revelation 9 in English.
-
----
-
-### ~~REM-20: Replace AmbilWarna with Material Color Picker~~ ✅ COMPLETED (2026-05-12)
-**Addresses:** TD-12  
-**Module:** UI — Color settings  
-**BRICE:** B=1 R=1 I=4 C=4 E=5 → **3.0**
-
-**Steps:**
-1. `AmbilWarnaDialog` is used in 2 files: `MarkersActivity.java` (lines 43, 233-243 — label color picker) and `TypeHighlightDialog.java` (line 19 — highlight color selection). There is no `ColorSettingsActivity`.
-2. Replace with `MaterialColorPickerDialog` from a Material-compatible library or implement custom using Material 3 color palette
-3. Ensure selected colors are stored in the same format (hex int)
-4. Delete `AmbilWarna` module
-
-**Difficulty:** Easy (3-4 hours).
-
-**Outcome:** Done in two PRs.
-
-The first PR (2026-05-11) replaced the two `AmbilWarnaDialog` call sites — `MarkersActivity` and `TypeHighlightDialog` — with a new iOS-style Compose color picker, inspired by Apple's UIColorPickerViewController and the Flutter `ios_color_picker` package. The picker lives in [Alkitab/src/main/java/yuku/alkitab/base/compose/colorpicker/IosColorPicker.kt](../Alkitab/src/main/java/yuku/alkitab/base/compose/colorpicker/IosColorPicker.kt) and exposes three tabs: a **Grid** (50-color preset palette: 10 greys × 1 row + 10 hues × 4 brightness rows), a **Spectrum** tab (saturation × value 2D box driven by tap & drag, with a hue slider underneath), and a **Sliders** tab (R/G/B channel sliders plus a 6-digit hex input field). The Java call sites reach the picker through a thin `ColorPickerDialog` wrapper ([ColorPickerDialog.kt](../Alkitab/src/main/java/yuku/alkitab/base/compose/colorpicker/ColorPickerDialog.kt)) that hosts the Compose view inside a `ModalBottomSheet` via `ComposeBottomSheetHost`. Color storage is unchanged — the picker returns the same `0xff000000 | rgb` int the legacy code expected, and `LabelColorUtil.encodeBackground` still masks to 24-bit RGB before persisting. The picker uses the existing `BibleAppTheme` so it inherits dynamic colors on Android 12+. Java callers reach the picker via a `fun interface Listener` (single-method, lambda-compatible).
-
-The follow-up PR (2026-05-12) finished the migration by replacing the 9 `<yuku.ambilwarna.widget.AmbilWarnaPreference …/>` entries across `color_settings.xml`, `color_settings_night.xml`, and `settings_display.xml` with a new [ColorPreference](../Alkitab/src/main/java/yuku/alkitab/base/widget/ColorPreference.kt) (`androidx.preference.Preference` subclass). It draws a 24dp rounded color swatch as its widget area and opens the same Compose bottom-sheet picker on click — persisting through the existing `persistInt` path, so all `Preferences.getInt(R.string.pref_textColor_key, …)` call sites elsewhere in the codebase keep reading the same ARGB int format. With the last consumer gone, the `AmbilWarna` Gradle module was deleted in full: `include(":AmbilWarna")` removed from `settings.gradle.kts`, `implementation(project(":AmbilWarna"))` removed from `Alkitab/build.gradle.kts`, and the entire `AmbilWarna/` directory deleted.
-
-**Verification:** `./gradlew assemblePlainDebug` and `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` both pass after each PR.
-
----
-
-### ~~REM-26: Port VerseRenderer to Kotlin~~ ✅ COMPLETED (2026-04-20)
-**Addresses:** TD-10 (leftover Unicode-constants comment), TD-11 (one of the listed Java files)  
-**Module:** Main reader (verse rendering)  
-**BRICE:** B=3 R=2 I=4 C=5 E=5 → **3.8**
-
-**Outcome:** `VerseRenderer.java` is now `VerseRenderer.kt` — a Kotlin `object` with `@JvmStatic` on the public `render` and `appendSuperscriptNumber` entry points, idiomatic `when` over the marker switch, range-based char checks (`text_c[3] in '1'..'4'`), and proper nullable types on optional parameters. All four parameters that the deleted `VerseRendererJavaHelper` shimmed (`lText`, `lVerseNumber`, `isVerseNumberShown`, `verseNumberText`, `highlightInfo`, `checked`, `inlineLinkSpanFactory`, `ftr`) now have Kotlin default values directly on `render`, with `verseNumberText` defaulting to `Ari.toVerse(ari).toString()`. The four callers of `VerseRendererJavaHelper.render(...)` (`MarkerListActivity`, `VerseActionModeController`, `VersesControllerImpl`, `RibkaReportActivity`) now call `VerseRenderer.render(...)` directly.
-
-The previously-documented private helpers (`renderVerseNumber`, `processFormattingCodes`, `applyHighlight`, `bindToTextViews`, `applyParaStyle`, `simpleRender`, `processSpecialTag`, `reportInvalidSpecialTag`, `createLeadingMarginSpan`) are now genuinely `private` — Kotlin lets us tighten visibility from Java's package-private default. No public API changes; the only caller-visible adjustment is `FormattedTextResult.result` becoming a typed nullable `CharSequence?` (matching the actual Java semantics), which surfaced one previously-implicit `!!` in `MarkerListActivity`.
-
-The undocumented Unicode constants flagged in TD-10 (the `superscriptDigits` array and `XREF_MARK`) now have inline comments naming the code points and what they're used for.
-
-Behavior preservation enforced by the same 39 Robolectric characterization tests (`VerseRendererTest.kt`) plus 274 other Alkitab tests — all 313 pass on both `testPlainDebugUnitTest` and `testPlainReleaseUnitTest`. `VerseRendererJavaHelper.kt` deleted.
-
----
-
-### ~~REM-25: Decompose VerseRenderer.render()~~ ✅ COMPLETED (2026-04-20)
-**Addresses:** TD-10  
-**Module:** Main reader (verse rendering)  
-**BRICE:** B=3 R=2 I=4 C=4 E=4 → **3.4**
-
-**Outcome:** The 200-line `render()` method in `VerseRenderer.java` (lines 71–271 before the refactor) is now an orchestrator that delegates to four named helpers:
-- `renderVerseNumber(sb, text_c, text_len, isVerseNumberShown, verseNumberText, checked) → int` — embeds the inline verse number (and decides when `@^`/`@1`–`@4` should suppress it), returns the start position past the prefix
-- `processFormattingCodes(text, text_c, text_len, sb, startPosAfterVerseNumber, verseNumberText, checked, ari, factory)` — runs the marker loop (paragraph, italic, red, line break, special tags) and flushes the trailing paragraph's `applyParaStyle`
-- `applyHighlight(sb, highlightInfo, startPosAfterVerseNumber)` — attaches the `BackgroundColorSpan`, including the partial-highlight hash check
-- `bindToTextViews(lText, lVerseNumber, sb, isVerseNumberShown, startPosAfterVerseNumber, verseNumberText)` — pushes the result into the optional `TextView`s
-
-The pre-existing `applyParaStyle` and `processSpecialTag` helpers were kept as-is. No public API change. Behavior preservation is enforced by the 39 Robolectric characterization tests added in commit `ec5e058` (`VerseRendererTest.kt`), which lock in every code path including the `@@@0Body` two-paragraph quirk and the `checked=true` red-letter suppression. Full Alkitab unit test suite (313 tests) and `assemblePlainDebug` both still pass.
-
-**Out of scope (TD-10 leftover):** the undocumented `superscriptDigits` Unicode constant on `VerseRenderer.java:23` — trivial follow-up.
-
----
-
-### ~~REM-23: Port ybuild.sh to Gradle~~ ✅ COMPLETED (2026-04-16)
-**Addresses:** TD-14  
-**Module:** Build  
-**BRICE:** B=4 R=3 I=3 C=4 E=5 → **3.8**
-
-**Outcome:** `ybuild.sh` deleted. Production builds are now `./gradlew assemble<Flavor>Release`, working on any platform Gradle supports. The placeholder `ddd_*` Bible files moved from `Alkitab/src/main/assets/internal/` to `Alkitab/src/plain/assets/internal/` so production flavors don't inherit them. A typed `CopyProprietaryAssetsTask` per production flavor copies `$ALKITAB_PROPRIETARY_DIR/overlay/<applicationId>/text_raw/*` into `Alkitab/build/generated/proprietaryAssets/<flavor>/internal/`, wired into AGP via `androidComponents { onVariants { ... addGeneratedSourceDirectory(...) } }` so every consumer (mergeAssets, lint vital, etc.) automatically depends on it. The git commit hash is now `BuildConfig.LAST_COMMIT_HASH` (the `R.string.last_commit_hash` resource was removed). APKs are still named `Alkitab-{versionCode}-{versionName}-{commitHash}-{applicationId}-{BUILD_DIST}.apk` (with `BUILD_DIST` defaulting to `dev`). All four flavors (plain debug, yuku_alkitab, yuku_quick_bible, sabda_alkitab) verified building end-to-end.
-
----
-
-**Original analysis:** Production release builds require running `ybuild.sh`, a 168-line macOS-only bash script that creates a RAM disk, copies proprietary assets from an external directory, stamps the git commit hash, runs Gradle, and renames the output APK. This cannot be run on Linux CI and prevents building with a simple `./gradlew assembleYuku_alkitabRelease`.
-
-Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradle:32-38`) and product flavors (lines 72-87). What's missing are 4 operations that can all be expressed as Gradle tasks.
-
-**Steps:**
-
-**Step 23a: Proprietary asset injection via Gradle**
-1. Add a `ALKITAB_PROPRIETARY_DIR` environment variable check in `Alkitab/build.gradle` — only required for non-`plain` flavors
-2. For each production flavor (`yuku_alkitab`, `yuku_quick_bible`, `sabda_alkitab`), define a mapping from flavor to its `BUILD_PACKAGE_NAME` overlay subdirectory (e.g., `yuku_alkitab` → `yuku`)
-3. Register a `preBuild`-dependent task (e.g., `copyProprietaryAssets${flavorName}`) that:
-   - Deletes `Alkitab/src/main/assets/internal/`
-   - Copies files from `$ALKITAB_PROPRIETARY_DIR/overlay/$BUILD_PACKAGE_NAME/text_raw/*` into `Alkitab/src/main/assets/internal/`
-4. Alternatively, use `sourceSets` to point each production flavor's `assets.srcDirs` to the proprietary directory directly, avoiding the copy:
-   ```groovy
-   yuku_alkitab {
-       applicationId 'yuku.alkitab'
-       assets.srcDirs = ['src/main/assets_without_internal', "$proprietaryDir/overlay/yuku"]
-   }
-   ```
-   This would require restructuring `src/main/assets` so that `internal/` is in its own source set.
-
-**Step 23b: Git commit hash injection via Gradle**
-1. Add a task that reads the git commit hash:
-   ```groovy
-   def gitHash = providers.exec {
-       commandLine 'git', 'log', '-1', '--format=format:%h'
-   }.standardOutput.asText.get().trim()
-   ```
-2. Option A: Generate `last_commit.xml` as a build output (preferred — avoids modifying source):
-   ```groovy
-   android.applicationVariants.all { variant ->
-       def task = tasks.register("generateLastCommit${variant.name.capitalize()}") {
-           def outputDir = layout.buildDirectory.dir("generated/res/lastCommit/${variant.name}")
-           outputs.dir(outputDir)
-           doLast {
-               def dir = outputDir.get().asFile
-               new File(dir, "values/last_commit.xml").with {
-                   parentFile.mkdirs()
-                   text = """<?xml version="1.0" encoding="utf-8"?>
-   <resources><string name="last_commit_hash">${gitHash}</string></resources>"""
-               }
-           }
-       }
-       variant.registerGeneratedResFolders(project.files(task.map { it.outputs.files.singleFile }))
-   }
-   ```
-3. Option B (simpler): Use `buildConfigField` instead of a resource:
-   ```groovy
-   defaultConfig {
-       buildConfigField 'String', 'LAST_COMMIT_HASH', "\"${gitHash}\""
-   }
-   ```
-   Then update code that reads `R.string.last_commit_hash` to read `BuildConfig.LAST_COMMIT_HASH`. Grep for `last_commit_hash` to find all readers.
-
-**Step 23c: Custom APK naming via Gradle**
-1. Use the existing `applicationVariants.all` block (line 99 of `Alkitab/build.gradle`) to set the output filename:
-   ```groovy
-   android.applicationVariants.all { variant ->
-       variant.outputs.all { output ->
-           def flavor = variant.flavorName
-           def buildType = variant.buildType.name
-           def dist = System.getenv("BUILD_DIST") ?: "dev"
-           def pkgName = System.getenv("BUILD_PACKAGE_NAME") ?: "plain"
-           outputFileName = "Alkitab-${variant.versionCode}-${variant.versionName}-${gitHash}-${pkgName}-${dist}.apk"
-       }
-   }
-   ```
-
-**Step 23d: Remove RAM disk dependency**
-1. The RAM disk served two purposes: build isolation and speed. Neither is necessary:
-   - **Isolation:** Gradle's `build/` directory already isolates outputs. `./gradlew clean` handles cleanup.
-   - **Speed:** Modern SSDs make the speed benefit negligible. CI runners typically have fast storage.
-2. No Gradle changes needed — just stop using the RAM disk.
-
-**Step 23e: Validate environment and retire ybuild.sh**
-1. Add a validation task that checks required env vars for production flavors:
-   ```groovy
-   tasks.register("validateProductionEnv") {
-       doFirst {
-           if (System.getenv("ALKITAB_PROPRIETARY_DIR") == null) {
-               throw new GradleException("ALKITAB_PROPRIETARY_DIR not set")
-           }
-           // ... check SIGN_KEYSTORE, etc.
-       }
-   }
-   // Wire it: only for non-plain release builds
-   ```
-2. After all steps are verified, delete `ybuild.sh` and update documentation
-3. The new build command becomes:
-   ```bash
-   ALKITAB_PROPRIETARY_DIR=/path/to/proprietary \
-   BUILD_PACKAGE_NAME=yuku \
-   BUILD_DIST=playstore \
-   SIGN_KEYSTORE=/path/to/keystore \
-   SIGN_ALIAS=mykey \
-   SIGN_PASSWORD=secret \
-   ./gradlew assembleYuku_alkitabRelease
-   ```
-
-**Difficulty:** Medium (1-2 days). Step 23a (asset injection) is the trickiest part — need to decide between copy-on-build vs. sourceSets approach. Steps 23b-23d are straightforward Gradle configuration. Low risk since existing `ybuild.sh` can remain as fallback during transition.
-
----
+- [REM-15: Introduce Kotlin Coroutines](tech-debt-remediation/REM-15-coroutines.md) — **3.2**
+- [REM-16: Convert Core Java Files to Kotlin](tech-debt-remediation/REM-16-java-to-kotlin.md) — **3.0** (9 of 11 files ported)
+- [REM-17: Migrate Build to Kotlin DSL & Version Catalogs](tech-debt-remediation/REM-17-kotlin-dsl-build.md) ✅ **3.0**
+- [REM-19: Replace PRDownloaderFixed with WorkManager Downloads](tech-debt-remediation/REM-19-prdownloader-replacement.md) ✅ **2.8**
+- [REM-20: Replace AmbilWarna with Material Color Picker](tech-debt-remediation/REM-20-ambilwarna-replacement.md) ✅ **3.0**
+- [REM-25: Decompose VerseRenderer.render()](tech-debt-remediation/REM-25-verserenderer-decompose.md) ✅ **3.4**
+- [REM-26: Port VerseRenderer to Kotlin](tech-debt-remediation/REM-26-verserenderer-kotlin.md) ✅ **3.8**
 
 ## Phase 4: Long-term / Major Refactors (BRICE < 2.5)
 
-### REM-21: Migrate Song Storage from Parcelable to JSON
-**Addresses:** TD-04 (long-term part)  
-**Module:** Songs  
-**BRICE:** B=3 R=3 I=1 C=2 E=5 → **2.8**
-
-**Steps:**
-1. Define `SongJsonModel` using Kotlinx Serialization with explicit field names. Note: `KpriModel/Song.java` (line 13) implements both `Serializable` and `Parcelable`, and line 10-11 has a comment acknowledging this is a "Bad decision".
-2. Add database migration that reads all songs via old `Parcelable` format (currently stored as `Parcel.marshall()` byte arrays via `SongDb.marshallSong()` at line 29-35 and `unmarshallSong()` at line 37-44), re-serializes as JSON, and writes back
-3. Update `SongDb.java` to read/write JSON instead of `Parcelable` blobs — the "data" column (line 81) currently stores marshalled byte arrays
-4. Update server-side song book format to JSON (coordinate with backend team)
-5. Support both formats during transition (detect format by first byte)
-6. Remove `KpriModel.Song.writeToParcel()` / `createFromParcel()` (lines 31-38, 75-85) after migration period
-
-**Difficulty:** Hard (3-5 days). Risk: data migration must handle all existing song books without data loss. Requires server-side changes.
-
----
-
-### REM-22: Introduce Jetpack Compose for New Screens
-**Status:** Kicked off — `GotoActivity` + 3 fragments ported as the first screen.  
-**Addresses:** General modernization  
-**Module:** UI  
-**BRICE:** B=3 R=1 I=2 C=2 E=5 → **2.6**
-
-**Progress:**
-- Compose BOM `2026.04.01` (Compose 1.11.0 / Material 3 1.4.0) and `androidx.activity:activity-compose:1.13.0` added; `buildFeatures { compose = true }` enabled.
-- `BibleAppTheme` (dynamic color on Android 12+) introduced under `yuku.alkitab.base.compose`.
-- `GotoActivity` (`ComponentActivity` + `setContent`) and the three goto tabs (Dialer / Direct / Grid) implemented as Composables, replacing ~1,400 lines of Java/XML (activity, 3 fragments, base fragment, 9 layouts, menu, drawable). Public Java API on `GotoActivity` (`createIntent` / `obtainResult` / `Result`) is preserved so call sites in `IsiActivity` keep working unchanged.
-
-**Remaining steps:**
-1. Continue with simpler screens: `AboutActivity.kt` (Kotlin, View-based with custom animations), `HelpActivity.java` (Java, WebView-based — convert to Kotlin first)
-2. Gradually migrate: `SettingsActivity` → Compose Preference screens
-3. Do NOT migrate `IsiActivity` verse rendering — too complex and performance-critical for initial Compose adoption
-
-**Difficulty:** Hard (ongoing effort over months). Risk: Compose interop with existing View-based code requires careful fragment/activity management.
+- [REM-21: Migrate Song Storage from Parcelable to JSON](tech-debt-remediation/REM-21-song-json-storage.md) — **2.8**
+- [REM-22: Introduce Jetpack Compose for New Screens](tech-debt-remediation/REM-22-jetpack-compose.md) — **2.6** (kicked off)
 
 ---
 
@@ -731,36 +59,38 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 
 | ID | Task | BRICE | Phase |
 |----|------|-------|-------|
-| REM-01 | ~~Fix SongBookUtil deserialization safety~~ ✅ | **4.6** | 1 |
-| REM-02 | ~~Fix Preferences hold/unhold safety~~ ✅ | **4.2** | 1 |
-| REM-04 | ~~Fix FCM token retry~~ ✅ | **4.2** | 1 |
-| REM-05 | ~~Fix DevotionDownloader threading~~ ✅ | **4.0** | 1 |
-| REM-03 | ~~Replace LocalBroadcastManager~~ ✅ | **3.8** | 1 |
-| REM-23 | ~~Port ybuild.sh to Gradle~~ ✅ | **3.8** | 2 |
-| REM-06 | ~~Extract IsiActivity gestures~~ ✅ | **3.4** | 2 |
-| REM-07 | ~~Extract IsiActivity action mode~~ ✅ | **3.4** | 2 |
-| REM-09 | Introduce ViewModel | **3.4** | 2 |
-| REM-10 | ~~Room migration (Markers)~~ ✅ | **3.4** | 2 |
-| REM-12 | ~~Replace DragSortListView~~ ✅ | **3.4** | 2 |
-| REM-14 | ~~Replace material-dialogs~~ ✅ | **3.4** | 2 |
-| REM-18 | ~~Add test coverage~~ ✅ | **3.4** | 2 |
-| REM-24 | ~~Refactor S.kt service locator (steps 24a–24d complete)~~ ✅ | **3.2** | 2 |
-| REM-08 | ~~Extract split view manager~~ ✅ | **3.2** | 2 |
-| REM-11 | ~~Room migration (Version)~~ ✅ | **3.2** | 2 |
-| REM-15 | Introduce coroutines | **3.2** | 3 |
-| REM-16 | Java→Kotlin conversion | **3.0** | 3 |
-| REM-17 | ~~Kotlin DSL build migration~~ ✅ | **3.0** | 3 |
-| REM-20 | ~~Replace AmbilWarna~~ ✅ | **3.0** | 3 |
-| REM-19 | ~~Replace PRDownloader~~ ✅ | **2.8** | 3 |
-| REM-21 | Song storage migration | **2.8** | 4 |
-| REM-22 | Jetpack Compose adoption (kicked off) | **2.6** | 4 |
+| [REM-01](tech-debt-remediation/REM-01-songbookutil-deserialization.md) | ~~Fix SongBookUtil deserialization safety~~ ✅ | **4.6** | 1 |
+| [REM-02](tech-debt-remediation/REM-02-preferences-hold-unhold.md) | ~~Fix Preferences hold/unhold safety~~ ✅ | **4.2** | 1 |
+| [REM-04](tech-debt-remediation/REM-04-fcm-token-retry.md) | ~~Fix FCM token retry~~ ✅ | **4.2** | 1 |
+| [REM-05](tech-debt-remediation/REM-05-devotion-downloader-threading.md) | ~~Fix DevotionDownloader threading~~ ✅ | **4.0** | 1 |
+| [REM-03](tech-debt-remediation/REM-03-localbroadcastmanager.md) | ~~Replace LocalBroadcastManager~~ ✅ | **3.8** | 1 |
+| [REM-23](tech-debt-remediation/REM-23-ybuild-gradle.md) | ~~Port ybuild.sh to Gradle~~ ✅ | **3.8** | 2 |
+| [REM-26](tech-debt-remediation/REM-26-verserenderer-kotlin.md) | ~~Port VerseRenderer to Kotlin~~ ✅ | **3.8** | 3 |
+| [REM-06](tech-debt-remediation/REM-06-isiactivity-gestures.md) | ~~Extract IsiActivity gestures~~ ✅ | **3.4** | 2 |
+| [REM-07](tech-debt-remediation/REM-07-isiactivity-action-mode.md) | ~~Extract IsiActivity action mode~~ ✅ | **3.4** | 2 |
+| [REM-09](tech-debt-remediation/REM-09-isiactivity-viewmodel.md) | Introduce ViewModel | **3.4** | 2 |
+| [REM-10](tech-debt-remediation/REM-10-room-markers.md) | ~~Room migration (Markers)~~ ✅ | **3.4** | 2 |
+| [REM-12](tech-debt-remediation/REM-12-itemtouchhelper.md) | ~~Replace DragSortListView~~ ✅ | **3.4** | 2 |
+| [REM-14](tech-debt-remediation/REM-14-material-dialogs.md) | ~~Replace material-dialogs~~ ✅ | **3.4** | 2 |
+| [REM-18](tech-debt-remediation/REM-18-test-coverage.md) | ~~Add test coverage~~ ✅ | **3.4** | 2 |
+| [REM-25](tech-debt-remediation/REM-25-verserenderer-decompose.md) | ~~Decompose VerseRenderer.render~~ ✅ | **3.4** | 3 |
+| [REM-24](tech-debt-remediation/REM-24-s-service-locator.md) | ~~Refactor S.kt service locator (steps 24a–24d complete)~~ ✅ | **3.2** | 2 |
+| [REM-08](tech-debt-remediation/REM-08-isiactivity-split-view.md) | ~~Extract split view manager~~ ✅ | **3.2** | 2 |
+| [REM-11](tech-debt-remediation/REM-11-room-version.md) | ~~Room migration (Version)~~ ✅ | **3.2** | 2 |
+| [REM-15](tech-debt-remediation/REM-15-coroutines.md) | Introduce coroutines | **3.2** | 3 |
+| [REM-16](tech-debt-remediation/REM-16-java-to-kotlin.md) | Java→Kotlin conversion (9/11 done) | **3.0** | 3 |
+| [REM-17](tech-debt-remediation/REM-17-kotlin-dsl-build.md) | ~~Kotlin DSL build migration~~ ✅ | **3.0** | 3 |
+| [REM-20](tech-debt-remediation/REM-20-ambilwarna-replacement.md) | ~~Replace AmbilWarna~~ ✅ | **3.0** | 3 |
+| [REM-19](tech-debt-remediation/REM-19-prdownloader-replacement.md) | ~~Replace PRDownloader~~ ✅ | **2.8** | 3 |
+| [REM-21](tech-debt-remediation/REM-21-song-json-storage.md) | Song storage migration | **2.8** | 4 |
+| [REM-22](tech-debt-remediation/REM-22-jetpack-compose.md) | Jetpack Compose adoption (kicked off) | **2.6** | 4 |
 
 ## Suggested Execution Order
 
-**Sprint 1 (1 week):** ~~REM-01~~✅, ~~REM-02~~✅, ~~REM-04~~✅, ~~REM-05~~✅ — quick safety fixes (all done)  
-**Sprint 2 (1 week):** ~~REM-03~~✅ — LocalBroadcastManager removal (done)  
-**Sprint 3 (2 weeks):** ~~REM-07~~✅, ~~REM-06~~✅, ~~REM-08~~✅ — IsiActivity decomposition (REM-06, REM-07, REM-08 done)  
-**Sprint 4 (1 week):** ~~REM-12~~✅, ~~REM-14~~✅ — deprecated library replacements (done)  
-**Sprint 5 (2 weeks):** ~~REM-10~~✅, ~~REM-11~~✅ — Room migration for core tables (both done; remaining tables — `ReadingPlan`, `Devotion`, `SyncShadow`, `SyncLog`, `PerVersion`, `ProgressMark` — can follow the same pattern)  
-**Sprint 6 (2 weeks):** REM-09, ~~REM-18a-f~~✅ — ViewModel + test coverage (REM-18a/b/c/d/e/f done)  
+**Sprint 1 (1 week):** ~~REM-01~~✅, ~~REM-02~~✅, ~~REM-04~~✅, ~~REM-05~~✅ — quick safety fixes (all done)
+**Sprint 2 (1 week):** ~~REM-03~~✅ — LocalBroadcastManager removal (done)
+**Sprint 3 (2 weeks):** ~~REM-07~~✅, ~~REM-06~~✅, ~~REM-08~~✅ — IsiActivity decomposition (all done)
+**Sprint 4 (1 week):** ~~REM-12~~✅, ~~REM-14~~✅ — deprecated library replacements (done)
+**Sprint 5 (2 weeks):** ~~REM-10~~✅, ~~REM-11~~✅ — Room migration for core tables (both done; remaining tables — `ReadingPlan`, `Devotion`, `SyncShadow`, `SyncLog`, `PerVersion`, `ProgressMark` — can follow the same pattern)
+**Sprint 6 (2 weeks):** REM-09, ~~REM-18a-f~~✅ — ViewModel + test coverage (REM-18a/b/c/d/e/f done)
 **Ongoing:** REM-15, REM-16, ~~REM-17~~✅ — modernization work mixed into feature sprints (REM-17 done)

--- a/docs/tech-debt-remediation.md
+++ b/docs/tech-debt-remediation.md
@@ -332,17 +332,20 @@ If the project adopts Hilt for other reasons (e.g., ViewModel injection in REM-0
 
 ---
 
-### REM-11: Migrate InternalDb to Room (Version Table)
+### ~~REM-11: Migrate InternalDb to Room (Version Table)~~ ✅ COMPLETED (2026-05-13)
 **Addresses:** TD-02  
 **Module:** Storage — Versions subsystem  
 **BRICE:** B=3 R=2 I=3 C=3 E=5 → **3.2**
 
-**Steps:**
-1. Define `VersionEntity` Room entity
-2. Define `VersionDao` with queries: `listAllVersions()`, `insertOrUpdateVersion()`, `deleteVersion()`, `setVersionActive()`
-3. Add Room migration for the `Version` table
-4. Replace `InternalDb.listAllVersions()` (line 531) with DAO call
-5. Update `S.getAvailableVersions()` to use the DAO
+**Outcome.** The legacy hand-rolled `Version` table is now backed by Room in a new, separate-file database (`AlkitabRoomDb`) at `yuku.alkitab.base.storage.room.AppDatabase` (`@Database(version = 1)` at landing; later bumped to v2 by REM-10). A separate file avoids the `user_version` collision with `InternalDbHelper`'s versionCode-driven schema — see `docs/superpowers/specs/2026-05-13-rem-11-room-version-table-design.md`.
+
+**Shipped:**
+- **Entities and DAO:** `VersionEntity.kt` mirrors the legacy columns; `VersionRoomDao.kt` exposes `listAllOrderedByOrdering()`, `getById()`, `insertOrUpdate()`, `deleteByPresetName()`, and the active-flag / ordering helpers.
+- **Data migration:** `VersionDataMigration.kt` — idempotent one-time copy from the legacy `Version` table into Room, wired into `S.db`'s lazy initializer.
+- **Facade preservation:** `VersionDao.kt` (under `storage/`) now delegates to Room, mapping `VersionEntity` ↔ `MVersionDb`. `InternalDb.listAllVersions()` and related methods continue to work unchanged.
+- **Legacy table left in place** as a rollback safety net; a future release can drop it once the Room path has baked.
+
+**Verification.** Migration test scaffolding via `MigrationTestHelper` (added separately) plus `VersionRoomDaoTest.kt` and `VersionDataMigrationTest.kt`. Schema JSON checked in at `Alkitab/schemas/yuku.alkitab.base.storage.room.AppDatabase/1.json`.
 
 **Difficulty:** Medium (1-2 days). Lower risk than Markers since the Version table is simpler.
 
@@ -737,13 +740,13 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 | REM-06 | ~~Extract IsiActivity gestures~~ ✅ | **3.4** | 2 |
 | REM-07 | ~~Extract IsiActivity action mode~~ ✅ | **3.4** | 2 |
 | REM-09 | Introduce ViewModel | **3.4** | 2 |
-| REM-10 | Room migration (Markers) | **3.4** | 2 |
+| REM-10 | ~~Room migration (Markers)~~ ✅ | **3.4** | 2 |
 | REM-12 | ~~Replace DragSortListView~~ ✅ | **3.4** | 2 |
 | REM-14 | ~~Replace material-dialogs~~ ✅ | **3.4** | 2 |
 | REM-18 | ~~Add test coverage~~ ✅ | **3.4** | 2 |
 | REM-24 | ~~Refactor S.kt service locator (steps 24a–24d complete)~~ ✅ | **3.2** | 2 |
 | REM-08 | ~~Extract split view manager~~ ✅ | **3.2** | 2 |
-| REM-11 | Room migration (Version) | **3.2** | 2 |
+| REM-11 | ~~Room migration (Version)~~ ✅ | **3.2** | 2 |
 | REM-15 | Introduce coroutines | **3.2** | 3 |
 | REM-16 | Java→Kotlin conversion | **3.0** | 3 |
 | REM-17 | ~~Kotlin DSL build migration~~ ✅ | **3.0** | 3 |
@@ -758,6 +761,6 @@ Gradle already handles signing (`signingConfigs.release` at `Alkitab/build.gradl
 **Sprint 2 (1 week):** ~~REM-03~~✅ — LocalBroadcastManager removal (done)  
 **Sprint 3 (2 weeks):** ~~REM-07~~✅, ~~REM-06~~✅, ~~REM-08~~✅ — IsiActivity decomposition (REM-06, REM-07, REM-08 done)  
 **Sprint 4 (1 week):** ~~REM-12~~✅, ~~REM-14~~✅ — deprecated library replacements (done)  
-**Sprint 5 (2 weeks):** REM-10, REM-11 — Room migration for core tables  
+**Sprint 5 (2 weeks):** ~~REM-10~~✅, ~~REM-11~~✅ — Room migration for core tables (both done; remaining tables — `ReadingPlan`, `Devotion`, `SyncShadow`, `SyncLog`, `PerVersion`, `ProgressMark` — can follow the same pattern)  
 **Sprint 6 (2 weeks):** REM-09, ~~REM-18a-f~~✅ — ViewModel + test coverage (REM-18a/b/c/d/e/f done)  
 **Ongoing:** REM-15, REM-16, ~~REM-17~~✅ — modernization work mixed into feature sprints (REM-17 done)

--- a/docs/tech-debt-remediation/REM-01-songbookutil-deserialization.md
+++ b/docs/tech-debt-remediation/REM-01-songbookutil-deserialization.md
@@ -1,0 +1,20 @@
+# REM-01: Fix SongBookUtil Resource Leak & Unsafe Deserialization ✅ COMPLETED
+
+**Addresses:** TD-04, PB-06
+**Module:** Songs
+**BRICE:** B=4 R=5 I=4 C=5 E=5 → **4.6**
+**Phase:** 1 — Quick Wins & Safety Fixes
+
+**Completed in:** `1b9b74d9` (2026-04-11)
+
+**What was done (steps 1-3):**
+1. ✅ Wrapped `Response` and streams in try-with-resources to prevent leaks
+2. ✅ Added response body size validation (rejects >50MB)
+3. ✅ Introduced `SafeObjectInputStream` with class whitelist (`java.util.*`, `java.lang.*`, and Song model classes only) to prevent deserialization attacks. Also added `instanceof` check before casting.
+4. ⬜ Long-term: Migrate song download format from Java serialization to JSON (Kotlinx Serialization) — not yet started, requires server change (tracked separately as [REM-21](REM-21-song-json-storage.md))
+
+**Tests added:** 7 unit tests in `SongBookUtilTest.java` covering single/multiple songs, empty list, gzip, Unicode, multiple lyrics, and null fields.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-02-preferences-hold-unhold.md
+++ b/docs/tech-debt-remediation/REM-02-preferences-hold-unhold.md
@@ -1,0 +1,19 @@
+# REM-02: Fix Preferences hold()/unhold() Safety ✅ COMPLETED
+
+**Addresses:** TD-09, PB-07
+**Module:** Afw
+**BRICE:** B=3 R=4 I=5 C=5 E=4 → **4.2**
+**Phase:** 1 — Quick Wins & Safety Fixes
+
+**Completed in:** `0b61084a`, `cffe49ad`, `80cd9f34` (2026-04-10/11)
+
+**What was done:**
+1. ✅ Added `Preferences.withTransaction(Runnable)` method that wraps `hold()/unhold()` in try/finally
+2. ✅ Migrated all 6 existing `hold()`/`unhold()` call sites to `withTransaction` (`CurrentReading.java`, `DailyVerseData.java`, `SyncSettingsActivity.java`, `IsiActivity.kt`, `InternalDbHelper.java`, `SecretSyncDebugActivity.kt`)
+3. ✅ Made `hold()` and `unhold()` private — stronger than a safety timeout since external code can no longer call them directly, eliminating the misuse risk entirely
+
+**Note:** Two call sites (`SyncSettingsActivity`, `SecretSyncDebugActivity`) were previously missing try/finally, meaning an exception would have buffered preference writes indefinitely. This bug is now fixed.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-03-localbroadcastmanager.md
+++ b/docs/tech-debt-remediation/REM-03-localbroadcastmanager.md
@@ -1,0 +1,30 @@
+# ~~REM-03: Replace LocalBroadcastManager~~ ✅ COMPLETED (2026-04-22)
+
+**Addresses:** TD-03 (LocalBroadcastManager)
+**Module:** Cross-cutting
+**BRICE:** B=3 R=3 I=3 C=4 E=5 → **3.8**
+**Phase:** 1 — Quick Wins & Safety Fixes
+
+**Outcome:** All 24 files that used `App.getLbm()` now talk through a single Kotlin event-bus object at `yuku.alkitab.base.events.AppEvents`. Each former `ACTION_*` broadcast became a named `MutableSharedFlow` (most `<Unit>`, one `<Boolean>` for the version-list refreshing spinner, and one `<DevotionDownloadedEvent>` data-class-typed bus carrying the kind name + `yyyyMMdd` date). Buses are configured with `extraBufferCapacity = 16, onBufferOverflow = DROP_OLDEST` — `tryEmit` is guaranteed to succeed regardless of buffer pressure, and when bursts exceed the buffer the oldest queued "reload" signal is dropped rather than the newest (which is what a collector catching up actually needs). Preserves LBM's fire-and-forget, in-process, no-replay semantics.
+
+**What was done:**
+
+1. **Senders** — every `App.getLbm().sendBroadcast(new Intent(ACTION_*))` replaced with a `@JvmStatic` emit helper on `AppEvents` (e.g. `AppEvents.emitAttributeMapChanged()`). Touched: `IsiActivity`, `SyncAdapter` (9 call sites), `MarkerListActivity` (4 call sites), `SecretSyncDebugActivity`, `VersionListFragment` (5 call sites), `VersionsActivity`, `VersionConfigUpdaterService`, `VersionDownloadCompleteReceiver`, `DownloadMapper`, `DevotionDownloader`, `ProgressMarkRenameDialog`, `DataTransferFragment`, `DisplayFragment`, `CurrentReading`.
+
+2. **Receivers (Kotlin activities/fragments)** — replaced `BroadcastReceiver` + `registerReceiver`/`unregisterReceiver` with `lifecycleScope.launch { AppEvents.foo.collect { ... } }` in `IsiActivity`, `MarkerListActivity`, `VersionListFragment`. The associated `onDestroy` overrides (only doing `unregisterReceiver`) became no-ops and were deleted.
+
+3. **Receivers (Java activities/fragments)** — added two Java-friendly helpers on `AppEvents`: `observe(LifecycleOwner, Flow<*>, Runnable)` collects until `DESTROYED`, and `observeWhileStarted` (+ typed `observeWhileStartedWithValue`) uses `repeatOnLifecycle(STARTED)` for onStart/onStop-scoped flows. Migrated `MarkersActivity`, `ReadingPlanActivity`, `SyncSettingsActivity.SyncSettingsFragment`, `DailyVerseAppWidgetConfigurationActivity` (lifecycle = DESTROYED) and `DevotionActivity` (lifecycle = STARTED, typed value consumer).
+
+4. **Receivers (Java custom views)** — `LabeledSplitHandleButton.init()` and `LeftDrawer.Text.onFinishInflate` call a third helper, `AppEvents.observeOnView(view, flow, runnable)`. The helper installs an `OnAttachStateChangeListener`: collection starts on attach (launching a fresh `MainScope` job each time) and is cancelled on detach, so a view that's inflated but never attached does not leak a live collector, and a re-attached view automatically resubscribes. Contract: call once per view instance — calling from `onAttachedToWindow` would accumulate a listener per attach cycle.
+
+5. **Stale constants removed** — `IsiActivity.ACTION_ATTRIBUTE_MAP_CHANGED` / `ACTION_ACTIVE_VERSION_CHANGED` / `ACTION_NIGHT_MODE_CHANGED` / `ACTION_NEEDS_RESTART`, `MarkersActivity.ACTION_RELOAD`, `MarkerListActivity.ACTION_RELOAD`, `ReadingPlanActivity.ACTION_READING_PLAN_PROGRESS_CHANGED`, `SyncSettingsActivity.ACTION_RELOAD`, `CurrentReading.ACTION_CURRENT_READING_CHANGED`, `DevotionDownloader.ACTION_DOWNLOADED`, `VersionListFragment.ACTION_RELOAD` / `ACTION_UPDATE_REFRESHING_STATUS` / `EXTRA_refreshing`, plus the private `DevotionDownloader.broadcastDownloaded` helper.
+
+6. **Dependency removed** — `androidx-localbroadcastmanager` deleted from `gradle/libs.versions.toml` and `Alkitab/build.gradle.kts`. `App.getLbm()` helper and the `LocalBroadcastManager` import removed from `App.java`.
+
+Coroutines and `lifecycleScope` were already on the classpath transitively through `androidx.fragment:fragment-ktx:1.8.9` (pulling `kotlinx-coroutines-android:1.9.0` and `lifecycle-runtime-ktx:2.7.0`); no new dependency was needed.
+
+**Verified:** `./gradlew :Alkitab:assemblePlainDebug` plus `testPlainDebugUnitTest testPlainReleaseUnitTest` — all 313 unit tests pass.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-04-fcm-token-retry.md
+++ b/docs/tech-debt-remediation/REM-04-fcm-token-retry.md
@@ -1,0 +1,23 @@
+# ~~REM-04: Fix FCM Token Re-registration Retry~~ ✅ COMPLETED (2026-04-22)
+
+**Addresses:** PB-04
+**Module:** Sync
+**BRICE:** B=4 R=4 I=5 C=4 E=4 → **4.2**
+**Phase:** 1 — Quick Wins & Safety Fixes
+
+**Outcome:** `Sync.sendFcmRegistrationId` now has a two-tier recovery path. In-process: a failed send schedules up to three retries on a single-thread `ScheduledExecutorService` (`fcmRetryExecutor`, daemon) at 1 min / 5 min / 30 min; any retry that succeeds clears the persistent flag and short-circuits the chain. Cross-launch: every send-failure branch (`!response.success`, `IOException | JsonIOException`, `JsonSyntaxException`) sets `Prefkey.fcm_registration_pending = true`, the success branch sets it to `false`, and `App.staticInit()` calls the new `Sync.retryPendingFcmRegistrationIfNeeded(registrationId)` with the FCM id returned by `Fcm.renewFcmRegistrationIdIfNeeded` — so if the in-process chain never completed (e.g. process died, network was off the whole 30 min), the next launch that already has a stored FCM id re-sends it. If no id is stored yet, the existing listener path (`Fcm.renewFcmRegistrationIdIfNeeded(Sync::notifyNewFcmRegistrationId)`) still fires `notifyNewFcmRegistrationId` once registration completes, which then runs its own retry chain.
+
+**What was done:**
+1. ✅ Added `Prefkey.fcm_registration_pending` to `Prefkey.kt` with a kdoc comment describing the contract.
+2. ✅ Added `FCM_RETRY_DELAYS_MS = {1min, 5min, 30min}`, `fcmRetryExecutor` (single-thread, daemon), `pendingFcmRetry` (`AtomicReference<ScheduledFuture<?>>`), and `scheduleFcmRegistrationRetries(registrationId, attemptIndex)` in `Sync.java`. Each scheduled attempt re-reads `Prefkey.sync_simpleToken` so a mid-chain logout stops retrying.
+3. ✅ `notifyNewFcmRegistrationId` now schedules a retry chain when the inline send fails.
+4. ✅ Public `retryPendingFcmRegistrationIfNeeded(@NonNull String registrationId)` reads the pending flag and (if set) re-enters `notifyNewFcmRegistrationId`. Called once from `App.staticInit()` with the id returned by `Fcm.renewFcmRegistrationIdIfNeeded`.
+5. ✅ Bumped all four send-failure log sites in `sendFcmRegistrationId` from `AppLog.d` to `AppLog.w` and added `Preferences.setBoolean(Prefkey.fcm_registration_pending, …)` on each path (`true` on failure, `false` on success).
+
+**Not retried on:** if the response is valid but `success == false` (server explicitly rejected the registration id), the flag is still set and the retry chain still runs. This is intentional — the plan did not distinguish retriable vs. terminal failures, and rejections are rare enough that the extra requests are harmless. If this turns out to generate noise, a future change can key off `response.message`.
+
+**Verified:** `./gradlew :Alkitab:assemblePlainDebug testPlainDebugUnitTest testPlainReleaseUnitTest` — all 313 unit tests pass.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-05-devotion-downloader-threading.md
+++ b/docs/tech-debt-remediation/REM-05-devotion-downloader-threading.md
@@ -1,0 +1,21 @@
+# REM-05: Refactor DevotionDownloader threading ✅ COMPLETED
+
+**Addresses:** TD-06 (DevotionDownloader)
+**Module:** Devotions
+**BRICE:** B=2 R=3 I=5 C=5 E=5 → **4.0**
+**Phase:** 1 — Quick Wins & Safety Fixes
+
+**Completed in:** `758793f5` (2026-04-20)
+
+**What was done:**
+1. ✅ Replaced `extends Thread` with a single-thread `ExecutorService` (`Executors.newSingleThreadExecutor()`)
+2. ✅ Replaced `queue_.wait()/notify()` with `LinkedBlockingDeque.take()` — blocking take provides natural backpressure
+3. ✅ Added `shutdown()` method that sets a `volatile boolean shutdown_` flag and calls `executor_.shutdownNow()`; the download loop checks the flag and propagates `InterruptedException` by re-interrupting and breaking out
+4. ✅ Hardcoded `SystemClock.sleep(50)` removed
+5. ✅ HTTP response handling now goes through `Connections.downloadString(url)`, which handles stream cleanup internally
+
+**Remaining:** The broadcast at the end of `downloadLoop` previously used `App.getLbm()` (LocalBroadcastManager); that was migrated to the `AppEvents` `SharedFlow` bus in [REM-03](REM-03-localbroadcastmanager.md).
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-06-isiactivity-gestures.md
+++ b/docs/tech-debt-remediation/REM-06-isiactivity-gestures.md
@@ -1,0 +1,29 @@
+# REM-06: Extract IsiActivity Gesture Handling ✅ COMPLETED
+
+**Addresses:** TD-01 (gesture cluster)
+**Module:** Main reader
+**BRICE:** B=4 R=3 I=3 C=3 E=4 → **3.4**
+**Phase:** 2 — Architecture Improvements
+
+**What was done:**
+1. ✅ Created `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHandler.kt` (~125 lines). The class implements **three** listener interfaces in one place: `TwofingerLinearLayout.Listener` (split-root pinch + swipe), `GotoButton.FloaterDragListener` (drag-from-goto-button), and `Floater.Listener` (final ari selection).
+2. ✅ Moved the three inline lambda objects out of `IsiActivity.kt`: the `splitRoot_listener` (75 lines, two-finger pinch/scale/dragX/dragY/end + one-finger left/right), `bGoto_floaterDrag` (18 lines, floater drag-start/move/complete), and `floater_listener` (3 lines, ari selection).
+3. ✅ Defined two interfaces following the REM-07 pattern: `ReaderGestureHost.kt` (read-only state — `chapter_1`, `activeSplit0Book`, `activeSplit0Version`, `floater`, `textAppearancePanel`, plus pre-computed `gestureDisplayDensity` and `defaultUkuranHuruf2` to avoid forcing the handler to hold a `Resources` reference) and `ReaderGestureActions.kt` (write-side triggers — `onFloaterAriSelected`, `goToPreviousChapter`, `goToNextChapter`, `applyPreferences`, `setFullScreenWithDrawerHandle`).
+4. ✅ `IsiActivity` now implements both interfaces, holds a `gestureHandler` lazy field, and wires the handler into `splitRoot.setListener`, `bGoto.setFloaterDragListener`, and `floater.setListener` (was previously three different objects).
+5. ✅ Behavior preserved verbatim: split-pane drag, pinch zoom (with the 2f–42f clamp), one-finger left/right chapter swipe, two-finger horizontal drag for multi-chapter skip, two-finger vertical drag toggling fullscreen (paired with `leftDrawer.handle.setFullScreen` under a single new action). Gesture state (`startFontSize`, `startDx`, `moreSwipeYAllowed`, `chapterSwipeCellWidth`, `floaterLocationOnScreen`) now lives on the handler instead of inline objects.
+
+**Result:** `IsiActivity.kt` shrank from 2452 → 2371 lines (−81 lines). Gesture-state fields and 96 lines of listener code are gone from the activity; 13 lines of host/actions implementations remain as the seam between the activity and the new handler.
+
+**What stayed in `IsiActivity`:** the gesture-triggered Activity methods themselves (`bLeft_click`, `bRight_click`, `jumpToAri`, `applyPreferences`, `setFullScreen`) and the existing `leftDrawer.handle.setFullScreen` follow-up call — all wrapped in thin action overrides.
+
+**Files touched:**
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHandler.kt` (new, 125 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureHost.kt` (new, 38 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/ReaderGestureActions.kt` (new, 27 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt` (modified: −81 lines, class signature gains two interfaces, four import lines added)
+
+**Difficulty:** Medium (actually 2-3 hours, came in well under the 4-6 hour estimate).
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-07-isiactivity-action-mode.md
+++ b/docs/tech-debt-remediation/REM-07-isiactivity-action-mode.md
@@ -1,0 +1,24 @@
+# REM-07: Extract IsiActivity Action Mode ✅ COMPLETED
+
+**Addresses:** TD-01 (action mode cluster)
+**Module:** Main reader
+**BRICE:** B=4 R=3 I=3 C=3 E=4 → **3.4**
+**Phase:** 2 — Architecture Improvements
+
+**Completed in:** `89a1894e` (REM-07 refactor) + `716eb1ce` (follow-up split-1 fix, 2026-04-16)
+
+**What was done:**
+1. ✅ Created `VerseActionModeController.kt` (~593 lines) implementing `ActionMode.Callback`. Moved the entire ~500-line `actionMode_callback` object from `IsiActivity.kt` into this class.
+2. ✅ Defined two interfaces: `VerseActionModeHost` (queries activity state — selected verses, versions, book data, chapter) and `VerseActionModeActions` (callbacks back into the activity — navigate, show toasts, etc.)
+3. ✅ Extracted pure text-building logic into `VerseTextFormatter` (no Android dependencies, purely testable under plain JUnit)
+4. ✅ Moved `RibkaEligibility` to a standalone top-level file `RibkaEligibility.kt`
+5. ✅ Added `mockk` to the test classpath. Added 26 unit tests: 11 pure-JUnit tests for `VerseTextFormatterTest`, 15 Robolectric tests for `VerseActionModeControllerTest` (menu visibility rules, click routing)
+6. ✅ Follow-up PR `716eb1ce` fixed the split-1 share URL metadata bug (PB-08) that had been preserved verbatim in the REM-07 refactor. Four regression tests added for copy/share split-0/1 metadata routing.
+
+**Result:** `IsiActivity.kt` shrank from 2894 → 2320 lines (−574 lines). Action mode is now independently testable without instantiating the Activity.
+
+**Difficulty:** Medium (6-8 hours). Risk: action mode references many Activity-level fields and methods.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-08-isiactivity-split-view.md
+++ b/docs/tech-debt-remediation/REM-08-isiactivity-split-view.md
@@ -1,0 +1,32 @@
+# REM-08: Extract IsiActivity Split View Manager ✅ COMPLETED
+
+**Addresses:** TD-01 (split view cluster)
+**Module:** Main reader
+**BRICE:** B=3 R=2 I=3 C=4 E=4 → **3.2**
+**Phase:** 2 — Architecture Improvements
+
+**What was done:**
+1. ✅ Created `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt` (~367 lines) that owns `activeSplit1` and the split-pane UI: `openSplitDisplay()`, `closeSplitDisplay()`, `configureSplitSizes()`, `displaySplitFollowingMaster()`, `loadSplitVersion()`, `disableSplitVersion()`, `openSplitVersionsDialog()`, `configureTextAppearancePanelForSplitVersion()`, plus `restoreFromPreferences(verse_1)` / `saveToPreferences()` for the `lastSplitVersionId` / `lastSplitOrientation` / `lastSplitProp` round-trip.
+2. ✅ Moved three listener objects out of `IsiActivity.kt`: the `splitRoot_globalLayout` (`OnGlobalLayoutListener` that re-invokes `configureSplitSizes` on bounds change), `splitHandleButton_listener` (drag-prop math + `lastSplitProp` persistence), and `splitHandleButton_labelPressed` (rotate / start / end label-button dispatch).
+3. ✅ Defined two interfaces following the REM-06 / REM-07 pattern: `SplitViewHost.kt` (read-only state — `splitRoot`, `splitHandleButton`, `lsSplit0`, `lsSplit1`, `bVersion`, `leftDrawer`, `textAppearancePanel`, `actionMode`, `chapter_1`, `activeSplit0Book`, `activeSplit0Version`, plus `getVerse_1BasedOnScrolls()`) and `SplitViewActions.kt` (write-side triggers — `applyPreferences`, `openPrimaryVersionsDialog`, `loadChapterIntoSplit1`, `setSplit1DataModel`).
+4. ✅ `IsiActivity` now implements both interfaces, holds a `splitViewManager by lazy { SplitViewManager(this, this) }`, and `onCreate` calls `splitViewManager.installListeners()` (replaces the inline `addOnGlobalLayoutListener` + two handle-button listener setups) and `splitViewManager.restoreFromPreferences(...)` (replaces the 17-line `Preferences.getString(Prefkey.lastSplitVersionId)` restore block). `display(...)` delegates to `splitViewManager.displaySplitFollowingMaster(...)`; `onStop` to `splitViewManager.saveToPreferences()`; `cSplitVersion_checkedChange` to the manager's open/disable methods.
+5. ✅ Moved `ActiveSplit1` from a nested data class inside `IsiActivity` to a top-level data class in `yuku.alkitab.base.widget`. `IsiActivity.activeSplit1` is now a read-only `val` getter that delegates to `splitViewManager.activeSplit1` — every existing call site (audio bar host, action mode host overrides, `applyPreferences` padding logic, `consumeKey` split scrolling, `VerseInlineLinkSpan` xref/footnote routing, Ribka eligibility, etc.) keeps reading `activeSplit1?.version` unchanged.
+6. ✅ Behavior preserved verbatim: split-pane open/close transitions (including `bVersion` show/hide, `leftDrawer.handle.setSplitVersion(...)` toggling, and `actionMode.invalidate()` re-prepare), the split handle drag with proportion clamp and `lastSplitProp` persistence, the rotate-orientation label button, master → split chapter following including the "split version can't display this book" empty-message path, the uncheck-suppression guard around split chapter loads (via the new `loadChapterIntoSplit1` action), text-appearance-panel split version label, and the `lastSplitVersionId` / `lastSplitOrientation` save/restore round-trip across app restarts.
+
+**Result:** `IsiActivity.kt` shrank from 2411 → 2160 lines (−251 lines). Split view is now a self-contained component testable in isolation; `activeSplit1` is read-only from `IsiActivity`'s perspective (all writes happen inside the manager).
+
+**Files touched:**
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt` (new, 367 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewHost.kt` (new, 43 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewActions.kt` (new, 28 lines)
+- `Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt` (modified: −251 lines, class signature gains two interfaces, four import lines added, six lateinit vars + `actionMode` + `getVerse_1BasedOnScrolls()` widened to `override`)
+
+**Verification:**
+- `./gradlew assemblePlainDebug` → BUILD SUCCESSFUL in 14s (cold) / 5s (warm)
+- `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` → BUILD SUCCESSFUL, 420 tests pass per variant
+
+**Difficulty:** Medium (came in around the lower end of the 4-6 hour estimate). The fan-out of `activeSplit1` references was the main risk; addressed by keeping a read-through getter on the activity so no call site outside the moved methods had to change.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-09-isiactivity-viewmodel.md
+++ b/docs/tech-debt-remediation/REM-09-isiactivity-viewmodel.md
@@ -1,0 +1,27 @@
+# REM-09: Introduce ViewModel for IsiActivity
+
+**Addresses:** TD-07
+**Module:** Main reader
+**BRICE:** B=4 R=3 I=2 C=3 E=5 → **3.4**
+**Phase:** 2 — Architecture Improvements
+
+**Status:** Not started.
+
+**Steps:**
+1. Create `IsiViewModel : ViewModel()` with:
+   - `activeVersion: StateFlow<MVersion>`
+   - `currentAri: StateFlow<Int>`
+   - `versesDataModel: StateFlow<VersesDataModel>`
+   - `selectedVerses: StateFlow<Set<Int>>`
+   - `splitVersion: StateFlow<MVersion?>`
+2. Move version loading, chapter display logic, and verse selection state from `IsiActivity` into `IsiViewModel`
+3. `IsiActivity` observes StateFlows and updates UI
+4. Navigation history moves to ViewModel (survives rotation)
+
+**Prerequisite:** [REM-06](REM-06-isiactivity-gestures.md) ✅, [REM-07](REM-07-isiactivity-action-mode.md) ✅, [REM-08](REM-08-isiactivity-split-view.md) ✅ should be done first to reduce IsiActivity size before extracting ViewModel. (All three are complete.)
+
+**Difficulty:** Hard (2-3 days). Risk: extensive refactoring of the largest file in the codebase.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-10-room-markers.md
+++ b/docs/tech-debt-remediation/REM-10-room-markers.md
@@ -1,0 +1,33 @@
+# REM-10: Migrate InternalDb to Room (Markers Table) ✅ COMPLETED (2026-05-14)
+
+**Addresses:** TD-02
+**Module:** Storage — Markers subsystem
+**BRICE:** B=4 R=3 I=2 C=3 E=5 → **3.4**
+**Phase:** 2 — Architecture Improvements
+
+**Outcome.** All three legacy hand-rolled SQLite tables — `Marker`, `Label`, `Marker_Label` — are now backed by Room in `AlkitabRoomDb` (the same separate-file Room database [REM-11](REM-11-room-version.md) introduced). `AppDatabase` bumped `version = 1 → 2`; the SQL inside `MIGRATION_1_2` mirrors what Room's entity definitions emit (verified by `MigrationTestHelper.runMigrationsAndValidate` with `validateDroppedTables = true`).
+
+**Shipped:**
+- **Entities:** `MarkerEntity.kt` / `LabelEntity.kt` / `MarkerLabelEntity.kt` mirror the legacy columns. Indexes match the legacy ones with one exception — the legacy `index_Marker_05 (kind, caption COLLATE NOCASE)` is dropped because Room's `@Index` does not support per-column collation; the only caller (`InternalDb.listMarkers` caption sort) falls back to SQLite's in-memory sort, which is negligible at realistic marker volumes (hundreds, max).
+- **Room DAOs:** `MarkerRoomDao.kt` / `LabelRoomDao.kt` / `MarkerLabelRoomDao.kt`. `LabelRoomDao` carries the pair-wise `reorderById` shift inside a `@Transaction`. `MarkerRoomDao` exposes a `@RawQuery` escape hatch (`listMarkersRaw`) for `InternalDb.listMarkers`'s dynamic `ORDER BY` + optional join; the facade whitelists the four valid sort columns (`createTime` / `modifyTime` / `ari` / `caption`) before composing the SQL.
+- **Schema bump:** `AppDatabase.kt` now `@Database(version = 2)` with `@JvmField val MIGRATION_1_2`. `Alkitab/schemas/yuku.alkitab.base.storage.room.AppDatabase/2.json` is checked in alongside the existing `1.json`.
+- **Data migration:** `MarkerDataMigration.kt` — idempotent one-time copy from the legacy three tables into Room, running inside a single `roomDb.runInTransaction { ... }` so the three tables move atomically (Gemini-correct on REM-11). Idempotency uses a combined `marker + label + marker_label` count check so that a legacy state with labels-but-no-markers (or vice versa) doesn't double-copy on retry. Translates the legacy Indonesian column names (`judul` / `urutan` / `warnaLatar`) to the Room schema's English equivalents (`title` / `ordering` / `backgroundColor`). Wired into `S.kt`'s `db` lazy initializer next to `VersionDataMigration`.
+- **Facade preservation:** `MarkerDao.kt` / `LabelDao.kt` / `Marker_LabelDao.kt` rewritten to delegate to the Room DAOs, mapping between Room entities and the `Marker` / `Label` / `Marker_Label` model classes. Public method signatures unchanged — call sites in `IsiActivity`, `MarkerListActivity`, sync code, etc. did not need to be touched.
+- **InternalDb rewrites:** Seven raw-SQL methods rewritten to use Room: `listMarkers`, `deleteMarkerById`, `putAttributes`, `updateOrInsertPartialHighlight`, `updateOrInsertHighlights`, `getHighlightColorRgb` (both overloads), `updateLabels`, `deleteLabelAndMarker_LabelsByLabelId`, `sortLabelsAlphabetically`, `reorderLabels`. Transactional flows that previously used `helper.getWritableDatabase().beginTransactionNonExclusive()` now use `AppDatabase.get(App.context).runInTransaction(...)`. Removed unused imports (`Cursor`, `SQLiteDatabase`, `DatabaseUtils`, `ContentValues`, `Sqlitil`, `Literals.Array`, `Literals.ToStringArray`).
+- **Legacy tables left in place.** `Marker` / `Label` / `Marker_Label` are still created by `InternalDbHelper.onCreate` so the rollback safety net is preserved; a future release can drop them once the Room path has baked.
+
+**Tests (4 new files, 1 updated, 1 InternalDbTest extended):**
+- `MarkerRoomDaoTest.kt` (13 tests) — Room-level primitives: range queries inclusive/exclusive bounds, ordering, `@RawQuery` bridge with and without `marker_label` joins.
+- `LabelRoomDaoTest.kt` (10 tests) — `reorderById` move-up / move-down / no-op, `listByMarkerGid` cross-join order.
+- `MarkerLabelRoomDaoTest.kt` (10 tests) — cascade-helper deletes by marker_gid / label_gid, count-by-label, gid uniqueness.
+- `MarkerDataMigrationTest.kt` (8 tests) — empty/full copies, idempotency, no-stomp-on-existing-Room-rows, fresh `_id` assignment, atomic copy of all three tables.
+- `AppDatabaseMigrationTest.kt` — added the real `migrates1To2` test (replacing the scaffold) plus an end-to-end open-via-Room round-trip after migrating from v1; the existing v1-schema sanity test now passes `MIGRATION_1_2` to the builder so the v1 → current open succeeds.
+- `InternalDbTest.kt` — `@Before` now installs an in-memory `AppDatabase` via `AppDatabase.setForTesting` (necessary harness change because the facade DAOs route through Room), and 4 new tests cover the `listMarkers` `@RawQuery` branches: `label_id == 0`, `label_id == LABELID_noLabel`, label-filtered, and the case-insensitive caption sort.
+
+**Verification.** `./gradlew :Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest` — 494 tests, all green. `./gradlew :Alkitab:assemblePlainDebug` produces a working APK. On-device smoke (Pixel emulator API 35, pre-existing dataset of 1456 markers / 18 labels / 152 marker_label associations from a v1 Room install): installing the new APK ran `MarkerDataMigration` once on first launch (logged `Copied 1456 marker(s), 18 label(s), 152 marker_label row(s) from legacy tables to Room`), counts match the legacy table exactly, second launch is idempotent (no row growth), spot-check confirms `gid` / `ari` / `caption` round-trip verbatim.
+
+**Difficulty:** Hard. Took ~1 day with the REM-11 pattern already established. Subsequent tables (`ReadingPlan`, `Devotion`, `SyncShadow`, `SyncLog`, `PerVersion`, `ProgressMark`) can follow the same pattern.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-11-room-version.md
+++ b/docs/tech-debt-remediation/REM-11-room-version.md
@@ -1,0 +1,22 @@
+# ~~REM-11: Migrate InternalDb to Room (Version Table)~~ ✅ COMPLETED (2026-05-13)
+
+**Addresses:** TD-02
+**Module:** Storage — Versions subsystem
+**BRICE:** B=3 R=2 I=3 C=3 E=5 → **3.2**
+**Phase:** 2 — Architecture Improvements
+
+**Outcome.** The legacy hand-rolled `Version` table is now backed by Room in a new, separate-file database (`AlkitabRoomDb`) at `yuku.alkitab.base.storage.room.AppDatabase` (`@Database(version = 1)` at landing; later bumped to v2 by [REM-10](REM-10-room-markers.md)). A separate file avoids the `user_version` collision with `InternalDbHelper`'s versionCode-driven schema — see `../superpowers/specs/2026-05-13-rem-11-room-version-table-design.md`.
+
+**Shipped:**
+- **Entities and DAO:** `VersionEntity.kt` mirrors the legacy columns; `VersionRoomDao.kt` exposes `listAllOrderedByOrdering()`, `getById()`, `insertOrUpdate()`, `deleteByPresetName()`, and the active-flag / ordering helpers.
+- **Data migration:** `VersionDataMigration.kt` — idempotent one-time copy from the legacy `Version` table into Room, wired into `S.db`'s lazy initializer.
+- **Facade preservation:** `VersionDao.kt` (under `storage/`) now delegates to Room, mapping `VersionEntity` ↔ `MVersionDb`. `InternalDb.listAllVersions()` and related methods continue to work unchanged.
+- **Legacy table left in place** as a rollback safety net; a future release can drop it once the Room path has baked.
+
+**Verification.** Migration test scaffolding via `MigrationTestHelper` (added separately) plus `VersionRoomDaoTest.kt` and `VersionDataMigrationTest.kt`. Schema JSON checked in at `Alkitab/schemas/yuku.alkitab.base.storage.room.AppDatabase/1.json`.
+
+**Difficulty:** Medium (1-2 days). Lower risk than Markers since the Version table is simpler.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-12-itemtouchhelper.md
+++ b/docs/tech-debt-remediation/REM-12-itemtouchhelper.md
@@ -1,0 +1,20 @@
+# REM-12: Replace DragSortListView with ItemTouchHelper ✅ COMPLETED
+
+**Addresses:** TD-12
+**Module:** Markers (label management)
+**BRICE:** B=2 R=2 I=4 C=4 E=5 → **3.4**
+**Phase:** 2 — Architecture Improvements
+
+**Completed changes:**
+- `MarkersActivity.java` rewritten to use `RecyclerView` + custom `ItemTouchHelper.Callback` (drag-handle initiated via `startDrag`, divider guarded via `getMovementFlags` and `canDropOver`). Native context menu replaced with a `PopupMenu` shown on long-press.
+- `VersionListFragment.kt` converted to `RecyclerView.Adapter<VersionItemHolder>` with `ItemTouchHelper` installed only when `downloadedOnly == true`.
+- DB persistence still uses the existing pair-wise `reorderLabels` / `reorderVersions`. Instead of committing on every `onMove`, the adapter snapshots its item list at drag start and issues a single reorder call in `clearView` using `snapshot[startPos]` and `snapshot[endPos]`.
+- Translucent-white drag overlay (`0x22ffffff`) preserved via `onSelectedChanged` / `clearView`.
+- Three layouts (`activity_markers.xml`, `fragment_versions_all.xml`, `fragment_versions_downloaded.xml`) switched to `androidx.recyclerview.widget.RecyclerView`.
+- `DragSortListView` module removed from `settings.gradle`, `Alkitab/build.gradle`, and the filesystem.
+
+**Difficulty:** Easy-Medium (4-6 hours).
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-14-material-dialogs.md
+++ b/docs/tech-debt-remediation/REM-14-material-dialogs.md
@@ -1,0 +1,14 @@
+# ~~REM-14: Replace material-dialogs with Material 3~~ ✅ COMPLETED
+
+**Addresses:** TD-12
+**Module:** Cross-cutting UI
+**BRICE:** B=2 R=3 I=3 C=4 E=5 → **3.4**
+**Phase:** 2 — Architecture Improvements
+
+**Completed in:** `ca9a9138` (PR #140)
+
+**Outcome:** All `com.afollestad.materialdialogs` usages replaced with `MaterialAlertDialogBuilder` (Material 3). The `material-dialogs` dependencies are gone from the build, and no remaining imports exist in the codebase.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-15-coroutines.md
+++ b/docs/tech-debt-remediation/REM-15-coroutines.md
@@ -1,0 +1,38 @@
+# REM-15: Introduce Kotlin Coroutines
+
+**Addresses:** TD-06 (threading)
+**Module:** Cross-cutting
+**BRICE:** B=4 R=2 I=2 C=3 E=5 → **3.2**
+**Phase:** 3 — Modernization
+
+**Status:** Partial. Coroutines are already on the classpath transitively via `androidx.fragment:fragment-ktx` (pulled in by [REM-03](REM-03-localbroadcastmanager.md)), and `VersionDownloadWorker` (a `CoroutineWorker`, from [REM-19](REM-19-prdownloader-replacement.md)) plus the `AppEvents` `SharedFlow` buses already use them. The remaining work is module-by-module.
+
+**Steps — incremental by module:**
+
+**Step 15a: Sync module**
+1. Add `kotlinx-coroutines-android` dependency (already present transitively; no change needed)
+2. Convert `SyncAdapter` (WorkManager `Worker`) to `CoroutineWorker`
+3. Replace `Thread`-based sync execution with `withContext(Dispatchers.IO)`
+4. Add `supervisorScope` for independent entity sync (markers, pins, history can fail independently)
+
+**Step 15b: Devotion downloads**
+1. Replace `DevotionDownloader` thread with a coroutine-based downloader using `Channel`
+2. Use `flow {}` for download progress tracking
+3. Integrate with `DevotionActivity` via `lifecycleScope`
+
+(`DevotionDownloader` is now an `ExecutorService`-based class after [REM-05](REM-05-devotion-downloader-threading.md), and the broadcast at the end of the loop went through `AppEvents`/`SharedFlow` in [REM-03](REM-03-localbroadcastmanager.md). The full migration to coroutines here is still pending.)
+
+**Step 15c: Search engine**
+1. Wrap `SearchEngine.searchByGrep()` in `withContext(Dispatchers.Default)`
+2. Add `yield()` between book iterations for cancellation support
+3. Return results via `Flow<SearchResult>` for progressive display
+
+**Step 15d: Version loading**
+1. Make `Version.loadChapterText()` suspending or wrap in `Dispatchers.IO`
+2. IsiActivity display pipeline becomes: `viewModelScope.launch { loadAndDisplay() }`
+
+**Difficulty:** Hard (1-2 weeks total, but can be done module-by-module over time).
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-16-java-to-kotlin.md
+++ b/docs/tech-debt-remediation/REM-16-java-to-kotlin.md
@@ -1,0 +1,37 @@
+# REM-16: Convert Core Java Files to Kotlin
+
+**Addresses:** TD-11
+**Module:** Various
+**BRICE:** B=3 R=1 I=3 C=3 E=5 → **3.0**
+**Phase:** 3 — Modernization
+
+**Status:** Substantial progress — 9 of the 11 originally-listed files ported. Remaining: `Sync.java` and `InternalDb.java` (high-risk).
+
+**Steps — ordered by value and risk (lowest risk first):**
+
+| Priority | File | Lines | Risk | Notes |
+|----------|------|-------|------|-------|
+| 1 | ~~`Highlights.java`~~ | ~~~200~~ | ~~Low~~ | ✅ ported to `Highlights.kt` (2026-05-12). `object` with `@JvmStatic` methods and `@JvmField` properties to preserve Java call sites; 5 Kotlin callers got `!!` on `Info.partial` (now properly nullable). All 31 `HighlightsTest` cases + full unit-test suite pass. |
+| 2 | ~~`TargetDecoder.java`~~ | ~~~150~~ | ~~Low~~ | ✅ ported to `TargetDecoder.kt` (2026-05-13). `object` with `@JvmStatic decode()`; returns non-nullable `IntArrayList` (empty on error) to preserve call sites. |
+| 3 | ~~`Jumper.java`~~ | ~~~200~~ | ~~Low~~ | ✅ ported to `Jumper.kt` on 2026-05-12; behavior preserved, JumperTest + full unit suite pass |
+| 4 | ~~`QueryTokenizer.java`~~ | ~~~100~~ | ~~Low~~ | ✅ ported to `QueryTokenizer.kt` (2026-05-13). `object` with `@JvmStatic` on all public methods; `tokenize()` accepts `String?` for backwards-compatible null handling. |
+| 5 | ~~`DevotionDownloader.java`~~ | ~~111~~ | ~~Low~~ | ✅ ported to `DevotionDownloader.kt` (2026-05-13). Regular Kotlin class with `@Synchronized`/`@Volatile` annotations, `::downloadLoop` method reference. |
+| 6 | ~~`Provider.java`~~ | ~~~200~~ | ~~Medium~~ | ✅ ported to `Provider.kt` (2026-05-13). `open class` (needed for test anonymous subclass); `companion object` for constants and static `uriMatcher`; `when` replaces `switch`. |
+| 7 | ~~`SongBookUtil.java`~~ | ~~219~~ | ~~Medium~~ | ✅ ported to `SongBookUtil.kt` (2026-05-13). `object` with nested interfaces/classes; `@JvmStatic` on all public methods; `@JvmField` on `SongBookInfo` fields. |
+| 8 | ~~`VerseRenderer.java`~~ | ~~423~~ | ~~Medium~~ | ✅ ported ([REM-26](REM-26-verserenderer-kotlin.md)) |
+| 9 | ~~`SearchEngine.java`~~ | ~~537~~ | ~~Medium~~ | ✅ ported to `SearchEngine.kt` (2026-05-13). `object` with nested `ReadyTokens` class; `@JvmStatic` on public methods; `searchByGrep()` returns non-nullable `IntArrayList`; `sortWith` replaces `Arrays.sort`. |
+| 10 | `Sync.java` | 508 | High | Threading + network, many call sites |
+| 11 | `InternalDb.java` | 1771 | High | Core database, skip if doing Room migration ([REM-10](REM-10-room-markers.md)) |
+
+Use Android Studio's "Convert Java File to Kotlin" as a starting point, then manually clean up:
+- Replace `@Nullable`/`@NonNull` with Kotlin nullability
+- Replace `static` methods with top-level or companion object
+- Replace `for` loops with `forEach`/`map`
+- Replace `switch` with `when`
+- Use data classes where appropriate
+
+**Difficulty:** Varies (1 hour to 1 day per file depending on size). Do alongside other changes to avoid merge conflicts.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-17-kotlin-dsl-build.md
+++ b/docs/tech-debt-remediation/REM-17-kotlin-dsl-build.md
@@ -1,0 +1,20 @@
+# ~~REM-17: Migrate Build to Kotlin DSL & Version Catalogs~~ ✅ COMPLETED (2026-04-20)
+
+**Addresses:** TD-12 (build system)
+**Module:** Build
+**BRICE:** B=2 R=1 I=3 C=4 E=5 → **3.0**
+**Phase:** 3 — Modernization
+
+**Outcome:**
+- Created `gradle/libs.versions.toml` centralising all 30+ dependency versions, 20+ library coordinates, and 8 plugin IDs. Firebase BOM dependencies declared without version (BOM-managed). SDK integer versions (`compileSdk`, `minSdk`, `targetSdk`) stored as strings and accessed via `.get().toInt()` in build files.
+- `settings.gradle` → `settings.gradle.kts`: added `pluginManagement` and `dependencyResolutionManagement` (with `FAIL_ON_PROJECT_REPOS`) so all repository declarations are centralised in one place. `jitpack.io` (needed for `FancyShowCaseView`) declared there. Foojay toolchain resolver kept inline (version catalog not yet available at settings `plugins {}` eval time).
+- Root `build.gradle` → `build.gradle.kts`: replaced `buildscript` + `allprojects` with a lean `plugins { ... apply false }` block. The `ext {}` block is gone — all versions live in the catalog.
+- `Alkitab/build.gradle` → `Alkitab/build.gradle.kts`: `CopyProprietaryAssetsTask` converted to Kotlin abstract class with `@Inject constructor(private val fs: FileSystemOperations)`. `firebaseApiKeyProblem` converted to a top-level function with `@Suppress("UNCHECKED_CAST")`. `String.capitalize()` (deprecated in Kotlin 2.x) replaced with `replaceFirstChar { it.uppercaseChar() }`. All `$androidxActivityVersion` ext references replaced with `libs.androidx.activity.ktx` catalog accessors. Server-host constants (`SERVER_HOST`, `RIBKA_FUNCTIONS_HOST`, `RIBKA_FUNCTIONS_HOST_DEBUG`) inlined as `val` in this file and duplicated in `AlkitabFeedback` (only two consumers; no ext lookup needed).
+- All 15 library module `build.gradle` files converted to Kotlin DSL. `apply plugin:` replaced with `alias(libs.plugins.*)`. `compileSdkVersion`/`minSdkVersion`/`targetSdkVersion` methods replaced with `compileSdk`/`minSdk`/`targetSdk` property assignments. `minifyEnabled` → `isMinifyEnabled`, `shrinkResources` → `isShrinkResources`. Stale `repositories {}` blocks in `AlkitabYes2` and `AlkitabFeedback` removed (centralised in settings). `kotlin-android` / `kotlin-parcelize` plugin IDs replaced with their full `org.jetbrains.kotlin.*` IDs.
+- `apply plugin: 'com.google.gms.google-services'` (legacy bottom-of-file pattern) moved to the `plugins {}` block at the top of `Alkitab/build.gradle.kts`.
+
+**Difficulty:** Medium (1-2 days). Mostly mechanical but Groovy-specific constructs need manual translation.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-18-test-coverage.md
+++ b/docs/tech-debt-remediation/REM-18-test-coverage.md
@@ -1,0 +1,48 @@
+# ~~REM-18: Add Test Coverage for Core Modules~~ ✅ COMPLETED (2026-05-11)
+
+**Addresses:** TD-13
+**Module:** Cross-cutting
+**BRICE:** B=4 R=3 I=2 C=3 E=5 → **3.4**
+**Phase:** 2 — Architecture Improvements
+
+**Outcome:** All six sub-steps shipped — see per-step entries below. Cumulatively this added ~170 unit tests across `HighlightsTest`, the four `Sync*Test` files, `InternalDbTest`, `SearchEngineTest`, `Yes2RoundTripTest` + `SnappyStreamRoundTripTest`, and `ProviderTest`, plus latent-bug fixes in `Highlights.alphaMix`, `Sync_Pins.Content.equals/hashCode`, and a flagged `SnappyInputStream` EOF edge. Robolectric (`4.14.1`) is now a `testImplementation` dependency on `Alkitab`, and test-scope shadows for `android.util.Log` / `FirebaseCrashlytics` / `android.util.Pair` unblock further pure-JUnit work on Android-touching code.
+
+**Steps — prioritized by risk coverage:**
+
+**Step 18a: Highlight encoding tests** ✅ COMPLETED
+**Completed in:** `513961b9` / `1ca73821` (2026-04-16)
+1. ✅ Added 31 unit tests in `HighlightsTest.kt`: encode/decode round-trip, hash verification, partial-highlight guard, alphaMix with ARGB input
+2. ✅ Fixed `Highlights.alphaMix()` ARGB leak: changed `0xa0000000 | colorRgb` to `0xa0000000 | (colorRgb & 0x00ffffff)` so the output alpha is always `0xA0` regardless of what the caller passes
+3. ✅ Added test-scope no-op shadows for `android.util.Log` and `com.google.firebase.crashlytics.FirebaseCrashlytics` — these unblock all future Alkitab module unit tests that touch `AppLog`
+
+**Step 18b: Sync protocol tests** ✅ COMPLETED
+**Completed in:** `b4bce934` (2026-04-16)
+1. ✅ Added 101 unit tests across `SyncDeltaTest.kt`, `Sync_MabelTest.kt`, `Sync_PinsTest.kt`, `Sync_RpTest.kt` — covers `SyncAdapter.patchNoConflict` delta application (add/mod/del, missing GIDs, conflict, idempotency), `Sync.entitiesEqual`, `SyncUtils.findEntity/isSameContent`, `Sync_Mabel.updateMarker/Label/Marker_Label`, and `Content equals/hashCode/toString` for all three sync sets
+2. ✅ Fixed `Sync_Pins.Content.equals()`: was sorting copies but comparing the original unsorted lists — now compares sorted copies. Fixed `hashCode()` to match order-insensitive equals (violations would cause misbehavior inside `HashMap`/`HashSet`)
+3. ✅ Added test-scope stub for `android.util.Pair` so `patchNoConflict` runs without Robolectric
+
+**Step 18c: InternalDb tests (or Room DAO tests)** ✅ COMPLETED
+1. ✅ Added Robolectric (`4.14.1`) as a `testImplementation` dependency and enabled `testOptions.unitTests.includeAndroidResources` in `Alkitab/build.gradle` — Robolectric is required because `InternalDbHelper` extends Android's `SQLiteOpenHelper`
+2. ✅ Added `InternalDbTest.kt` under `Alkitab/src/test/java/yuku/alkitab/base/storage/` using `RobolectricTestRunner` with `@Config(application = Application::class)` so `yuku.alkitab.base.App.onCreate` (Firebase / PRDownloader / FCM) doesn't run. Reuses the existing test-scope shadows of `android.util.Log` and `com.google.firebase.crashlytics.FirebaseCrashlytics` (added in REM-18a) so `AppLog`'s static initializer loads without bootstrapping Firebase. `yuku.afw.App.context` is set manually in `@Before`; because no `sync_simpleToken` preference is present, `Sync.notifySyncNeeded` early-returns and no background work fires
+3. ✅ Test names follow the Kotlin backtick-sentence convention from CLAUDE.md. Covers marker CRUD (`insertMarker`, `insertOrUpdateMarker`, `getMarkerById/Gid`, `listMarkersForAriKind`, `listAllMarkers`, `deleteMarkerById` with cascade to `Marker_Label`, `countMarkersForBookChapter`), label ordering (`insertLabel`, `getLabelMaxOrdering`, `reorderLabels` up/down, `sortLabelsAlphabetically`, `listLabelsByMarker` ordering), highlight storage (`updateOrInsertHighlights` insert/update/delete, `updateOrInsertPartialHighlight` including dedup of sync-duplicates, `getHighlightColorRgb` single/multi-verse), and attribute loading (`putAttributes` bookmarks, notes, multi-verse highlight spread, ordering by `modifyTime`, book-chapter filtering)
+
+**Step 18d: SearchEngine tests** ✅ COMPLETED
+1. ✅ Unit tests added in `SearchEngineTest.kt` — covers `ReadyTokens` construction, `satisfiesTokens`, and end-to-end `searchByGrep` against a small in-memory fake `Version`. Exercises single token, multi-token (AND) intersection, whole-word matching, quoted phrases (multiword), book-id filtering, duplicate-token de-duplication, and cross-verse-boundary rejection.
+2. ✅ Runs under `RobolectricTestRunner` so `android.util.SparseBooleanArray` is a real implementation rather than the "not mocked" stub. `AppLog` is kept quiet via the existing test-scope shadows (`android.util.Log`, `FirebaseCrashlytics`) introduced for `HighlightsTest`.
+3. Difficulty: Medium (4-6 hours)
+
+**Step 18e: YES2 reader/writer round-trip tests** ✅ COMPLETED
+1. ✅ Added `Yes2RoundTripTest.kt` (12 tests) and `SnappyStreamRoundTripTest.kt` (4 tests) under `AlkitabYes2/src/test/java/`. Round-trip covers: single-book uncompressed read-back of every verse; multi-book boundaries (Genesis / Exodus / Revelation) preserving book ordering and chapter offsets; BMP UTF-8 content (Indonesian, Greek, Hebrew, extended Latin) — limited to U+FFFF because `Utf8Decoder` is documented as "intentionally incomplete" and does not support 4-byte UTF-8 sequences; `dontSeparateVerses` newline-joined form; `lowercase` flag; out-of-range chapter returns null; pericope round-trip with parallels and ARI-keyed lookup; pericope empty-chapter and no-pericope-section cases; missing xref / footnote sections return null.
+2. ✅ Snappy-compressed text section round-trip: writes multi-block compressed Bible text and verifies every verse decodes identically; separately verifies that a compressed file is strictly smaller than the uncompressed equivalent for highly-repetitive text.
+3. ✅ Direct `SnappyOutputStream` / `SnappyInputStream` round-trip: single-block, multi-block (4 blocks with partial trailing block), mid-block `seek` crossing block boundaries, and compression-ratio check on highly-repetitive input (each 4 KB block compresses to under 400 bytes via the pure-Java codec).
+4. ✅ Added a test-scope `android.util.Log` shadow at `AlkitabYes2/src/test/java/android/util/Log.java` — mirrors the one in the Alkitab module so direct `Log.e` calls in `Yes2Reader`, `SectionIndex`, and the xref/footnote sections don't trigger "Method not mocked" during plain JUnit.
+5. The tests exposed a latent bug in `SnappyInputStream`: after the last byte of the last block is read, calling `read()` again increments `current_block_index` past the end and throws `ArrayIndexOutOfBoundsException` instead of returning -1. Production callers in `Yes2Reader.TextSectionReader.loadVerseText` always read exact-length ranges derived from verse `varuint` lengths, so they never hit EOF this way. Flagged in-file rather than silently worked around; see `SnappyStreamRoundTripTest.kt`.
+
+**Step 18f: Content provider tests** ✅ COMPLETED (2026-05-11)
+1. ✅ Added `ProviderTest.kt` (14 tests) under `Alkitab/src/test/java/yuku/alkitab/base/cp/` exercising every URI path the read-only [`Provider`](../../Alkitab/src/main/java/yuku/alkitab/base/cp/Provider.kt) supports: single-verse by ARI (with `_id`, `ari`, book short name, and verse-text assertions), single-verse by LID (resolved via `LidToAri`), range by ARI within a single chapter, range by ARI crossing a chapter boundary, range by ARI crossing a book boundary, range by LID, whole-chapter shorthand (`bbcc00-bbcc00` → all verses in that chapter), and the `bible/versions` listing query (asserts the internal version row using `AppConfig.get()` for `shortName` / `longName` / `description`).
+2. ✅ Pinned the contract edges: `formatting=0` (default) strips inline formatting codes via `FormattedVerseText.removeSpecialCodes`, `formatting=1` returns the raw verse text including codes, out-of-range `bookId` (single or range) returns an empty `MatrixCursor` rather than null, an unknown URI path returns null, and `getType` returns null for every URI (production behaviour — `Provider.getType` is hardcoded to null).
+3. ✅ Same Robolectric setup as steps 18c/d: `@Config(application = Application::class)` to skip `App.onCreate`; existing test-scope shadows of `android.util.Log` and `FirebaseCrashlytics` keep `AppLog` quiet; `yuku.afw.App.context` is wired in `@Before`. The fake `MVersion` returns an anonymous `Version` subclass with two books, three chapters, and one verse carrying real `@@` / `@9` / `@7` formatting codes; `S.setActiveVersion(fakeMv)` overwrites the active version after `ActiveVersionHolder`'s init naturally falls back to the placeholder DDD `MVersionInternal` (constructor-only, no asset I/O). The provider is constructed as an anonymous subclass that no-ops `onCreate` to skip `App.staticInit` (FCM / PRDownloader / FeedbackSender) while still running `attachInfo` to set up the static `UriMatcher`.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-19-prdownloader-replacement.md
+++ b/docs/tech-debt-remediation/REM-19-prdownloader-replacement.md
@@ -1,0 +1,18 @@
+# ~~REM-19: Replace PRDownloaderFixed with WorkManager Downloads~~ ✅ COMPLETED (2026-05-13)
+
+**Addresses:** TD-12
+**Module:** Downloads
+**BRICE:** B=2 R=2 I=2 C=3 E=5 → **2.8**
+**Phase:** 3 — Modernization
+
+**Outcome:** Bible-version downloads now run inside [VersionDownloadWorker](../../Alkitab/src/main/java/yuku/alkitab/base/util/VersionDownloadWorker.kt), a `CoroutineWorker` that uses the shared `Connections.okHttp` client and reports progress via `setProgress(Data)`. [DownloadMapper](../../Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt) was rewritten from a Java enum singleton into a Kotlin `class` with a companion `instance`, internally observing `WorkManager.getWorkInfoByIdFlow(uuid)` on a `MainScope` coroutine and mirroring `WorkInfo.State` into `DownloadManager.STATUS_*` constants so the existing `VersionListFragment` polling UI (`getStatus(downloadKey)` / `getDownloadProgress(downloadKey)`) keeps working unchanged. On terminal `SUCCEEDED`, the observer hands off to the existing [VersionDownloadCompleteReceiver.onReceive](../../Alkitab/src/main/java/yuku/alkitab/base/br/VersionDownloadCompleteReceiver.java); on `FAILED`, it shows the existing network / server error dialog and calls `remove()`.
+
+Resume support is implemented as documented in the original step 3: the worker checks the destination file's existing length and, if non-zero, sends `Range: bytes=N-`. A 206 Partial Content response appends to the file; a 200 response wipes and restarts. To keep on-disk byte counts in sync with wire byte counts (and so progress reporting and Range offsets remain accurate), the worker explicitly sends `Accept-Encoding: identity` — without this OkHttp would transparently decode any `Content-Encoding: gzip` response and strip Content-Length, breaking both progress reporting and Range-based resume. The `.yes` file itself is still gzip-precompressed at the application layer; `OptionalGzipInputStream` in `VersionDownloadCompleteReceiver` continues to handle that on the receiver side.
+
+Song-book downloads in [SongBookUtil.downloadSongBook](../../Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.kt) were never routed through PRDownloader — they already use raw OkHttp via `Connections.downloadCall(...)` — so the original step 5 of the plan was a no-op. The full module deletion took the rest of the steps with it: `:PrDownloaderFixed` removed from `settings.gradle.kts`, `implementation(project(":PrDownloaderFixed"))` removed from `Alkitab/build.gradle.kts`, `PRDownloader.initialize(...)` removed from `App.java`, the `PRDownloaderOkHttpClient` adapter deleted, and the entire `PrDownloaderFixed/` directory deleted.
+
+**Verification:** `./gradlew assemblePlainDebug testPlainDebugUnitTest testPlainReleaseUnitTest` all pass. End-to-end smoke test on an Android 15 emulator: BBE (Bible in Basic English) preset downloaded successfully from `api.alkitab.app`, was inserted into the version DB, and the reader correctly switched to it and rendered Revelation 9 in English.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-20-ambilwarna-replacement.md
+++ b/docs/tech-debt-remediation/REM-20-ambilwarna-replacement.md
@@ -1,0 +1,26 @@
+# ~~REM-20: Replace AmbilWarna with Material Color Picker~~ ✅ COMPLETED (2026-05-12)
+
+**Addresses:** TD-12
+**Module:** UI — Color settings
+**BRICE:** B=1 R=1 I=4 C=4 E=5 → **3.0**
+**Phase:** 3 — Modernization
+
+**Steps:**
+1. `AmbilWarnaDialog` is used in 2 files: `MarkersActivity.java` (lines 43, 233-243 — label color picker) and `TypeHighlightDialog.java` (line 19 — highlight color selection). There is no `ColorSettingsActivity`.
+2. Replace with `MaterialColorPickerDialog` from a Material-compatible library or implement custom using Material 3 color palette
+3. Ensure selected colors are stored in the same format (hex int)
+4. Delete `AmbilWarna` module
+
+**Difficulty:** Easy (3-4 hours).
+
+**Outcome:** Done in two PRs.
+
+The first PR (2026-05-11) replaced the two `AmbilWarnaDialog` call sites — `MarkersActivity` and `TypeHighlightDialog` — with a new iOS-style Compose color picker, inspired by Apple's UIColorPickerViewController and the Flutter `ios_color_picker` package. The picker lives in [Alkitab/src/main/java/yuku/alkitab/base/compose/colorpicker/IosColorPicker.kt](../../Alkitab/src/main/java/yuku/alkitab/base/compose/colorpicker/IosColorPicker.kt) and exposes three tabs: a **Grid** (50-color preset palette: 10 greys × 1 row + 10 hues × 4 brightness rows), a **Spectrum** tab (saturation × value 2D box driven by tap & drag, with a hue slider underneath), and a **Sliders** tab (R/G/B channel sliders plus a 6-digit hex input field). The Java call sites reach the picker through a thin `ColorPickerDialog` wrapper ([ColorPickerDialog.kt](../../Alkitab/src/main/java/yuku/alkitab/base/compose/colorpicker/ColorPickerDialog.kt)) that hosts the Compose view inside a `ModalBottomSheet` via `ComposeBottomSheetHost`. Color storage is unchanged — the picker returns the same `0xff000000 | rgb` int the legacy code expected, and `LabelColorUtil.encodeBackground` still masks to 24-bit RGB before persisting. The picker uses the existing `BibleAppTheme` so it inherits dynamic colors on Android 12+. Java callers reach the picker via a `fun interface Listener` (single-method, lambda-compatible).
+
+The follow-up PR (2026-05-12) finished the migration by replacing the 9 `<yuku.ambilwarna.widget.AmbilWarnaPreference …/>` entries across `color_settings.xml`, `color_settings_night.xml`, and `settings_display.xml` with a new [ColorPreference](../../Alkitab/src/main/java/yuku/alkitab/base/widget/ColorPreference.kt) (`androidx.preference.Preference` subclass). It draws a 24dp rounded color swatch as its widget area and opens the same Compose bottom-sheet picker on click — persisting through the existing `persistInt` path, so all `Preferences.getInt(R.string.pref_textColor_key, …)` call sites elsewhere in the codebase keep reading the same ARGB int format. With the last consumer gone, the `AmbilWarna` Gradle module was deleted in full: `include(":AmbilWarna")` removed from `settings.gradle.kts`, `implementation(project(":AmbilWarna"))` removed from `Alkitab/build.gradle.kts`, and the entire `AmbilWarna/` directory deleted.
+
+**Verification:** `./gradlew assemblePlainDebug` and `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` both pass after each PR.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-21-song-json-storage.md
+++ b/docs/tech-debt-remediation/REM-21-song-json-storage.md
@@ -1,0 +1,22 @@
+# REM-21: Migrate Song Storage from Parcelable to JSON
+
+**Addresses:** TD-04 (long-term part)
+**Module:** Songs
+**BRICE:** B=3 R=3 I=1 C=2 E=5 → **2.8**
+**Phase:** 4 — Long-term / Major Refactors
+
+**Status:** Not started.
+
+**Steps:**
+1. Define `SongJsonModel` using Kotlinx Serialization with explicit field names. Note: `KpriModel/Song.java` (line 13) implements both `Serializable` and `Parcelable`, and line 10-11 has a comment acknowledging this is a "Bad decision".
+2. Add database migration that reads all songs via old `Parcelable` format (currently stored as `Parcel.marshall()` byte arrays via `SongDb.marshallSong()` at line 29-35 and `unmarshallSong()` at line 37-44), re-serializes as JSON, and writes back
+3. Update `SongDb.java` to read/write JSON instead of `Parcelable` blobs — the "data" column (line 81) currently stores marshalled byte arrays
+4. Update server-side song book format to JSON (coordinate with backend team)
+5. Support both formats during transition (detect format by first byte)
+6. Remove `KpriModel.Song.writeToParcel()` / `createFromParcel()` (lines 31-38, 75-85) after migration period
+
+**Difficulty:** Hard (3-5 days). Risk: data migration must handle all existing song books without data loss. Requires server-side changes.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-22-jetpack-compose.md
+++ b/docs/tech-debt-remediation/REM-22-jetpack-compose.md
@@ -1,0 +1,24 @@
+# REM-22: Introduce Jetpack Compose for New Screens
+
+**Status:** Kicked off — `GotoActivity` + 3 fragments ported as the first screen.
+**Addresses:** General modernization
+**Module:** UI
+**BRICE:** B=3 R=1 I=2 C=2 E=5 → **2.6**
+**Phase:** 4 — Long-term / Major Refactors
+
+**Progress:**
+- Compose BOM `2026.04.01` (Compose 1.11.0 / Material 3 1.4.0) and `androidx.activity:activity-compose:1.13.0` added; `buildFeatures { compose = true }` enabled.
+- `BibleAppTheme` (dynamic color on Android 12+) introduced under `yuku.alkitab.base.compose`.
+- `GotoActivity` (`ComponentActivity` + `setContent`) and the three goto tabs (Dialer / Direct / Grid) implemented as Composables, replacing ~1,400 lines of Java/XML (activity, 3 fragments, base fragment, 9 layouts, menu, drawable). Public Java API on `GotoActivity` (`createIntent` / `obtainResult` / `Result`) is preserved so call sites in `IsiActivity` keep working unchanged.
+- The iOS-style color picker added in [REM-20](REM-20-ambilwarna-replacement.md) is also a Compose surface (`IosColorPicker` + `ColorPickerDialog`) hosted inside a `ModalBottomSheet`.
+
+**Remaining steps:**
+1. Continue with simpler screens: `AboutActivity.kt` (Kotlin, View-based with custom animations), `HelpActivity.java` (Java, WebView-based — convert to Kotlin first)
+2. Gradually migrate: `SettingsActivity` → Compose Preference screens
+3. Do NOT migrate `IsiActivity` verse rendering — too complex and performance-critical for initial Compose adoption
+
+**Difficulty:** Hard (ongoing effort over months). Risk: Compose interop with existing View-based code requires careful fragment/activity management.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-23-ybuild-gradle.md
+++ b/docs/tech-debt-remediation/REM-23-ybuild-gradle.md
@@ -1,0 +1,115 @@
+# ~~REM-23: Port ybuild.sh to Gradle~~ ✅ COMPLETED (2026-04-16)
+
+**Addresses:** TD-14
+**Module:** Build
+**BRICE:** B=4 R=3 I=3 C=4 E=5 → **3.8**
+**Phase:** 2 — Architecture Improvements
+
+**Outcome:** `ybuild.sh` deleted. Production builds are now `./gradlew assemble<Flavor>Release`, working on any platform Gradle supports. The placeholder `ddd_*` Bible files moved from `Alkitab/src/main/assets/internal/` to `Alkitab/src/plain/assets/internal/` so production flavors don't inherit them. A typed `CopyProprietaryAssetsTask` per production flavor copies `$ALKITAB_PROPRIETARY_DIR/overlay/<applicationId>/text_raw/*` into `Alkitab/build/generated/proprietaryAssets/<flavor>/internal/`, wired into AGP via `androidComponents { onVariants { ... addGeneratedSourceDirectory(...) } }` so every consumer (mergeAssets, lint vital, etc.) automatically depends on it. The git commit hash is now `BuildConfig.LAST_COMMIT_HASH` (the `R.string.last_commit_hash` resource was removed). APKs are still named `Alkitab-{versionCode}-{versionName}-{commitHash}-{applicationId}-{BUILD_DIST}.apk` (with `BUILD_DIST` defaulting to `dev`). All four flavors (plain debug, yuku_alkitab, yuku_quick_bible, sabda_alkitab) verified building end-to-end.
+
+---
+
+## Original analysis & steps (for reference)
+
+Production release builds required running `ybuild.sh`, a 168-line macOS-only bash script that created a RAM disk, copied proprietary assets from an external directory, stamped the git commit hash, ran Gradle, and renamed the output APK. This could not run on Linux CI and prevented building with a simple `./gradlew assembleYuku_alkitabRelease`.
+
+Gradle already handled signing (`signingConfigs.release` at `Alkitab/build.gradle:32-38`) and product flavors (lines 72-87). What was missing were 4 operations that could all be expressed as Gradle tasks.
+
+**Step 23a: Proprietary asset injection via Gradle**
+1. Add an `ALKITAB_PROPRIETARY_DIR` environment variable check in `Alkitab/build.gradle` — only required for non-`plain` flavors
+2. For each production flavor (`yuku_alkitab`, `yuku_quick_bible`, `sabda_alkitab`), define a mapping from flavor to its `BUILD_PACKAGE_NAME` overlay subdirectory (e.g., `yuku_alkitab` → `yuku`)
+3. Register a `preBuild`-dependent task (e.g., `copyProprietaryAssets${flavorName}`) that:
+   - Deletes `Alkitab/src/main/assets/internal/`
+   - Copies files from `$ALKITAB_PROPRIETARY_DIR/overlay/$BUILD_PACKAGE_NAME/text_raw/*` into `Alkitab/src/main/assets/internal/`
+4. Alternatively, use `sourceSets` to point each production flavor's `assets.srcDirs` to the proprietary directory directly, avoiding the copy:
+   ```groovy
+   yuku_alkitab {
+       applicationId 'yuku.alkitab'
+       assets.srcDirs = ['src/main/assets_without_internal', "$proprietaryDir/overlay/yuku"]
+   }
+   ```
+   This would require restructuring `src/main/assets` so that `internal/` is in its own source set.
+
+**Step 23b: Git commit hash injection via Gradle**
+1. Add a task that reads the git commit hash:
+   ```groovy
+   def gitHash = providers.exec {
+       commandLine 'git', 'log', '-1', '--format=format:%h'
+   }.standardOutput.asText.get().trim()
+   ```
+2. Option A: Generate `last_commit.xml` as a build output (preferred — avoids modifying source):
+   ```groovy
+   android.applicationVariants.all { variant ->
+       def task = tasks.register("generateLastCommit${variant.name.capitalize()}") {
+           def outputDir = layout.buildDirectory.dir("generated/res/lastCommit/${variant.name}")
+           outputs.dir(outputDir)
+           doLast {
+               def dir = outputDir.get().asFile
+               new File(dir, "values/last_commit.xml").with {
+                   parentFile.mkdirs()
+                   text = """<?xml version="1.0" encoding="utf-8"?>
+   <resources><string name="last_commit_hash">${gitHash}</string></resources>"""
+               }
+           }
+       }
+       variant.registerGeneratedResFolders(project.files(task.map { it.outputs.files.singleFile }))
+   }
+   ```
+3. Option B (simpler): Use `buildConfigField` instead of a resource:
+   ```groovy
+   defaultConfig {
+       buildConfigField 'String', 'LAST_COMMIT_HASH', "\"${gitHash}\""
+   }
+   ```
+   Then update code that reads `R.string.last_commit_hash` to read `BuildConfig.LAST_COMMIT_HASH`. Grep for `last_commit_hash` to find all readers.
+
+**Step 23c: Custom APK naming via Gradle**
+1. Use the existing `applicationVariants.all` block (line 99 of `Alkitab/build.gradle`) to set the output filename:
+   ```groovy
+   android.applicationVariants.all { variant ->
+       variant.outputs.all { output ->
+           def flavor = variant.flavorName
+           def buildType = variant.buildType.name
+           def dist = System.getenv("BUILD_DIST") ?: "dev"
+           def pkgName = System.getenv("BUILD_PACKAGE_NAME") ?: "plain"
+           outputFileName = "Alkitab-${variant.versionCode}-${variant.versionName}-${gitHash}-${pkgName}-${dist}.apk"
+       }
+   }
+   ```
+
+**Step 23d: Remove RAM disk dependency**
+1. The RAM disk served two purposes: build isolation and speed. Neither is necessary:
+   - **Isolation:** Gradle's `build/` directory already isolates outputs. `./gradlew clean` handles cleanup.
+   - **Speed:** Modern SSDs make the speed benefit negligible. CI runners typically have fast storage.
+2. No Gradle changes needed — just stop using the RAM disk.
+
+**Step 23e: Validate environment and retire ybuild.sh**
+1. Add a validation task that checks required env vars for production flavors:
+   ```groovy
+   tasks.register("validateProductionEnv") {
+       doFirst {
+           if (System.getenv("ALKITAB_PROPRIETARY_DIR") == null) {
+               throw new GradleException("ALKITAB_PROPRIETARY_DIR not set")
+           }
+           // ... check SIGN_KEYSTORE, etc.
+       }
+   }
+   // Wire it: only for non-plain release builds
+   ```
+2. After all steps are verified, delete `ybuild.sh` and update documentation
+3. The new build command becomes:
+   ```bash
+   ALKITAB_PROPRIETARY_DIR=/path/to/proprietary \
+   BUILD_PACKAGE_NAME=yuku \
+   BUILD_DIST=playstore \
+   SIGN_KEYSTORE=/path/to/keystore \
+   SIGN_ALIAS=mykey \
+   SIGN_PASSWORD=secret \
+   ./gradlew assembleYuku_alkitabRelease
+   ```
+
+**Difficulty:** Medium (1-2 days). Step 23a (asset injection) is the trickiest part — need to decide between copy-on-build vs. sourceSets approach. Steps 23b-23d are straightforward Gradle configuration. Low risk since existing `ybuild.sh` can remain as fallback during transition.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-24-s-service-locator.md
+++ b/docs/tech-debt-remediation/REM-24-s-service-locator.md
@@ -1,0 +1,89 @@
+# REM-24: Refactor S.kt Service Locator — Steps 24a–24d complete 2026-05-12
+
+**Addresses:** TD-15
+**Module:** Cross-cutting (50 files)
+**BRICE:** B=4 R=2 I=2 C=3 E=5 → **3.2**
+**Phase:** 2 — Architecture Improvements
+
+**Status:** Steps 24a (interface extraction), 24b (UI dialog removal), 24c (thread-safety fix), and 24d (AppServices container + caller migration) all complete as of 2026-05-12. ~216 direct `S.xxx` references across 44 files migrated to `App.services.*`. The `S` adapter properties (`S.storage`, `S.versions`, `S.uiDimensions`) and the legacy `@JvmStatic` accessors are retained so any new caller written against `S.foo` keeps compiling; new code should prefer `App.services`. 24e (Hilt) is still optional/deferred.
+
+**24d caller-migration follow-up shipped 2026-05-12:**
+- `App.services` is now initialized eagerly at the static field declaration in `App.java` rather than only inside `staticInit()`. This keeps `App.services.*` non-null for callers that exercise migrated code in tests that deliberately bypass `App.onCreate()` / `App.staticInit()` (e.g. `ProviderTest`, `VerseRendererTest`'s setup). The adapter objects on `S` only touch context/preferences when their methods are invoked, so eager init is safe before `App.context` is set.
+- `AppServices`'s `storage` / `versions` / `uiDimensions` fields are annotated `@JvmField` so Java callers can write `App.services.versions.activeVersion()` (matching Kotlin syntax) instead of `App.services.getVersions().activeVersion()`.
+- One deliberately un-migrated call site remains: the `S.db.listAllVersions().isEmpty()` check inside `IsiActivity.openVersionsDialog`. The rest of that method already uses `App.services.versions`; the single `S.db` line is left for the next person touching that method to migrate, to keep diffs cohesive.
+
+**What shipped on 2026-05-12:**
+- New `yuku.alkitab.base.services` package with `StorageProvider`, `VersionManager`, `UiDimensionsProvider`, and `AppServices` (see `Alkitab/src/main/java/yuku/alkitab/base/services/`).
+- `S` exposes three adapter properties (`S.storage`, `S.versions`, `S.uiDimensions`) that implement the new interfaces. `@JvmStatic` is retained on the original `S.db`, `S.applied()`, `S.activeVersion()` etc. so existing Java call sites keep compiling — these are the migration target for the rest of 24d.
+- `openVersionsDialog` / `openVersionsDialogWithNone` moved off `S` into `yuku.alkitab.base.util.VersionDialogHelper`. Callers in `IsiActivity.kt` and `SearchActivity.kt` were updated.
+- `recalculateAppliedValuesBasedOnPreferences()` renamed to `recalculate()` to match the interface (single call site in `IsiActivity.kt`).
+- Active-version state collapsed from three mutable nullable fields to a single `@Volatile var state: ActiveVersionState` data-class reference so all readers see a consistent `(mVersion, version, versionId)` triple.
+- `App.staticInit()` now constructs `App.services = new AppServices(S.storage, S.versions, S.uiDimensions)` before any other init step.
+- `AppServicesTest` (4 cases) demonstrates the new interfaces are fake-implementable in pure JUnit — no Robolectric or Android context required.
+
+**Current state:** `S.kt` (313 lines) is a Kotlin `object` singleton mixing database access (`db`, `songDb`), active version state, and UI dimensions (`CalculatedDimensions`). Imported by 50 files with 161+ call sites. Untestable without a full Android environment.
+
+**Recommended approach: Incremental interface extraction, then manual DI**
+
+Hilt/Dagger adds significant complexity (annotation processing, code generation) for a codebase that doesn't yet use any DI. A lighter approach is to extract interfaces first, then provide them via a simple app-level container.
+
+**Steps:**
+
+**Step 24a: Extract interfaces (no DI yet, no callers change)**
+1. Create `StorageProvider` interface:
+   ```kotlin
+   interface StorageProvider {
+       val db: InternalDb
+       val songDb: SongDb
+   }
+   ```
+2. Create `VersionManager` interface:
+   ```kotlin
+   interface VersionManager {
+       fun activeVersion(): Version
+       fun activeMVersion(): MVersion
+       fun activeVersionId(): String
+       fun setActiveVersion(mv: MVersion)
+       fun getVersionFromVersionId(versionId: String?): MVersion?
+       fun getAvailableVersions(): List<MVersion>
+       fun getMVersionInternal(): MVersionInternal
+   }
+   ```
+3. Create `UiDimensionsProvider` interface:
+   ```kotlin
+   interface UiDimensionsProvider {
+       fun applied(): CalculatedDimensions
+       fun recalculate()
+   }
+   ```
+4. Make `S` implement all three interfaces, delegating to its existing internal holders. This is a no-op refactor — all existing `S.db` / `S.applied()` / `S.activeVersion()` calls keep working.
+
+**Step 24b: Move UI dialogs out of S**
+1. Move `openVersionsDialog()` and `openVersionsDialogWithNone()` (lines 271-320) into a standalone `VersionDialogHelper` object or extension function. These are UI operations that don't belong in a service locator.
+
+**Step 24c: Fix thread safety**
+1. Make `activeVersion()` / `activeMVersion()` / `activeVersionId()` getters `@Synchronized` to match the setter
+2. Or better: replace the three mutable fields with a single `AtomicReference<ActiveVersionState>` data class to ensure atomic reads
+
+**Step 24d: Introduce app-level service container**
+1. Create `AppServices` class initialized in `App.onCreate()`:
+   ```kotlin
+   class AppServices(
+       val storage: StorageProvider,
+       val versions: VersionManager,
+       val uiDimensions: UiDimensionsProvider,
+   )
+   ```
+2. Initialize in `App`: `val services = AppServices(S, S, S)` — initially delegates back to `S`
+3. New code uses `App.services.storage.db` instead of `S.db`
+4. Gradually migrate existing callers (50 files, can be done file-by-file)
+5. In tests, provide fake implementations of the interfaces
+
+**Step 24e: (Optional, later) Migrate to Hilt**
+If the project adopts Hilt for other reasons (e.g., ViewModel injection in [REM-09](REM-09-isiactivity-viewmodel.md)), the interfaces from Step 24a become `@Provides` targets naturally.
+
+**Difficulty:** Medium-Hard (2-3 days for steps 24a-24c, then ongoing migration for 24d). Step 24a is the critical enabler — once interfaces exist, the rest is incremental.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-25-verserenderer-decompose.md
+++ b/docs/tech-debt-remediation/REM-25-verserenderer-decompose.md
@@ -1,0 +1,20 @@
+# ~~REM-25: Decompose VerseRenderer.render()~~ ✅ COMPLETED (2026-04-20)
+
+**Addresses:** TD-10
+**Module:** Main reader (verse rendering)
+**BRICE:** B=3 R=2 I=4 C=4 E=4 → **3.4**
+**Phase:** 3 — Modernization
+
+**Outcome:** The 200-line `render()` method in `VerseRenderer.java` (lines 71–271 before the refactor) is now an orchestrator that delegates to four named helpers:
+- `renderVerseNumber(sb, text_c, text_len, isVerseNumberShown, verseNumberText, checked) → int` — embeds the inline verse number (and decides when `@^`/`@1`–`@4` should suppress it), returns the start position past the prefix
+- `processFormattingCodes(text, text_c, text_len, sb, startPosAfterVerseNumber, verseNumberText, checked, ari, factory)` — runs the marker loop (paragraph, italic, red, line break, special tags) and flushes the trailing paragraph's `applyParaStyle`
+- `applyHighlight(sb, highlightInfo, startPosAfterVerseNumber)` — attaches the `BackgroundColorSpan`, including the partial-highlight hash check
+- `bindToTextViews(lText, lVerseNumber, sb, isVerseNumberShown, startPosAfterVerseNumber, verseNumberText)` — pushes the result into the optional `TextView`s
+
+The pre-existing `applyParaStyle` and `processSpecialTag` helpers were kept as-is. No public API change. Behavior preservation is enforced by the 39 Robolectric characterization tests added in commit `ec5e058` (`VerseRendererTest.kt`), which lock in every code path including the `@@@0Body` two-paragraph quirk and the `checked=true` red-letter suppression. Full Alkitab unit test suite (313 tests) and `assemblePlainDebug` both still pass.
+
+**Out of scope (TD-10 leftover):** the undocumented `superscriptDigits` Unicode constant on `VerseRenderer.java:23` — addressed in the follow-up [REM-26](REM-26-verserenderer-kotlin.md) Kotlin port.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt-remediation/REM-26-verserenderer-kotlin.md
+++ b/docs/tech-debt-remediation/REM-26-verserenderer-kotlin.md
@@ -1,0 +1,18 @@
+# ~~REM-26: Port VerseRenderer to Kotlin~~ ✅ COMPLETED (2026-04-20)
+
+**Addresses:** TD-10 (leftover Unicode-constants comment), TD-11 (one of the listed Java files)
+**Module:** Main reader (verse rendering)
+**BRICE:** B=3 R=2 I=4 C=5 E=5 → **3.8**
+**Phase:** 3 — Modernization
+
+**Outcome:** `VerseRenderer.java` is now `VerseRenderer.kt` — a Kotlin `object` with `@JvmStatic` on the public `render` and `appendSuperscriptNumber` entry points, idiomatic `when` over the marker switch, range-based char checks (`text_c[3] in '1'..'4'`), and proper nullable types on optional parameters. All four parameters that the deleted `VerseRendererJavaHelper` shimmed (`lText`, `lVerseNumber`, `isVerseNumberShown`, `verseNumberText`, `highlightInfo`, `checked`, `inlineLinkSpanFactory`, `ftr`) now have Kotlin default values directly on `render`, with `verseNumberText` defaulting to `Ari.toVerse(ari).toString()`. The four callers of `VerseRendererJavaHelper.render(...)` (`MarkerListActivity`, `VerseActionModeController`, `VersesControllerImpl`, `RibkaReportActivity`) now call `VerseRenderer.render(...)` directly.
+
+The previously-documented private helpers (`renderVerseNumber`, `processFormattingCodes`, `applyHighlight`, `bindToTextViews`, `applyParaStyle`, `simpleRender`, `processSpecialTag`, `reportInvalidSpecialTag`, `createLeadingMarginSpan`) are now genuinely `private` — Kotlin lets us tighten visibility from Java's package-private default. No public API changes; the only caller-visible adjustment is `FormattedTextResult.result` becoming a typed nullable `CharSequence?` (matching the actual Java semantics), which surfaced one previously-implicit `!!` in `MarkerListActivity`.
+
+The undocumented Unicode constants flagged in TD-10 (the `superscriptDigits` array and `XREF_MARK`) now have inline comments naming the code points and what they're used for.
+
+Behavior preservation enforced by the same 39 Robolectric characterization tests (`VerseRendererTest.kt`) plus 274 other Alkitab tests — all 313 pass on both `testPlainDebugUnitTest` and `testPlainReleaseUnitTest`. `VerseRendererJavaHelper.kt` deleted.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -1,27 +1,33 @@
 # Tech Debt, Improvements & Critiques
 
-## TD-01: IsiActivity God Class (~2371 lines)
+## TD-01: IsiActivity God Class (~2170 lines)
 
 **File:** `Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt`
 
-The main Bible reader activity is a monolithic class containing many inline lambda callbacks, ~2371 lines of mixed concerns (down from 2897 after REM-07 extracted action mode, then back up slightly to 2452 with the audio-bible M1–M4 additions, now down to 2371 after REM-06 extracted gesture handling). Specific clusters that violate single-responsibility:
+The main Bible reader activity, down from 2897 lines after a series of extractions: REM-07 (action mode → `VerseActionModeController`), REM-06 (gestures → `ReaderGestureHandler`), and REM-08 (split view → `SplitViewManager`). The remaining ~2170 lines still contain mixed concerns. Specific clusters that violate single-responsibility:
 
 - **~~Gesture handling~~** ✅ **Extracted (REM-06):** The three gesture lambdas — `splitRoot_listener` (`TwofingerLinearLayout.Listener` for pinch zoom + one/two-finger swipes), `bGoto_floaterDrag` (`GotoButton.FloaterDragListener`), and `floater_listener` (`Floater.Listener`) — have been moved to `ReaderGestureHandler.kt` behind two interfaces (`ReaderGestureHost`, `ReaderGestureActions`). The activity now wires a single `gestureHandler` lazy field into all three setListener call sites. Gesture-local state (`startFontSize`, `startDx`, `moreSwipeYAllowed`, `chapterSwipeCellWidth`, `floaterLocationOnScreen`) lives on the handler instead of in inline objects.
 - **~~Action mode~~** ✅ **Extracted (REM-07):** The ~500-line `actionMode_callback` object has been moved to `VerseActionModeController.kt` behind two interfaces (`VerseActionModeHost`, `VerseActionModeActions`). Pure text-building logic is in `VerseTextFormatter` (no Android deps). `RibkaEligibility` is a top-level file. 26 unit tests added.
-- **Broadcast receivers (lines 451–519):** Two anonymous `BroadcastReceiver` instances registered inline, one for verse attribute changes and one for version changes.
-- **Verse selection listeners (lines 463–525):** Two `SelectedVersesListener` implementations (`lsSplit0_selectedVerses`, `lsSplit1_selectedVerses`) with partially duplicated logic.
-- **Split view management:** `openSplitDisplay()`, `closeSplitDisplay()`, `displaySplitFollowingMaster()`, `loadSplitVersion()` scattered across the file.
+- **~~Broadcast receivers~~** ✅ **Replaced (REM-03):** The two inline `BroadcastReceiver` registrations for verse-attribute and version changes are gone — `IsiActivity` now collects from the `AppEvents` `SharedFlow` buses via `lifecycleScope.launch { ... }`. `LocalBroadcastManager` is removed from the dependencies entirely.
+- **Verse selection listeners:** Two `SelectedVersesListener` implementations (`lsSplit0_selectedVerses`, `lsSplit1_selectedVerses`) with partially duplicated logic — still inline.
+- **~~Split view management~~** ✅ **Extracted (REM-08):** `openSplitDisplay()`, `closeSplitDisplay()`, `displaySplitFollowingMaster()`, `loadSplitVersion()`, and the three split-handle / global-layout listeners have moved to `SplitViewManager.kt` behind `SplitViewHost` / `SplitViewActions`. `IsiActivity.activeSplit1` is now a read-only getter that delegates to the manager.
 - **Navigation history:** `BackForwardListController` usage, `jumpToAri()`, `jumpTo(reference)`, `History` tracking.
 
-**Impact:** Any change to one concern risks breaking unrelated functionality. Testing individual behaviors requires instantiating the entire Activity. New developers face a ~2371-line class with no clear entry point.
+**Impact:** Any change to one concern risks breaking unrelated functionality. Testing individual behaviors requires instantiating the entire Activity. New developers face a ~2170-line class with no clear entry point.
 
 ---
 
-## TD-02: InternalDb — Raw SQL & Manual Statement Caching (830 lines, was 1771)
+## TD-02: InternalDb — Raw SQL & Manual Statement Caching (~757 lines, was 1771)
 
 **File:** `Alkitab/src/main/java/yuku/alkitab/base/storage/InternalDb.java`
 
-**Status:** Significantly improved. Per-table DAOs (`MarkerDao`, `LabelDao`, `VersionDao`, `DevotionDao`, `ReadingPlanDao`, `ProgressMarkDao`, `PerVersionDao`, `Marker_LabelDao`, `SyncShadowDao`) and `SyncApplier` were extracted in `d805265e`, shrinking `InternalDb.java` from 1771 → 830 lines. Further null-safety cleanup landed in `70c97818`. The remaining issues below are the parts not covered by that refactor.
+**Status:** Significantly improved.
+
+1. Per-table DAOs (`MarkerDao`, `LabelDao`, `VersionDao`, `DevotionDao`, `ReadingPlanDao`, `ProgressMarkDao`, `PerVersionDao`, `Marker_LabelDao`, `SyncShadowDao`) and `SyncApplier` were extracted in `d805265e`, shrinking `InternalDb.java` from 1771 → 830 lines. Further null-safety cleanup landed in `70c97818`.
+2. ✅ **REM-11 (Version table → Room, 2026-05-13)** — the `Version` table moved into a new separate-file Room database (`AlkitabRoomDb`). `VersionDao` is now a facade that routes through Room. Legacy `Version` table left in place as a rollback safety net.
+3. ✅ **REM-10 (Marker / Label / Marker_Label → Room, 2026-05-14)** — the three legacy hand-rolled SQLite tables for the marker subsystem also moved into Room (same `AlkitabRoomDb`, bumped to `@Database(version = 2)` via `MIGRATION_1_2`). `MarkerDao` / `LabelDao` / `Marker_LabelDao` are facades that delegate to the Room DAOs.
+
+The remaining issues below are the parts not covered by those refactors (the not-yet-migrated tables — `ReadingPlan`, `Devotion`, `SyncShadow`, `SyncLog`, `PerVersion`, `ProgressMark` — still go through raw SQL).
 
 ### Raw SQL string concatenation (~10 instances remain)
 Examples at `InternalDb.java:134, 137, 180, 593–597, 632–646`:
@@ -163,15 +169,19 @@ The `superscriptDigits` array now has an inline comment naming the Unicode code 
 
 ## TD-11: Mixed Java/Kotlin
 
-Core files still in Java with no clear migration plan:
-- `InternalDb.java` (1771 lines)
-- `SearchEngine.java` (537 lines)
+Core files still in Java:
+- `InternalDb.java` (~757 lines; partially superseded for the marker / version tables by Room facade DAOs — see TD-02)
+- ~~`SearchEngine.java`~~ ✅ ported to `SearchEngine.kt` (REM-16, 2026-05-13)
 - ~~`VerseRenderer.java`~~ ✅ ported to Kotlin (REM-26)
-- `Sync.java` (508 lines)
-- `SyncAdapter.java` (600+ lines)
-- `DevotionDownloader.java` (111 lines)
-- `Provider.java` (content provider)
-- `Highlights.java`, `Jumper.java`, `TargetDecoder.java`
+- `Sync.java` (~571 lines)
+- `SyncAdapter.java` (~630 lines)
+- ~~`DevotionDownloader.java`~~ ✅ ported to `DevotionDownloader.kt` (REM-16, 2026-05-13)
+- ~~`Provider.java`~~ ✅ ported to `Provider.kt` (REM-16, 2026-05-13)
+- ~~`Highlights.java`~~ ✅ ported to `Highlights.kt` (REM-16, 2026-05-12)
+- ~~`Jumper.java`~~ ✅ ported to `Jumper.kt` (REM-16, 2026-05-12)
+- ~~`TargetDecoder.java`~~ ✅ ported to `TargetDecoder.kt` (REM-16, 2026-05-13)
+- ~~`QueryTokenizer.java`~~ ✅ ported to `QueryTokenizer.kt` (REM-16, 2026-05-13)
+- ~~`SongBookUtil.java`~~ ✅ ported to `SongBookUtil.kt` (REM-16, 2026-05-13)
 - All devotion article parsers
 
 Newer files (activities, data classes) are Kotlin, creating a mixed codebase where Java code can't use Kotlin features (extension functions, coroutines, sealed classes, null safety).
@@ -245,9 +255,11 @@ BUILD_DIST=market \
 
 ## TD-15: S.kt — God Object Service Locator
 
-**File:** `Alkitab/src/main/java/yuku/alkitab/base/S.kt` (313 lines)
+**File:** `Alkitab/src/main/java/yuku/alkitab/base/S.kt` (~317 lines)
 
-A Kotlin `object` singleton that serves as the central service locator for the entire app, mixing three unrelated concerns:
+**Status:** Substantially improved by REM-24 (steps 24a–24d complete as of 2026-05-12). Three interfaces — `StorageProvider`, `VersionManager`, `UiDimensionsProvider` — have been extracted under `yuku.alkitab.base.services`, bundled into an `AppServices` container, and exposed via `App.services`. ~216 direct `S.xxx` references across 44 files have been migrated to `App.services.*`. The legacy `S.foo` accessors and the `S.storage` / `S.versions` / `S.uiDimensions` adapter properties are retained so existing callers compile; new code should depend on `App.services`. Active-version state was collapsed into a single `@Volatile var state: ActiveVersionState` data-class reference so all readers see a consistent `(mVersion, version, versionId)` triple (24c). `openVersionsDialog` / `openVersionsDialogWithNone` moved off `S` into `VersionDialogHelper` (24b).
+
+A Kotlin `object` singleton that historically served as the central service locator for the entire app, mixing three unrelated concerns:
 
 ### 1. Database access
 - `S.db` — lazy `InternalDb` instance (markers, labels, bookmarks, reading plans, sync, devotions)


### PR DESCRIPTION
## Summary

Several pieces of `CLAUDE.md` and the `docs/` tree had fallen behind the code on `develop` after recent remediation sprints. This is a docs-only pass that grounds each edit against the current code, the tech-debt-remediation entries, and the merged PRs (REM-06/07/08/10/11/16/19/20/24).

**Removed/architectural drift**
- `PrDownloaderFixed` module no longer exists (REM-19, PR #186) — dropped from the module tables in `CLAUDE.md` and `docs/architecture.md`. The download path is now `VersionDownloadWorker` (`CoroutineWorker` + OkHttp + Range-based resume), observed by `DownloadMapper` via `WorkManager.getWorkInfoByIdFlow`. `docs/backend-communication.md` updated to match.
- `S.kt` is no longer described as the single central service locator. Updated `CLAUDE.md` and `docs/architecture.md` to lead with `App.services` (the `AppServices` container with `StorageProvider` / `VersionManager` / `UiDimensionsProvider`) introduced in REM-24, while noting that the `S.foo` legacy accessors are still retained for incremental migration.
- `IsiActivity.kt` line count corrected from "~2900" / "~2371" to "~2170", and the gesture / action-mode / split-view clusters are now noted as extracted into `ReaderGestureHandler` (REM-06), `VerseActionModeController` (REM-07), and `SplitViewManager` (REM-08). Same fix applied in `docs/tech-debt.md` TD-01.

**Database schema (the big one)**
- `docs/storage.md` and the `CLAUDE.md` schema section now describe the two-file setup that landed in REM-10 / REM-11: the new `AlkitabRoomDb` Room database (`AppDatabase` at `@Database(version = 2)`, with `version` / `marker` / `label` / `marker_label`) plus the legacy `AlkitabDb` (`InternalDbHelper`) which still owns the not-yet-migrated tables (`ProgressMark`, `ReadingPlan*`, `Devotion`, `SyncShadow`/`SyncLog`, `PerVersion`). Documented the facade DAOs and the one-time `MarkerDataMigration` / `VersionDataMigration` copy wired from `S.db`'s lazy initializer.
- `docs/tech-debt-remediation.md`: REM-11 was marked as "Steps:" / not-yet-done; updated body, priority-summary row, and Sprint-5 line to mark it complete (2026-05-13). REM-10 already had a body entry but its summary row didn't have the strikethrough — fixed.
- `docs/tech-debt.md` TD-02 updated to record both Room migrations as the major progress on top of the earlier DAO extraction.

**Java → Kotlin (REM-16)**
- `docs/modules/markers.md`, `versions.md`, `search.md`, `devotions.md`, `songs.md`: switched the `.java` file paths to `.kt` for `Highlights`, `Jumper`, `TargetDecoder`, `QueryTokenizer`, `SearchEngine`, `Provider`, `DevotionDownloader`, `SongBookUtil`. Each entry includes a brief "ported in REM-16" pointer so future readers can find the context.
- `docs/tech-debt.md` TD-11 mirrors the updated list.

**Smaller corrections**
- `docs/modules/markers.md` notes the iOS-style Compose color picker that replaced `AmbilWarna` in REM-20.
- `docs/modules/versions.md`, `markers.md`: `ItemTouchHelper`-driven drag (REM-12) instead of `DragSortListView`.
- `docs/modules/sync.md`: documents the FCM retry chain from REM-04 and the PB-03 last-write-wins limitation.
- `docs/modules/devotions.md`: describes the executor-based shutdown path from REM-05.
- `docs/architecture.md`: threading-model section reflects the actual WorkManager / coroutines split rather than "no coroutines anywhere".
- `docs/tech-debt.md` TD-15 marks the S.kt service-locator critique as substantially improved by REM-24 24a-24d.

No code changes — `assemblePlainDebug` and the test suite are unaffected.

## Test plan

- [ ] Skim each touched markdown file to confirm internal links still resolve
- [ ] Confirm the new "two SQLite files" framing in `docs/storage.md` and `CLAUDE.md` matches `AppDatabase.kt` / `InternalDbHelper.java`
- [ ] No build needed (docs-only) — but `./gradlew assemblePlainDebug` should still succeed

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJKRTPnMkFXfDFVaX7RWVv)_