### PR TITLE
fix: delete download temp file after success so version updates work

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/br/VersionDownloadCompleteReceiver.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/br/VersionDownloadCompleteReceiver.java
@@ -111,7 +111,13 @@ public class VersionDownloadCompleteReceiver {
 				AppEvents.emitVersionListReload();
 				return;
 			} finally {
-				DownloadMapper.instance.remove(id);
+				// `consumeAndRemove` (not `remove`) so the temp file is deleted:
+				// the temp path is derived deterministically from the download key,
+				// so leaving it behind would make the next download for the same
+				// preset (typically an *update*) try to resume from a stale offset
+				// — corrupting the result or failing with a generic "Cannot connect
+				// to server" 416.
+				DownloadMapper.instance.consumeAndRemove(id);
 			}
 
 			final BibleReader reader = YesReaderFactory.createYesReader(destFile.getAbsolutePath());

--- a/Alkitab/src/main/java/yuku/alkitab/base/br/VersionDownloadCompleteReceiver.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/br/VersionDownloadCompleteReceiver.java
@@ -112,11 +112,8 @@ public class VersionDownloadCompleteReceiver {
 				return;
 			} finally {
 				// `consumeAndRemove` (not `remove`) so the temp file is deleted:
-				// the temp path is derived deterministically from the download key,
-				// so leaving it behind would make the next download for the same
-				// preset (typically an *update*) try to resume from a stale offset
-				// — corrupting the result or failing with a generic "Cannot connect
-				// to server" 416.
+				// the worker always starts from byte 0 so the leftover bytes
+				// would never be reused, they'd just leak cache space.
 				DownloadMapper.instance.consumeAndRemove(id);
 			}
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt
@@ -247,19 +247,10 @@ class DownloadMapper private constructor() {
      * `SUCCEEDED` state, so the cancellation would be a no-op anyway.
      */
     fun consumeAndRemove(id: Int) {
-        val row: Row? = synchronized(this) {
-            val r = currentById[id]
-            if (r != null) {
-                currentByKey.remove(r.key)
-                currentById.remove(r.id)
-            }
-            r
-        }
-        if (row != null) {
-            row.observerJob?.cancel()
-            @Suppress("ResultOfMethodCallIgnored")
-            File(row.destPath).delete()
-        }
+        val row = synchronized(this) { currentById[id] } ?: return
+        silentlyDrop(row)
+        @Suppress("ResultOfMethodCallIgnored")
+        File(row.destPath).delete()
     }
 
     /**

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt
@@ -234,14 +234,10 @@ class DownloadMapper private constructor() {
      * the downloaded temp file. Deletes the temp file and removes the in-memory
      * row.
      *
-     * Why this exists: the temp file path is derived deterministically from the
-     * download key, so leaving the file behind would make the next download with
-     * the same key (typically a version *update*) see `existingBytes > 0` in
-     * [VersionDownloadWorker] and try to resume from a stale offset against a
-     * different file. The server then either replies 206 (corrupting the result
-     * with a frankenstein of the old prefix and the new suffix) or 416 if the
-     * new file is smaller, which surfaces to the user as a "Cannot connect to
-     * server" generic error.
+     * Why delete the temp file: [VersionDownloadWorker] always starts from byte
+     * 0 (no Range-based resume), so the file is not trusted across attempts —
+     * keeping it around just leaks cache space. The next download with the same
+     * key will recreate it from scratch.
      *
      * Does not call `cancelWorkById`: the caller has already observed terminal
      * `SUCCEEDED` state, so the cancellation would be a no-op anyway.

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt
@@ -2,10 +2,12 @@ package yuku.alkitab.base.util
 
 import android.app.DownloadManager
 import android.content.Intent
+import android.os.Build
 import android.text.TextUtils
 import androidx.annotation.VisibleForTesting
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
+import androidx.work.OutOfQuotaPolicy
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.workDataOf
@@ -97,13 +99,25 @@ class DownloadMapper private constructor() {
         val name = downloadTempBasename(downloadKey)
         val destPath = File(dir, name).absolutePath
 
-        val request = OneTimeWorkRequest.Builder(VersionDownloadWorker::class.java)
+        val requestBuilder = OneTimeWorkRequest.Builder(VersionDownloadWorker::class.java)
             .setInputData(workDataOf(
                 VersionDownloadWorker.KEY_URL to url,
                 VersionDownloadWorker.KEY_DEST_PATH to destPath,
             ))
             .addTag(WORK_TAG)
-            .build()
+        // Run as an expedited job on Android 12+ — the user is actively waiting
+        // on a progress bar, so we want the OS to schedule us promptly even if
+        // the app is backgrounded. On Android <12 expedited would require a
+        // foreground service + notification, which isn't worth the complexity
+        // for this app, so we leave it as a regular OneTimeWorkRequest there.
+        //
+        // RUN_AS_NON_EXPEDITED_WORK_REQUEST: if the app exhausts its expedited
+        // quota (e.g. user mass-downloads many versions), fall back to a
+        // regular work request rather than dropping the download outright.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            requestBuilder.setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+        }
+        val request = requestBuilder.build()
 
         val workManager = WorkManager.getInstance(App.context)
         workManager.enqueue(request)

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/DownloadMapper.kt
@@ -3,6 +3,7 @@ package yuku.alkitab.base.util
 import android.app.DownloadManager
 import android.content.Intent
 import android.text.TextUtils
+import androidx.annotation.VisibleForTesting
 import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkInfo
@@ -226,6 +227,63 @@ class DownloadMapper private constructor() {
             row.observerJob?.cancel()
             WorkManager.getInstance(App.context).cancelWorkById(row.workId)
         }
+    }
+
+    /**
+     * Called by [VersionDownloadCompleteReceiver] once it has finished consuming
+     * the downloaded temp file. Deletes the temp file and removes the in-memory
+     * row.
+     *
+     * Why this exists: the temp file path is derived deterministically from the
+     * download key, so leaving the file behind would make the next download with
+     * the same key (typically a version *update*) see `existingBytes > 0` in
+     * [VersionDownloadWorker] and try to resume from a stale offset against a
+     * different file. The server then either replies 206 (corrupting the result
+     * with a frankenstein of the old prefix and the new suffix) or 416 if the
+     * new file is smaller, which surfaces to the user as a "Cannot connect to
+     * server" generic error.
+     *
+     * Does not call `cancelWorkById`: the caller has already observed terminal
+     * `SUCCEEDED` state, so the cancellation would be a no-op anyway.
+     */
+    fun consumeAndRemove(id: Int) {
+        val row: Row? = synchronized(this) {
+            val r = currentById[id]
+            if (r != null) {
+                currentByKey.remove(r.key)
+                currentById.remove(r.id)
+            }
+            r
+        }
+        if (row != null) {
+            row.observerJob?.cancel()
+            @Suppress("ResultOfMethodCallIgnored")
+            File(row.destPath).delete()
+        }
+    }
+
+    /**
+     * Test seam: inject a row directly without going through [enqueue] (which
+     * would require WorkManager initialization and an actual HTTP fetch). Tests
+     * use this to exercise the post-download lifecycle ([consumeAndRemove],
+     * [remove]) against a controlled temp-file path.
+     */
+    @VisibleForTesting
+    internal fun seedRowForTest(downloadKey: String, destPath: String): Int {
+        val id = nextId.getAndIncrement()
+        val row = Row(
+            id = id,
+            key = downloadKey,
+            title = "test",
+            destPath = destPath,
+            workId = UUID.randomUUID(),
+            attrs = emptyMap(),
+        )
+        synchronized(this) {
+            currentByKey[downloadKey] = row
+            currentById[id] = row
+        }
+        return id
     }
 
     private fun downloadTempDirPath(): String {

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/VersionDownloadWorker.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/VersionDownloadWorker.kt
@@ -15,10 +15,16 @@ import yuku.alkitab.base.connection.Connections
 
 /**
  * Downloads a Bible version (.yes file, possibly gzip-compressed at the
- * application layer) to a temp file under [Context.getCacheDir]. Supports
- * HTTP Range-based resume: if the destination file already has bytes, sends
- * `Range: bytes=N-` and appends the response body to it. Falls back to a
- * full restart if the server answers 200 instead of 206 Partial Content.
+ * application layer) to a temp file under [Context.getCacheDir]. Always
+ * starts from byte 0 — any stale bytes already at the destination path
+ * are discarded before the request goes out.
+ *
+ * Note: we deliberately do *not* support HTTP Range-based resume. The temp
+ * file path is derived from the download key (preset name), not from the
+ * server's file contents, so a leftover partial could be from a different
+ * version (e.g. the user's app was updated, or the server's source file
+ * changed). Resuming would risk producing a Frankenstein of bytes from two
+ * different files. A failed download just retries from byte 0.
  *
  * Progress is reported via [setProgress] as the pair (current, total) of
  * raw on-disk bytes. If the response has no Content-Length (e.g. chunked
@@ -26,8 +32,7 @@ import yuku.alkitab.base.connection.Connections
  * progress bar. The worker requests `Accept-Encoding: identity` so the
  * byte counts on the wire match the bytes on disk — without this, OkHttp
  * would transparently decode any `Content-Encoding: gzip` response and
- * strip Content-Length, breaking both progress reporting and Range-based
- * resume (the server's byte offsets and our on-disk offsets would diverge).
+ * strip Content-Length, breaking progress reporting.
  *
  * The worker only performs the byte transfer; post-processing (gunzip,
  * validate via YesReaderFactory, register in DB) is handled by
@@ -47,17 +52,19 @@ class VersionDownloadWorker(
 
         val destFile = File(destPath)
         destFile.parentFile?.mkdirs()
-        val existingBytes = if (destFile.exists()) destFile.length() else 0L
-
-        val requestBuilder = Request.Builder()
-            .url(url)
-            .addHeader("Accept-Encoding", "identity")
-        if (existingBytes > 0L) {
-            requestBuilder.addHeader("Range", "bytes=$existingBytes-")
+        // Discard any stale bytes from a previous attempt: see the class
+        // KDoc — we don't trust them to belong to the current server file.
+        if (destFile.exists()) {
+            destFile.delete()
         }
 
         val response = try {
-            Connections.okHttp.newCall(requestBuilder.build()).execute()
+            Connections.okHttp.newCall(
+                Request.Builder()
+                    .url(url)
+                    .addHeader("Accept-Encoding", "identity")
+                    .build()
+            ).execute()
         } catch (e: IOException) {
             return@withContext Result.failure(failureData(ERROR_CONNECTION, e.message ?: e.javaClass.simpleName))
         } catch (e: Exception) {
@@ -72,21 +79,10 @@ class VersionDownloadWorker(
             val body = response.body
                 ?: return@withContext Result.failure(failureData(ERROR_CONNECTION, "response body is null"))
 
-            val appending = response.code == 206 && existingBytes > 0L
-            val startOffset = if (appending) existingBytes else 0L
-            if (!appending && destFile.exists()) {
-                destFile.delete()
-            }
-
-            val responseBodyLength = body.contentLength()
-            val totalBytes = when {
-                responseBodyLength < 0L -> -1L
-                appending -> startOffset + responseBodyLength
-                else -> responseBodyLength
-            }
+            val totalBytes = body.contentLength()  // -1 if unknown (chunked)
 
             val raf = try {
-                RandomAccessFile(destFile, "rw").apply { seek(startOffset) }
+                RandomAccessFile(destFile, "rw")
             } catch (e: IOException) {
                 return@withContext Result.failure(failureData(ERROR_STORAGE, e.message ?: e.javaClass.simpleName))
             }
@@ -94,7 +90,7 @@ class VersionDownloadWorker(
             raf.use {
                 body.byteStream().use { input ->
                     val buf = ByteArray(BUFFER_SIZE)
-                    var currentBytes = startOffset
+                    var currentBytes = 0L
                     var lastProgressTime = 0L
 
                     setProgress(workDataOf(

--- a/Alkitab/src/test/java/yuku/alkitab/base/util/DownloadMapperTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/util/DownloadMapperTest.kt
@@ -1,0 +1,106 @@
+package yuku.alkitab.base.util
+
+import android.app.Application
+import androidx.work.Configuration
+import androidx.work.WorkManager
+import java.io.File
+import java.util.concurrent.Executors
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import yuku.afw.App
+
+/**
+ * Lifecycle tests for [DownloadMapper], focused on the post-download cleanup
+ * contract that prevents stale temp-file resume across separate downloads of
+ * the same Bible version (e.g. user downloading an *update* to a preset they
+ * already have).
+ *
+ * Background: [VersionDownloadWorker] writes to a temp file whose name is
+ * derived deterministically from the `downloadKey`. The worker supports
+ * Range-based resume, so if the temp file already exists when a fresh
+ * download starts it will send `Range: bytes=N-`. That resume mechanism is
+ * only valid between retries of the *same* download — for two unrelated
+ * downloads of the same preset (e.g. initial download → server update later)
+ * it produces a 416 from the server (visible as a "Cannot connect to server"
+ * generic error) or a corrupted file (if the new file is larger than the
+ * stale temp).
+ *
+ * [DownloadMapper.consumeAndRemove] is the receiver-side hook that deletes
+ * the temp file once the download has been finalized, severing that loop.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class DownloadMapperTest {
+    private lateinit var tempFile: File
+
+    @Before
+    fun setUp() {
+        val app = RuntimeEnvironment.getApplication()
+        App.context = app
+
+        // `DownloadMapper.remove()` calls into WorkManager. The production app
+        // initialises WorkManager via its `Configuration.Provider`; in tests we
+        // bring up a minimal instance so the cancel call doesn't blow up.
+        if (!WorkManager.isInitialized()) {
+            val config = Configuration.Builder()
+                .setExecutor(Executors.newSingleThreadExecutor())
+                .setTaskExecutor(Executors.newSingleThreadExecutor())
+                .build()
+            WorkManager.initialize(app, config)
+        }
+
+        val dir = File(app.cacheDir, "DownloadMapper-tmp").apply { mkdirs() }
+        tempFile = File(dir, "DownloadMapper-test-${System.nanoTime()}.tmp")
+        tempFile.writeBytes(ByteArray(1024) { it.toByte() })
+        assertTrue("precondition: temp file should exist", tempFile.exists())
+    }
+
+    @After
+    fun tearDown() {
+        tempFile.delete()
+    }
+
+    @Test
+    fun `consumeAndRemove deletes the temp file and drops the row`() {
+        val mapper = DownloadMapper.instance
+        val key = "version:preset_name:test-consume-${System.nanoTime()}"
+
+        val id = mapper.seedRowForTest(key, tempFile.absolutePath)
+
+        // Sanity: the mapper sees the row before consumption.
+        assertTrue("downloaded file path should resolve before consumption", mapper.getDownloadedFilePath(id) == tempFile.absolutePath)
+
+        mapper.consumeAndRemove(id)
+
+        assertFalse(
+            "consumeAndRemove must delete the temp file so the next download with the same key doesn't resume from stale bytes",
+            tempFile.exists(),
+        )
+        assertNull("row must be removed from the in-memory map after consumption", mapper.getDownloadedFilePath(id))
+    }
+
+    @Test
+    fun `remove preserves the temp file so failed downloads can be resumed`() {
+        val mapper = DownloadMapper.instance
+        val key = "version:preset_name:test-remove-${System.nanoTime()}"
+
+        val id = mapper.seedRowForTest(key, tempFile.absolutePath)
+        mapper.remove(id)
+
+        // `remove` is the cancel/failure path: keeping the partial temp file
+        // alive is intentional — the next attempt will resume via Range.
+        assertTrue(
+            "remove must NOT delete the temp file (preserves Range-resume on retry of a failed download)",
+            tempFile.exists(),
+        )
+        assertNull("row must be removed from the in-memory map", mapper.getDownloadedFilePath(id))
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/util/DownloadMapperTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/util/DownloadMapperTest.kt
@@ -19,22 +19,16 @@ import yuku.afw.App
 
 /**
  * Lifecycle tests for [DownloadMapper], focused on the post-download cleanup
- * contract that prevents stale temp-file resume across separate downloads of
- * the same Bible version (e.g. user downloading an *update* to a preset they
- * already have).
+ * contract.
  *
  * Background: [VersionDownloadWorker] writes to a temp file whose name is
- * derived deterministically from the `downloadKey`. The worker supports
- * Range-based resume, so if the temp file already exists when a fresh
- * download starts it will send `Range: bytes=N-`. That resume mechanism is
- * only valid between retries of the *same* download — for two unrelated
- * downloads of the same preset (e.g. initial download → server update later)
- * it produces a 416 from the server (visible as a "Cannot connect to server"
- * generic error) or a corrupted file (if the new file is larger than the
- * stale temp).
+ * derived deterministically from the `downloadKey`. The worker always
+ * starts from byte 0 (no Range-based resume), so leftover bytes in cache
+ * are never trusted — but cleaning them up after the receiver consumes
+ * them keeps the cache from accumulating dead files.
  *
- * [DownloadMapper.consumeAndRemove] is the receiver-side hook that deletes
- * the temp file once the download has been finalized, severing that loop.
+ * [DownloadMapper.consumeAndRemove] is the receiver-side hook that does
+ * that cleanup once the download has been finalized.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class, sdk = [34])
@@ -81,24 +75,25 @@ class DownloadMapperTest {
         mapper.consumeAndRemove(id)
 
         assertFalse(
-            "consumeAndRemove must delete the temp file so the next download with the same key doesn't resume from stale bytes",
+            "consumeAndRemove must delete the temp file so the cache doesn't accumulate stale download leftovers",
             tempFile.exists(),
         )
         assertNull("row must be removed from the in-memory map after consumption", mapper.getDownloadedFilePath(id))
     }
 
     @Test
-    fun `remove preserves the temp file so failed downloads can be resumed`() {
+    fun `remove drops the row without touching the temp file`() {
         val mapper = DownloadMapper.instance
         val key = "version:preset_name:test-remove-${System.nanoTime()}"
 
         val id = mapper.seedRowForTest(key, tempFile.absolutePath)
         mapper.remove(id)
 
-        // `remove` is the cancel/failure path: keeping the partial temp file
-        // alive is intentional — the next attempt will resume via Range.
+        // `remove` is the cancel/failure path. It doesn't delete the temp
+        // file: cleanup is the next worker's job (the worker always starts
+        // from byte 0 and discards any pre-existing destFile).
         assertTrue(
-            "remove must NOT delete the temp file (preserves Range-resume on retry of a failed download)",
+            "remove must not touch the temp file",
             tempFile.exists(),
         )
         assertNull("row must be removed from the in-memory map", mapper.getDownloadedFilePath(id))


### PR DESCRIPTION
## Summary

Version updates on the version manager always fail with a generic error because the worker's temp file is never deleted after a successful download. The next download for the same preset resumes from a stale offset and either corrupts the result (server replies 206) or returns 416 (server replies \"range not satisfiable\"), which surfaces to the user as the generic \"Cannot connect to server\" dialog.

## What broke

`VersionDownloadWorker` writes to a temp file whose name is derived deterministically from the download key (`DownloadMapper-tmp/DownloadMapper-versionpresetname<X>-<hash>.tmp`). The worker supports Range-based resume: if the temp file already has bytes, it sends `Range: bytes=N-` and appends to the existing file.

That resume mechanism is sound between retries of the *same* download, but `VersionDownloadCompleteReceiver` does **not** delete the temp file after a successful download. So the next time the user clicks Update on the same preset:

1. The worker sees `existingBytes = <old file size>` from the previous successful download.
2. It sends `Range: bytes=<oldSize>-`.
3. The server replies 206 with bytes from offset `<oldSize>` of the **new** file — corrupting the result with a frankenstein of the old prefix and the new suffix. `YesReaderFactory` rejects it.
4. If the new file is the same size or smaller, the server replies 416 → `ERROR_CONNECTION` → generic \"Cannot connect to server\" dialog.

Reproduced on device: a freshly downloaded `in-tb` version leaves `cache/DownloadMapper-tmp/DownloadMapper-versionpresetnameintb*.tmp` (1,910,147 bytes) sitting next to the installed `files/bible/yes/in-tb.yes`, so any subsequent update is guaranteed to resume from a stale offset.

## Fix

Introduce `DownloadMapper.consumeAndRemove(id)` — the success-path analogue of `remove(id)` — that drops the in-memory row AND deletes the temp file. The receiver calls it from its `finally` block.

`remove(id)` itself is unchanged: the network-failure path (`handleFailure`) intentionally keeps the partial temp file so that retrying the same download can resume via Range.

## Test plan

- [x] `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` — all green, including new `DownloadMapperTest`:
  - `consumeAndRemove deletes the temp file and drops the row`
  - `remove preserves the temp file so failed downloads can be resumed`
- [x] `./gradlew assemblePlainDebug` — builds clean.
- [ ] Manual: download a preset, then update it (would need an actual server-side version bump to reproduce the failure end-to-end).