### PR TITLE
fix #195: anchor REM-10 / REM-11 migration idempotency on a persistent flag

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/Prefkey.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/Prefkey.kt
@@ -136,4 +136,23 @@ enum class Prefkey {
      * Audio bible: playback speed (float, 0.5–2.0). Default 1.0.
      */
     audioPlaybackSpeed,
+
+    /**
+     * One-shot completion flag for the REM-10 `Marker` / `Label` / `Marker_Label`
+     * copy from the legacy `AlkitabDb` tables into Room. Set to true exactly
+     * once after the migration has either successfully copied all legacy rows
+     * or determined there is nothing to copy. Used in place of a count-based
+     * "are the Room tables empty?" check, which would resurrect deleted user
+     * data: if the user (or sync) deletes every marker/label after migration,
+     * the Room tables drop back to zero rows and a count check would re-copy
+     * the legacy rows on next launch. See GitHub issue #195.
+     */
+    marker_data_migration_v1_done,
+
+    /**
+     * One-shot completion flag for the REM-11 `Version` copy from the legacy
+     * `AlkitabDb` table into Room. Same rationale as
+     * [marker_data_migration_v1_done] — see GitHub issue #195.
+     */
+    version_data_migration_v1_done,
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/MarkerDataMigration.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/MarkerDataMigration.kt
@@ -1,7 +1,9 @@
 package yuku.alkitab.base.storage.room
 
+import yuku.afw.storage.Preferences
 import yuku.alkitab.base.storage.Db
 import yuku.alkitab.base.storage.InternalDbHelper
+import yuku.alkitab.base.storage.Prefkey
 import yuku.alkitab.base.util.AppLog
 
 /**
@@ -10,12 +12,21 @@ import yuku.alkitab.base.util.AppLog
  * `marker` / `label` / `marker_label` tables in `AlkitabRoomDb` (managed
  * by [AppDatabase]).
  *
- * Idempotent: a no-op when *any* of the three Room tables already has rows.
- * The single combined check is intentional — the three tables migrate
- * together atomically inside a single Room transaction, so partial state
- * cannot exist; if even one of them is non-empty, the migration has already
- * run. If the copy fails mid-flight (e.g. process kill, OOM), Room rolls
- * back the whole transaction and the next launch retries cleanly.
+ * Idempotency is anchored on the persistent
+ * [Prefkey.marker_data_migration_v1_done] flag rather than on a "are the
+ * Room tables empty?" check. A count-based check resurrects deleted user
+ * data: after a successful migration, if the user (or a sync delete-all
+ * delta) clears every marker, label and marker_label, the Room tables drop
+ * back to zero rows; on the next launch the migration would re-copy the
+ * legacy rows and sync would push them back up to the server. See GitHub
+ * issue #195.
+ *
+ * Crash safety:
+ *  - If the Room insert transaction fails mid-flight, Room rolls back the
+ *    whole transaction and the flag is never set; the next launch retries.
+ *  - If the process is killed after the transaction commits but before the
+ *    flag is set, the next launch sees Room rows already present and takes
+ *    the upgrade-path branch below (sets the flag, does not re-copy).
  *
  * The legacy tables are intentionally left intact so a future release can
  * audit/rollback. See REM-10 in `docs/tech-debt-remediation.md`.
@@ -24,14 +35,20 @@ object MarkerDataMigration {
     private const val TAG = "MarkerDataMigration"
 
     fun copyFromLegacyDbIfNeeded(roomDb: AppDatabase, legacyHelper: InternalDbHelper) {
+        if (Preferences.getBoolean(Prefkey.marker_data_migration_v1_done, false)) {
+            return
+        }
+
         val markerDao = roomDb.markerDao()
         val labelDao = roomDb.labelDao()
         val mlDao = roomDb.markerLabelDao()
 
-        // Combined idempotency check: if ANY of the three Room tables has
-        // rows, we've already migrated (or the user has organically added
-        // data after a previous migration). Don't double-copy.
+        // Upgrade path for users who already migrated under the old
+        // count-based code (PR #191) and have not yet seen this version.
+        // Any non-empty Room table means the copy already happened; just set
+        // the flag and bail so we don't double-insert legacy rows.
         if (markerDao.count() > 0 || labelDao.count() > 0 || mlDao.count() > 0) {
+            Preferences.setBoolean(Prefkey.marker_data_migration_v1_done, true)
             return
         }
 
@@ -40,7 +57,10 @@ object MarkerDataMigration {
         val markerLabels = readLegacyMarkerLabels(legacyHelper)
 
         if (markers.isEmpty() && labels.isEmpty() && markerLabels.isEmpty()) {
-            // No legacy data either (fresh install). Nothing to copy.
+            // No legacy data either (fresh install). There will never be
+            // anything to copy now — mark done so future launches skip the
+            // legacy-read entirely.
+            Preferences.setBoolean(Prefkey.marker_data_migration_v1_done, true)
             return
         }
 
@@ -57,6 +77,9 @@ object MarkerDataMigration {
             if (labels.isNotEmpty()) labelDao.insertAll(labels)
             if (markerLabels.isNotEmpty()) mlDao.insertAll(markerLabels)
         }
+        // Set the flag only after a successful commit. A crash between here
+        // and the next launch is handled by the upgrade-path branch above.
+        Preferences.setBoolean(Prefkey.marker_data_migration_v1_done, true)
 
         AppLog.d(
             TAG,

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/VersionDataMigration.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/VersionDataMigration.kt
@@ -1,7 +1,9 @@
 package yuku.alkitab.base.storage.room
 
+import yuku.afw.storage.Preferences
 import yuku.alkitab.base.storage.Db
 import yuku.alkitab.base.storage.InternalDbHelper
+import yuku.alkitab.base.storage.Prefkey
 import yuku.alkitab.base.util.AppLog
 
 /**
@@ -9,35 +11,61 @@ import yuku.alkitab.base.util.AppLog
  * (managed by `InternalDbHelper`) into the Room `version` table in
  * `AlkitabRoomDb` (managed by [AppDatabase]).
  *
- * Idempotent: a no-op when the Room table already has rows. If the copy fails
- * mid-flight, the next launch retries. The legacy table is intentionally left
- * intact so a future release can audit/rollback.
+ * Idempotency is anchored on the persistent
+ * [Prefkey.version_data_migration_v1_done] flag rather than on a
+ * `dao.count() > 0` check. The count check would resurrect deleted user
+ * data: a user who deletes every downloaded version (or one who hasn't
+ * downloaded any yet, so the Room table is legitimately empty) would re-copy
+ * the legacy rows on every launch. See GitHub issue #195.
  *
- * See `docs/superpowers/specs/2026-05-13-rem-11-room-version-table-design.md`
+ * Crash safety:
+ *  - If the Room insert fails mid-flight, Room rolls back and the flag is
+ *    never set; the next launch retries.
+ *  - If the process is killed after the insert commits but before the flag
+ *    is set, the next launch sees Room rows already present and takes the
+ *    upgrade-path branch (sets the flag, does not re-copy).
+ *
+ * The legacy table is intentionally left intact so a future release can
+ * audit/rollback. See
+ * `docs/superpowers/specs/2026-05-13-rem-11-room-version-table-design.md`
  * for the migration rationale.
  */
 object VersionDataMigration {
     private const val TAG = "VersionDataMigration"
 
     fun copyFromLegacyDbIfNeeded(roomDb: AppDatabase, legacyHelper: InternalDbHelper) {
+        if (Preferences.getBoolean(Prefkey.version_data_migration_v1_done, false)) {
+            return
+        }
+
         val dao = roomDb.versionDao()
+
+        // Upgrade path for users who already migrated under the old
+        // count-based code (PR #188) and have not yet seen this version.
+        // Room having rows means the copy already happened; set the flag and
+        // bail so we don't double-insert.
         if (dao.count() > 0) {
-            // Already migrated (or app freshly installed and a previous version
-            // wrote to Room directly). Either way: nothing to do.
+            Preferences.setBoolean(Prefkey.version_data_migration_v1_done, true)
             return
         }
 
         val rows = readLegacyRows(legacyHelper)
         if (rows.isEmpty()) {
-            // No legacy data either (fresh install). Nothing to copy.
+            // No legacy data either (fresh install). Mark done so future
+            // launches skip the legacy-read entirely.
+            Preferences.setBoolean(Prefkey.version_data_migration_v1_done, true)
             return
         }
 
         // Bulk insert — Room's `@Insert` runs inside a single transaction, so
         // a crash mid-migration leaves zero rows in Room and the next launch
         // retries cleanly. Per-row inserts would leave a partial state and
-        // make `count() > 0` lie about completeness.
+        // would not be safely recoverable from the flag-only idempotency
+        // check.
         dao.insertAll(rows)
+        // Set the flag only after a successful commit. A crash between here
+        // and the next launch is handled by the upgrade-path branch above.
+        Preferences.setBoolean(Prefkey.version_data_migration_v1_done, true)
         AppLog.d(TAG, "Copied ${rows.size} version row(s) from legacy Version table to Room")
     }
 

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/MarkerDataMigrationTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/MarkerDataMigrationTest.kt
@@ -2,9 +2,11 @@ package yuku.alkitab.base.storage.room
 
 import android.app.Application
 import android.content.ContentValues
+import android.preference.PreferenceManager
 import androidx.room.Room
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -13,8 +15,10 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import yuku.afw.storage.Preferences
 import yuku.alkitab.base.storage.Db
 import yuku.alkitab.base.storage.InternalDbHelper
+import yuku.alkitab.base.storage.Prefkey
 
 /**
  * Verifies the one-time copy from the legacy `Marker` / `Label` /
@@ -31,6 +35,11 @@ class MarkerDataMigrationTest {
     fun setUp() {
         val app = RuntimeEnvironment.getApplication()
         yuku.afw.App.context = app
+        // Idempotency is anchored on a SharedPreferences flag. Clear it (and
+        // the [Preferences] static cache that may hold a previous test's
+        // SharedPreferences instance) so every test starts with a clean slate.
+        PreferenceManager.getDefaultSharedPreferences(app).edit().clear().commit()
+        Preferences.invalidate()
         legacy = InternalDbHelper(app)
         room = Room.inMemoryDatabaseBuilder(app, AppDatabase::class.java)
             .allowMainThreadQueries()
@@ -238,5 +247,96 @@ class MarkerDataMigrationTest {
         // contract is that _id is positive (fresh) rather than the legacy
         // _id literal we never asserted.
         assertTrue("expected positive Room _id, got ${row!!._id}", row._id > 0)
+    }
+
+    @Test
+    fun `does not resurrect deleted user data after the user clears every marker (issue #195)`() {
+        // Setup: legacy tables have data, mirroring a real upgrade from the
+        // pre-Room schema. The legacy rows are intentionally preserved as a
+        // rollback safety net even after migration.
+        insertLegacyMarker(gid = "m1", ari = 100)
+        insertLegacyLabel(gid = "L1", title = "L", ordering = 1)
+        insertLegacyMarkerLabel("ml1", "m1", "L1")
+
+        // First launch on the Room build: migration copies everything across.
+        MarkerDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertEquals(1, room.markerDao().listAll().size)
+        assertEquals(1, room.labelDao().listAll().size)
+        assertEquals(1, room.markerLabelDao().listAll().size)
+
+        // User (or a sync "delete all" delta) clears every marker, label and
+        // marker_label from Room. The legacy tables in AlkitabDb are
+        // deliberately not touched by any write path.
+        room.markerDao().deleteByGid("m1")
+        room.labelDao().deleteByGid("L1")
+        room.markerLabelDao().deleteByGid("ml1")
+        assertTrue(room.markerDao().listAll().isEmpty())
+        assertTrue(room.labelDao().listAll().isEmpty())
+        assertTrue(room.markerLabelDao().listAll().isEmpty())
+
+        // Next launch: migration runs again. With the old count-based gate,
+        // all three Room tables being empty caused the legacy rows to be
+        // re-copied — and sync would then push the resurrected markers up to
+        // the server, undoing the user's deletions on every device. With the
+        // flag-based gate the migration must be a strict no-op.
+        MarkerDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        assertTrue("legacy markers were resurrected", room.markerDao().listAll().isEmpty())
+        assertTrue("legacy labels were resurrected", room.labelDao().listAll().isEmpty())
+        assertTrue(
+            "legacy marker_labels were resurrected",
+            room.markerLabelDao().listAll().isEmpty(),
+        )
+    }
+
+    @Test
+    fun `successful copy sets the persistent done flag`() {
+        insertLegacyMarker(gid = "m1", ari = 100)
+
+        assertFalse(Preferences.getBoolean(Prefkey.marker_data_migration_v1_done, false))
+        MarkerDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertTrue(Preferences.getBoolean(Prefkey.marker_data_migration_v1_done, false))
+    }
+
+    @Test
+    fun `fresh install with no legacy data also sets the done flag`() {
+        // No legacy rows inserted. The migration has nothing to copy but must
+        // still mark itself done so subsequent launches don't keep querying
+        // the legacy DB.
+        assertFalse(Preferences.getBoolean(Prefkey.marker_data_migration_v1_done, false))
+        MarkerDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertTrue(Preferences.getBoolean(Prefkey.marker_data_migration_v1_done, false))
+    }
+
+    @Test
+    fun `upgrade path - flag unset but Room already has rows sets the flag without re-copying`() {
+        // Simulates a user who already migrated under the previous count-based
+        // code (PR #191) and is launching for the first time after this fix.
+        // Room is populated; legacy still has its preserved rows. The fix
+        // must NOT re-insert the legacy rows.
+        room.markerDao().insert(
+            MarkerEntity(
+                _id = 0L,
+                gid = "already-migrated",
+                ari = 999,
+                kind = 1,
+                caption = "already-migrated",
+                verseCount = 1,
+                createTime = 0,
+                modifyTime = 0,
+            ),
+        )
+        insertLegacyMarker(gid = "legacy-m1", ari = 100)
+        insertLegacyLabel(gid = "legacy-L1", title = "L", ordering = 1)
+
+        MarkerDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        // Existing Room state preserved; no legacy rows pulled in; flag set
+        // so future launches skip outright.
+        val rows = room.markerDao().listAll()
+        assertEquals(1, rows.size)
+        assertEquals("already-migrated", rows.single().gid)
+        assertTrue(room.labelDao().listAll().isEmpty())
+        assertTrue(Preferences.getBoolean(Prefkey.marker_data_migration_v1_done, false))
     }
 }

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/VersionDataMigrationTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/VersionDataMigrationTest.kt
@@ -2,9 +2,11 @@ package yuku.alkitab.base.storage.room
 
 import android.app.Application
 import android.content.ContentValues
+import android.preference.PreferenceManager
 import androidx.room.Room
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -13,8 +15,10 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import yuku.afw.storage.Preferences
 import yuku.alkitab.base.storage.Db
 import yuku.alkitab.base.storage.InternalDbHelper
+import yuku.alkitab.base.storage.Prefkey
 
 /**
  * Verifies the one-time copy from the legacy `Version` table into Room's
@@ -31,6 +35,11 @@ class VersionDataMigrationTest {
     fun setUp() {
         val app = RuntimeEnvironment.getApplication()
         yuku.afw.App.context = app
+        // Idempotency is anchored on a SharedPreferences flag. Clear it (and
+        // the [Preferences] static cache that may hold a previous test's
+        // SharedPreferences instance) so every test starts with a clean slate.
+        PreferenceManager.getDefaultSharedPreferences(app).edit().clear().commit()
+        Preferences.invalidate()
         legacy = InternalDbHelper(app)
         room = Room.inMemoryDatabaseBuilder(app, AppDatabase::class.java)
             .allowMainThreadQueries()
@@ -149,5 +158,77 @@ class VersionDataMigrationTest {
         val rows = room.versionDao().listAll()
         assertEquals(1, rows.size)
         assertEquals("/existing.yes", rows.single().filename)
+    }
+
+    @Test
+    fun `does not resurrect deleted user data after the user clears every version (issue #195)`() {
+        // Setup: a legacy install with one downloaded version row that the
+        // migration is supposed to bring across exactly once.
+        insertLegacyRow("/a.yes", 101)
+
+        // First launch: migration copies the legacy row.
+        VersionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertEquals(1, room.versionDao().listAll().size)
+
+        // User deletes the downloaded version through the UI (or it's
+        // removed via "Manage versions"). Room is now empty; legacy table
+        // still has the original row.
+        room.versionDao().deleteByFilename("/a.yes")
+        assertTrue(room.versionDao().listAll().isEmpty())
+
+        // Next launch: the old `dao.count() > 0` gate would re-copy the
+        // legacy row. The flag-based gate must keep Room empty.
+        VersionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        assertTrue("legacy version rows were resurrected", room.versionDao().listAll().isEmpty())
+    }
+
+    @Test
+    fun `successful copy sets the persistent done flag`() {
+        insertLegacyRow("/a.yes", 101)
+
+        assertFalse(Preferences.getBoolean(Prefkey.version_data_migration_v1_done, false))
+        VersionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertTrue(Preferences.getBoolean(Prefkey.version_data_migration_v1_done, false))
+    }
+
+    @Test
+    fun `fresh install with no legacy data also sets the done flag`() {
+        // No legacy rows inserted. The migration has nothing to copy but
+        // must still mark itself done so subsequent launches don't keep
+        // querying the legacy DB.
+        assertFalse(Preferences.getBoolean(Prefkey.version_data_migration_v1_done, false))
+        VersionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertTrue(Preferences.getBoolean(Prefkey.version_data_migration_v1_done, false))
+    }
+
+    @Test
+    fun `upgrade path - flag unset but Room already has rows sets the flag without re-copying`() {
+        // Simulates a user who already migrated under the previous count-
+        // based code (PR #188) and is launching for the first time after
+        // this fix. Room is populated; legacy still has its preserved row.
+        // The fix must NOT re-insert the legacy row.
+        room.versionDao().insert(
+            VersionEntity(
+                _id = 0L,
+                locale = "en",
+                shortName = "SN",
+                longName = "Existing",
+                description = "desc",
+                filename = "/existing.yes",
+                preset_name = null,
+                modifyTime = 0,
+                active = 1,
+                ordering = 500,
+            ),
+        )
+        insertLegacyRow("/a.yes", 101)
+
+        VersionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val rows = room.versionDao().listAll()
+        assertEquals(1, rows.size)
+        assertEquals("/existing.yes", rows.single().filename)
+        assertTrue(Preferences.getBoolean(Prefkey.version_data_migration_v1_done, false))
     }
 }


### PR DESCRIPTION
Fixes #195.

## Summary

- The count-based idempotency gate in `MarkerDataMigration` and `VersionDataMigration` would re-copy legacy `AlkitabDb` rows back into Room whenever the Room tables happened to be empty. After a user clears every marker/label (or sync delivers a delete-all delta), the next launch resurrected the legacy rows and sync pushed them back up — undoing the user's deletions on every device.
- Switch to a one-shot `SharedPreferences` flag per migration (`marker_data_migration_v1_done`, `version_data_migration_v1_done`). Set after a successful copy or once we confirm there's nothing to copy.
- Keep the old `count() > 0` check as an upgrade path: users who already migrated under PR #191 / #188 take a single-launch detour to set the flag without re-copying, then never re-read the legacy tables again.

## Test plan

- [x] `./gradlew :Alkitab:testPlainDebugUnitTest` — all green
- [x] `./gradlew :Alkitab:assemblePlainDebug` — builds clean
- [x] New regression test in both migration test classes: insert legacy rows → migrate → delete every Room row → migrate again → assert Room stays empty (the exact failure mode from issue #195)
- [x] New coverage for: flag set after successful copy, flag set on fresh install with no legacy data, upgrade path sets flag without re-copying when Room already has rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)