### PR TITLE
REM-27: migrate Devotion table from SQLite to Room

### DIFF
--- a/Alkitab/schemas/yuku.alkitab.base.storage.room.AppDatabase/3.json
+++ b/Alkitab/schemas/yuku.alkitab.base.storage.room.AppDatabase/3.json
@@ -1,0 +1,421 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "93929c43b420d02e175de187776d3504",
+    "entities": [
+      {
+        "tableName": "version",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `locale` TEXT, `shortName` TEXT, `longName` TEXT, `description` TEXT, `filename` TEXT, `preset_name` TEXT, `modifyTime` INTEGER NOT NULL, `active` INTEGER NOT NULL, `ordering` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "shortName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "longName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "preset_name",
+            "columnName": "preset_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifyTime",
+            "columnName": "modifyTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ordering",
+            "columnName": "ordering",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_version_ordering",
+            "unique": false,
+            "columnNames": [
+              "ordering"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_version_ordering` ON `${TABLE_NAME}` (`ordering`)"
+          },
+          {
+            "name": "index_version_active_longName",
+            "unique": false,
+            "columnNames": [
+              "active",
+              "longName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_version_active_longName` ON `${TABLE_NAME}` (`active`, `longName`)"
+          },
+          {
+            "name": "index_version_preset_name",
+            "unique": false,
+            "columnNames": [
+              "preset_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_version_preset_name` ON `${TABLE_NAME}` (`preset_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "marker",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `gid` TEXT, `ari` INTEGER NOT NULL, `kind` INTEGER NOT NULL, `caption` TEXT, `verseCount` INTEGER NOT NULL, `createTime` INTEGER NOT NULL, `modifyTime` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gid",
+            "columnName": "gid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ari",
+            "columnName": "ari",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "caption",
+            "columnName": "caption",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "verseCount",
+            "columnName": "verseCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createTime",
+            "columnName": "createTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifyTime",
+            "columnName": "modifyTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_marker_ari",
+            "unique": false,
+            "columnNames": [
+              "ari"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_ari` ON `${TABLE_NAME}` (`ari`)"
+          },
+          {
+            "name": "index_marker_kind_ari",
+            "unique": false,
+            "columnNames": [
+              "kind",
+              "ari"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_kind_ari` ON `${TABLE_NAME}` (`kind`, `ari`)"
+          },
+          {
+            "name": "index_marker_kind_modifyTime",
+            "unique": false,
+            "columnNames": [
+              "kind",
+              "modifyTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_kind_modifyTime` ON `${TABLE_NAME}` (`kind`, `modifyTime`)"
+          },
+          {
+            "name": "index_marker_kind_createTime",
+            "unique": false,
+            "columnNames": [
+              "kind",
+              "createTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_kind_createTime` ON `${TABLE_NAME}` (`kind`, `createTime`)"
+          },
+          {
+            "name": "index_marker_gid",
+            "unique": false,
+            "columnNames": [
+              "gid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_gid` ON `${TABLE_NAME}` (`gid`)"
+          },
+          {
+            "name": "index_marker_kind_caption",
+            "unique": false,
+            "columnNames": [
+              "kind",
+              "caption"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_kind_caption` ON `${TABLE_NAME}` (`kind`, `caption`)"
+          }
+        ]
+      },
+      {
+        "tableName": "label",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `gid` TEXT, `title` TEXT, `ordering` INTEGER NOT NULL, `backgroundColor` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gid",
+            "columnName": "gid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ordering",
+            "columnName": "ordering",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "backgroundColor",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_label_ordering",
+            "unique": false,
+            "columnNames": [
+              "ordering"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_label_ordering` ON `${TABLE_NAME}` (`ordering`)"
+          },
+          {
+            "name": "index_label_gid",
+            "unique": false,
+            "columnNames": [
+              "gid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_label_gid` ON `${TABLE_NAME}` (`gid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "marker_label",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `gid` TEXT, `marker_gid` TEXT, `label_gid` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gid",
+            "columnName": "gid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "marker_gid",
+            "columnName": "marker_gid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label_gid",
+            "columnName": "label_gid",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_marker_label_marker_gid",
+            "unique": false,
+            "columnNames": [
+              "marker_gid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_label_marker_gid` ON `${TABLE_NAME}` (`marker_gid`)"
+          },
+          {
+            "name": "index_marker_label_label_gid",
+            "unique": false,
+            "columnNames": [
+              "label_gid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_label_label_gid` ON `${TABLE_NAME}` (`label_gid`)"
+          },
+          {
+            "name": "index_marker_label_gid",
+            "unique": true,
+            "columnNames": [
+              "gid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_marker_label_gid` ON `${TABLE_NAME}` (`gid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "devotion",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `date` TEXT, `body` TEXT, `readyToUse` INTEGER NOT NULL, `touchTime` INTEGER NOT NULL, `dataFormatVersion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readyToUse",
+            "columnName": "readyToUse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "touchTime",
+            "columnName": "touchTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataFormatVersion",
+            "columnName": "dataFormatVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_devotion_name_date_dataFormatVersion",
+            "unique": false,
+            "columnNames": [
+              "name",
+              "date",
+              "dataFormatVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_devotion_name_date_dataFormatVersion` ON `${TABLE_NAME}` (`name`, `date`, `dataFormatVersion`)"
+          },
+          {
+            "name": "index_devotion_touchTime",
+            "unique": false,
+            "columnNames": [
+              "touchTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_devotion_touchTime` ON `${TABLE_NAME}` (`touchTime`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '93929c43b420d02e175de187776d3504')"
+    ]
+  }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/S.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/S.kt
@@ -234,6 +234,9 @@ object S {
         // the version copy; all three tables move atomically inside a single
         // Room transaction.
         yuku.alkitab.base.storage.room.MarkerDataMigration.copyFromLegacyDbIfNeeded(roomDb, helper)
+        // One-time copy of the legacy `Devotion` table into Room. Same
+        // idempotency / retry properties as the marker/version copies.
+        yuku.alkitab.base.storage.room.DevotionDataMigration.copyFromLegacyDbIfNeeded(roomDb, helper)
         InternalDb(helper)
     }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/DevotionDao.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/DevotionDao.kt
@@ -1,6 +1,5 @@
 package yuku.alkitab.base.storage
 
-import android.content.ContentValues
 import yuku.alkitab.base.ac.DevotionActivity
 import yuku.alkitab.base.devotion.ArticleMeidA
 import yuku.alkitab.base.devotion.ArticleMorningEveningEnglish
@@ -8,81 +7,75 @@ import yuku.alkitab.base.devotion.ArticleRenunganHarian
 import yuku.alkitab.base.devotion.ArticleRoc
 import yuku.alkitab.base.devotion.ArticleSantapanHarian
 import yuku.alkitab.base.devotion.DevotionArticle
+import yuku.alkitab.base.storage.room.AppDatabase
+import yuku.alkitab.base.storage.room.DevotionEntity
+import yuku.alkitab.base.storage.room.DevotionRoomDao
 import yuku.alkitab.base.util.Sqlitil
 import java.util.Date
 
 /**
- * Type-safe accessor for the `Devotion` table (cached devotional articles).
- * Rows are identified by `(name, date, dataFormatVersion)`.
+ * Facade over the Room-backed [DevotionRoomDao] that preserves the legacy
+ * `DevotionArticle`-based public surface. Existing call sites in [InternalDb]
+ * don't need to change.
+ *
+ * Rows are identified by `(name, date, dataFormatVersion)`. Cached articles
+ * with no body are stored as `readyToUse = 0` so a later download can
+ * back-fill the body without invalidating the row.
+ *
+ * Cross-file note: this DAO is constructed with [InternalDbHelper] only so
+ * its constructor signature stays unchanged. The helper is no longer used
+ * internally; [AppDatabase] supplies the underlying SQLite file. The
+ * one-time data copy runs in
+ * [yuku.alkitab.base.storage.room.DevotionDataMigration].
  */
-class DevotionDao(private val helper: InternalDbHelper) {
+@Suppress("UNUSED_PARAMETER")
+class DevotionDao(helper: InternalDbHelper) {
+
+    private val roomDao: DevotionRoomDao
+        get() = AppDatabase.get(yuku.afw.App.context).devotionDao()
 
     /**
      * Upserts the article row identified by `(kind.name, date)`. Implemented
-     * as delete-then-insert inside a transaction because the table has no
-     * uniqueness constraint.
+     * as delete-then-insert inside a single Room transaction because the
+     * table has no uniqueness constraint — see [DevotionRoomDao.upsertByNameAndDate].
      */
     fun storeArticle(article: DevotionArticle) {
-        val db = helper.writableDatabase
-        val values = ContentValues().apply {
-            put(Table.Devotion.name.name, article.kind.name)
-            put(Table.Devotion.date.name, article.date)
-            put(Table.Devotion.readyToUse.name, if (article.readyToUse) 1 else 0)
-            if (article.readyToUse) {
-                put(Table.Devotion.body.name, article.body)
-            } else {
-                putNull(Table.Devotion.body.name)
-            }
-            put(Table.Devotion.touchTime.name, Sqlitil.nowDateTime())
-            put(Table.Devotion.dataFormatVersion.name, 1)
-        }
-
-        db.beginTransactionNonExclusive()
-        try {
-            db.delete(
-                Table.Devotion.tableName(),
-                Table.Devotion.name.name + "=? and " + Table.Devotion.date.name + "=?",
-                arrayOf(article.kind.name, article.date),
-            )
-            db.insert(Table.Devotion.tableName(), null, values)
-            db.setTransactionSuccessful()
-        } finally {
-            db.endTransaction()
-        }
-    }
-
-    fun deleteWithTouchTimeBefore(date: Date): Int {
-        return helper.writableDatabase.delete(
-            Table.Devotion.tableName(),
-            Table.Devotion.touchTime.name + "<?",
-            arrayOf(Sqlitil.toInt(date).toString()),
+        val entity = DevotionEntity(
+            _id = 0L,
+            name = article.kind.name,
+            date = article.date,
+            body = if (article.readyToUse) article.body else null,
+            readyToUse = if (article.readyToUse) 1 else 0,
+            touchTime = Sqlitil.nowDateTime(),
+            dataFormatVersion = DATA_FORMAT_VERSION,
         )
+        roomDao.upsertByNameAndDate(entity)
     }
+
+    fun deleteWithTouchTimeBefore(date: Date): Int =
+        roomDao.deleteWithTouchTimeBefore(Sqlitil.toInt(date))
 
     /** Returns the stored article, or null if none cached. Non-ready-to-use rows are returned too. */
     fun tryGet(name: String, date: String): DevotionArticle? {
-        helper.readableDatabase.query(
-            Table.Devotion.tableName(),
-            null,
-            Table.Devotion.name.name + "=? and " + Table.Devotion.date.name + "=? and " +
-                Table.Devotion.dataFormatVersion.name + "=?",
-            arrayOf(name, date, "1"),
-            null, null, null,
-        ).use { c ->
-            if (!c.moveToNext()) return null
-            val colBody = c.getColumnIndexOrThrow(Table.Devotion.body.name)
-            val colReadyToUse = c.getColumnIndexOrThrow(Table.Devotion.readyToUse.name)
-            val body = c.getString(colBody)
-            val readyToUse = c.getInt(colReadyToUse) > 0
-
-            val kind = DevotionActivity.DevotionKind.getByName(name) ?: return null
-            return when (kind) {
-                DevotionActivity.DevotionKind.RH -> ArticleRenunganHarian(date, body, readyToUse)
-                DevotionActivity.DevotionKind.SH -> ArticleSantapanHarian(date, body, readyToUse)
-                DevotionActivity.DevotionKind.ME_EN -> ArticleMorningEveningEnglish(date, body, true)
-                DevotionActivity.DevotionKind.MEID_A -> ArticleMeidA(date, body, readyToUse)
-                DevotionActivity.DevotionKind.ROC -> ArticleRoc(date, body, readyToUse)
-            }
+        val row = roomDao.findByNameDateAndDataFormatVersion(name, date, DATA_FORMAT_VERSION)
+            ?: return null
+        val kind = DevotionActivity.DevotionKind.getByName(name) ?: return null
+        val body = row.body
+        val readyToUse = row.readyToUse > 0
+        return when (kind) {
+            DevotionActivity.DevotionKind.RH -> ArticleRenunganHarian(date, body, readyToUse)
+            DevotionActivity.DevotionKind.SH -> ArticleSantapanHarian(date, body, readyToUse)
+            // Legacy DevotionDao forced `readyToUse = true` for ME_EN — preserve verbatim.
+            DevotionActivity.DevotionKind.ME_EN -> ArticleMorningEveningEnglish(date, body, true)
+            DevotionActivity.DevotionKind.MEID_A -> ArticleMeidA(date, body, readyToUse)
+            DevotionActivity.DevotionKind.ROC -> ArticleRoc(date, body, readyToUse)
         }
+    }
+
+    companion object {
+        // The legacy DevotionDao hard-coded the value `1` on both write and
+        // read sides. Preserve that exact contract so callers don't observe a
+        // behaviour change; a future format bump can introduce a v2 alongside.
+        private const val DATA_FORMAT_VERSION = 1
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/Prefkey.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/Prefkey.kt
@@ -155,4 +155,14 @@ enum class Prefkey {
      * [marker_data_migration_v1_done] — see GitHub issue #195.
      */
     version_data_migration_v1_done,
+
+    /**
+     * One-shot completion flag for the `Devotion` copy from the legacy
+     * `AlkitabDb` table into Room. Same rationale as
+     * [marker_data_migration_v1_done] — see GitHub issue #195. The Devotion
+     * table is a transient cache (entries expire on `touchTime`), so
+     * resurrecting deleted rows is less damaging than for markers, but the
+     * flag-based gate is cheap and keeps the pattern uniform across tables.
+     */
+    devotion_data_migration_v1_done,
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/AppDatabase.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/AppDatabase.kt
@@ -23,6 +23,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
  *   their indexes. See [MIGRATION_1_2]. Legacy `Marker` / `Label` /
  *   `Marker_Label` tables in `AlkitabDb` are left in place as a rollback
  *   safety net; a follow-up release will drop them.
+ * - v3 — added the `devotion` table and its two indexes. See
+ *   [MIGRATION_2_3]. Same rollback-safety convention: the legacy `Devotion`
+ *   table in `AlkitabDb` is left intact.
  *
  * REM-10 follow-up note: [MIGRATION_1_2] creates the
  * `index_marker_kind_caption` index with `COLLATE NOCASE` (matching the
@@ -38,8 +41,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         MarkerEntity::class,
         LabelEntity::class,
         MarkerLabelEntity::class,
+        DevotionEntity::class,
     ],
-    version = 2,
+    version = 3,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -47,6 +51,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun markerDao(): MarkerRoomDao
     abstract fun labelDao(): LabelRoomDao
     abstract fun markerLabelDao(): MarkerLabelRoomDao
+    abstract fun devotionDao(): DevotionRoomDao
 
     companion object {
         const val DB_NAME = "AlkitabRoomDb"
@@ -124,6 +129,41 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v2 → v3: create the `devotion` table and its two indexes. SQL
+         * mirrors what Room emits for the v3 entity (compare against
+         * `Alkitab/schemas/.../3.json`) — keep them in sync if [DevotionEntity]
+         * changes.
+         *
+         * A v2 device upgrading runs this migration once; a fresh install
+         * skips straight to v3 via Room's `onCreate` (Room uses the entity
+         * definitions, not this migration, for fresh schemas — that's why
+         * the SQL here must match what Room would emit).
+         */
+        @JvmField
+        val MIGRATION_2_3: Migration = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `devotion` (" +
+                        "`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`name` TEXT, " +
+                        "`date` TEXT, " +
+                        "`body` TEXT, " +
+                        "`readyToUse` INTEGER NOT NULL, " +
+                        "`touchTime` INTEGER NOT NULL, " +
+                        "`dataFormatVersion` INTEGER NOT NULL)",
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_devotion_name_date_dataFormatVersion` " +
+                        "ON `devotion` (`name`, `date`, `dataFormatVersion`)",
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_devotion_touchTime` " +
+                        "ON `devotion` (`touchTime`)",
+                )
+            }
+        }
+
         @Volatile
         private var instance: AppDatabase? = null
 
@@ -141,7 +181,7 @@ abstract class AppDatabase : RoomDatabase() {
                 // methods) are synchronous. Coroutine-based callers can be
                 // introduced later — see REM-15 in tech-debt-remediation.md.
                 .allowMainThreadQueries()
-                .addMigrations(MIGRATION_1_2)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                 .build()
 
         /**

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/DevotionDataMigration.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/DevotionDataMigration.kt
@@ -19,12 +19,20 @@ import yuku.alkitab.base.util.AppLog
  * would be re-copied from the legacy table on the next launch. See GitHub
  * issue #195.
  *
+ * Memory profile: rows are streamed from the legacy cursor straight into
+ * Room inside a single `runInTransaction` block. A devotion `body` can be
+ * a multi-kilobyte HTML payload and the legacy cache may accumulate years
+ * of articles, so buffering every row into an `ArrayList` before insert
+ * (the REM-10/REM-11 pattern, where individual rows are small) would risk
+ * an [OutOfMemoryError] on low-end devices. Streaming keeps the footprint
+ * bound by one row at a time.
+ *
  * Crash safety:
- *  - If the Room insert fails mid-flight, Room rolls back and the flag is
- *    never set; the next launch retries.
- *  - If the process is killed after the insert commits but before the flag
- *    is set, the next launch sees Room rows already present and takes the
- *    upgrade-path branch (sets the flag, does not re-copy).
+ *  - If any insert fails mid-flight, Room rolls back the whole transaction
+ *    and the flag is never set; the next launch retries.
+ *  - If the process is killed after the transaction commits but before the
+ *    flag is set, the next launch sees Room rows already present and takes
+ *    the upgrade-path branch (sets the flag, does not re-copy).
  *
  * The legacy table is intentionally left intact so a future release can
  * audit/rollback.
@@ -48,26 +56,31 @@ object DevotionDataMigration {
             return
         }
 
-        val rows = readLegacyRows(legacyHelper)
-        if (rows.isEmpty()) {
-            // No legacy data either (fresh install). Mark done so future
-            // launches skip the legacy-read entirely.
-            Preferences.setBoolean(Prefkey.devotion_data_migration_v1_done, true)
-            return
-        }
-
-        // Bulk insert — Room's `@Insert` runs inside a single transaction, so
-        // a crash mid-migration leaves zero rows in Room and the next launch
-        // retries cleanly.
-        dao.insertAll(rows)
+        val copied = streamCopyInsideTransaction(roomDb, dao, legacyHelper)
         // Set the flag only after a successful commit. A crash between here
         // and the next launch is handled by the upgrade-path branch above.
         Preferences.setBoolean(Prefkey.devotion_data_migration_v1_done, true)
-        AppLog.d(TAG, "Copied ${rows.size} devotion row(s) from legacy Devotion table to Room")
+        if (copied > 0) {
+            AppLog.d(TAG, "Copied $copied devotion row(s) from legacy Devotion table to Room")
+        }
     }
 
-    private fun readLegacyRows(legacyHelper: InternalDbHelper): List<DevotionEntity> {
-        val res = ArrayList<DevotionEntity>()
+    /**
+     * Reads rows from the legacy cursor and inserts them into Room one at a
+     * time inside a single Room transaction. Returns the number of rows
+     * copied (0 on a fresh install where the legacy table is empty).
+     *
+     * Why not the REM-10 `dao.insertAll(list)` pattern? `Devotion.body` can
+     * be a multi-kilobyte HTML payload; loading every cached year's worth
+     * into a single `ArrayList` before insertion blows up memory on low-end
+     * devices. Streaming through the cursor keeps memory bound by one row.
+     */
+    private fun streamCopyInsideTransaction(
+        roomDb: AppDatabase,
+        dao: DevotionRoomDao,
+        legacyHelper: InternalDbHelper,
+    ): Int {
+        var copied = 0
         legacyHelper.readableDatabase.query(
             Table.Devotion.tableName(), null, null, null, null, null, "_id ASC",
         ).use { c ->
@@ -77,21 +90,26 @@ object DevotionDataMigration {
             val colReadyToUse = c.getColumnIndexOrThrow(Table.Devotion.readyToUse.name)
             val colTouchTime = c.getColumnIndexOrThrow(Table.Devotion.touchTime.name)
             val colDataFormatVersion = c.getColumnIndexOrThrow(Table.Devotion.dataFormatVersion.name)
-            while (c.moveToNext()) {
-                res += DevotionEntity(
-                    // Don't carry over `_id` — Room assigns a fresh one. Nothing
-                    // outside the table referenced the legacy `_id`; the
-                    // identity key used by callers is `(name, date, dataFormatVersion)`.
-                    _id = 0L,
-                    name = c.getString(colName),
-                    date = c.getString(colDate),
-                    body = c.getString(colBody),
-                    readyToUse = c.getInt(colReadyToUse),
-                    touchTime = c.getInt(colTouchTime),
-                    dataFormatVersion = c.getInt(colDataFormatVersion),
-                )
+            roomDb.runInTransaction {
+                while (c.moveToNext()) {
+                    dao.insert(
+                        DevotionEntity(
+                            // Don't carry over `_id` — Room assigns a fresh one. Nothing
+                            // outside the table referenced the legacy `_id`; the
+                            // identity key used by callers is `(name, date, dataFormatVersion)`.
+                            _id = 0L,
+                            name = c.getString(colName),
+                            date = c.getString(colDate),
+                            body = c.getString(colBody),
+                            readyToUse = c.getInt(colReadyToUse),
+                            touchTime = c.getInt(colTouchTime),
+                            dataFormatVersion = c.getInt(colDataFormatVersion),
+                        ),
+                    )
+                    copied++
+                }
             }
         }
-        return res
+        return copied
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/DevotionDataMigration.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/DevotionDataMigration.kt
@@ -1,0 +1,97 @@
+package yuku.alkitab.base.storage.room
+
+import yuku.afw.storage.Preferences
+import yuku.alkitab.base.storage.InternalDbHelper
+import yuku.alkitab.base.storage.Prefkey
+import yuku.alkitab.base.storage.Table
+import yuku.alkitab.base.util.AppLog
+
+/**
+ * One-time data copy from the legacy `Devotion` table in `AlkitabDb`
+ * (managed by `InternalDbHelper`) into Room's `devotion` table in
+ * `AlkitabRoomDb` (managed by [AppDatabase]).
+ *
+ * Idempotency is anchored on the persistent
+ * [Prefkey.devotion_data_migration_v1_done] flag rather than on a
+ * `dao.count() > 0` check. The count check would resurrect deleted user
+ * data: any rows the user (or the eviction sweep in
+ * [yuku.alkitab.base.storage.DevotionDao.deleteWithTouchTimeBefore]) drops
+ * would be re-copied from the legacy table on the next launch. See GitHub
+ * issue #195.
+ *
+ * Crash safety:
+ *  - If the Room insert fails mid-flight, Room rolls back and the flag is
+ *    never set; the next launch retries.
+ *  - If the process is killed after the insert commits but before the flag
+ *    is set, the next launch sees Room rows already present and takes the
+ *    upgrade-path branch (sets the flag, does not re-copy).
+ *
+ * The legacy table is intentionally left intact so a future release can
+ * audit/rollback.
+ */
+object DevotionDataMigration {
+    private const val TAG = "DevotionDataMigration"
+
+    fun copyFromLegacyDbIfNeeded(roomDb: AppDatabase, legacyHelper: InternalDbHelper) {
+        if (Preferences.getBoolean(Prefkey.devotion_data_migration_v1_done, false)) {
+            return
+        }
+
+        val dao = roomDb.devotionDao()
+
+        // Upgrade path: if a future build ever ships the count-based gate
+        // accidentally (mirroring the pre-#198 mistakes for marker/version),
+        // a non-empty Room table means the copy already happened. Set the
+        // flag and bail.
+        if (dao.count() > 0) {
+            Preferences.setBoolean(Prefkey.devotion_data_migration_v1_done, true)
+            return
+        }
+
+        val rows = readLegacyRows(legacyHelper)
+        if (rows.isEmpty()) {
+            // No legacy data either (fresh install). Mark done so future
+            // launches skip the legacy-read entirely.
+            Preferences.setBoolean(Prefkey.devotion_data_migration_v1_done, true)
+            return
+        }
+
+        // Bulk insert — Room's `@Insert` runs inside a single transaction, so
+        // a crash mid-migration leaves zero rows in Room and the next launch
+        // retries cleanly.
+        dao.insertAll(rows)
+        // Set the flag only after a successful commit. A crash between here
+        // and the next launch is handled by the upgrade-path branch above.
+        Preferences.setBoolean(Prefkey.devotion_data_migration_v1_done, true)
+        AppLog.d(TAG, "Copied ${rows.size} devotion row(s) from legacy Devotion table to Room")
+    }
+
+    private fun readLegacyRows(legacyHelper: InternalDbHelper): List<DevotionEntity> {
+        val res = ArrayList<DevotionEntity>()
+        legacyHelper.readableDatabase.query(
+            Table.Devotion.tableName(), null, null, null, null, null, "_id ASC",
+        ).use { c ->
+            val colName = c.getColumnIndexOrThrow(Table.Devotion.name.name)
+            val colDate = c.getColumnIndexOrThrow(Table.Devotion.date.name)
+            val colBody = c.getColumnIndexOrThrow(Table.Devotion.body.name)
+            val colReadyToUse = c.getColumnIndexOrThrow(Table.Devotion.readyToUse.name)
+            val colTouchTime = c.getColumnIndexOrThrow(Table.Devotion.touchTime.name)
+            val colDataFormatVersion = c.getColumnIndexOrThrow(Table.Devotion.dataFormatVersion.name)
+            while (c.moveToNext()) {
+                res += DevotionEntity(
+                    // Don't carry over `_id` — Room assigns a fresh one. Nothing
+                    // outside the table referenced the legacy `_id`; the
+                    // identity key used by callers is `(name, date, dataFormatVersion)`.
+                    _id = 0L,
+                    name = c.getString(colName),
+                    date = c.getString(colDate),
+                    body = c.getString(colBody),
+                    readyToUse = c.getInt(colReadyToUse),
+                    touchTime = c.getInt(colTouchTime),
+                    dataFormatVersion = c.getInt(colDataFormatVersion),
+                )
+            }
+        }
+        return res
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/DevotionEntity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/DevotionEntity.kt
@@ -1,0 +1,47 @@
+package yuku.alkitab.base.storage.room
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Room entity for a cached devotional article. Lives in [AppDatabase] (file
+ * `AlkitabRoomDb`), distinct from the legacy `Devotion` table in `AlkitabDb`
+ * which is still created by `InternalDbHelper` but no longer written to. The
+ * one-time data copy on first launch is wired up in [DevotionDataMigration].
+ *
+ * Identity: rows are matched on `(name, date, dataFormatVersion)`. There is no
+ * uniqueness constraint — the facade dedupes via delete-then-insert in a
+ * single transaction, mirroring the legacy [yuku.alkitab.base.storage.DevotionDao]
+ * behaviour.
+ *
+ * Column types — `readyToUse`/`touchTime`/`dataFormatVersion` are non-nullable
+ * here even though the legacy schema allowed NULLs; [DevotionDataMigration]
+ * coalesces legacy NULLs to 0. The text columns (`name`/`date`/`body`) stay
+ * nullable to faithfully round-trip whatever the legacy rows contain.
+ *
+ * Indexes mirror the legacy `Devotion` table's two indexes
+ * (`createIndexDevotion` in `InternalDbHelper`).
+ */
+@Entity(
+    tableName = "devotion",
+    indices = [
+        Index(
+            value = ["name", "date", "dataFormatVersion"],
+            name = "index_devotion_name_date_dataFormatVersion",
+        ),
+        Index(value = ["touchTime"], name = "index_devotion_touchTime"),
+    ],
+)
+data class DevotionEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "_id")
+    val _id: Long = 0L,
+    val name: String?,
+    val date: String?,
+    val body: String?,
+    val readyToUse: Int,
+    val touchTime: Int,
+    val dataFormatVersion: Int,
+)

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/DevotionRoomDao.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/DevotionRoomDao.kt
@@ -1,0 +1,77 @@
+package yuku.alkitab.base.storage.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+
+/**
+ * Room DAO for the `devotion` table. Consumed by the facade in
+ * [yuku.alkitab.base.storage.DevotionDao].
+ *
+ * Naming convention: this DAO speaks in [DevotionEntity]; the mapping to/from
+ * the public `DevotionArticle` model lives in the facade so call sites that
+ * already use `DevotionArticle` don't need to change.
+ */
+@Dao
+interface DevotionRoomDao {
+
+    @Query("SELECT * FROM devotion")
+    fun listAll(): List<DevotionEntity>
+
+    @Query("SELECT COUNT(*) FROM devotion")
+    fun count(): Int
+
+    /**
+     * Returns the cached row keyed by `(name, date, dataFormatVersion)`, or
+     * `null` if none is cached. Mirrors the legacy DevotionDao.tryGet — the
+     * dataFormatVersion filter is what the legacy SQL pinned to the literal
+     * `1`; expose it here so a future format bump can search past versions.
+     */
+    @Query(
+        "SELECT * FROM devotion" +
+            " WHERE name = :name AND date = :date AND dataFormatVersion = :dataFormatVersion" +
+            " LIMIT 1",
+    )
+    fun findByNameDateAndDataFormatVersion(
+        name: String,
+        date: String,
+        dataFormatVersion: Int,
+    ): DevotionEntity?
+
+    @Query("DELETE FROM devotion WHERE name = :name AND date = :date")
+    fun deleteByNameAndDate(name: String, date: String): Int
+
+    /** Cache eviction: rows older than [touchTime] are removed wholesale. */
+    @Query("DELETE FROM devotion WHERE touchTime < :touchTime")
+    fun deleteWithTouchTimeBefore(touchTime: Int): Int
+
+    @Insert
+    fun insert(entity: DevotionEntity): Long
+
+    /**
+     * Bulk insert — runs atomically in a single transaction (Room's `@Insert`
+     * default). Used by [DevotionDataMigration] so a partial migration can't
+     * leave the table in a half-populated state.
+     */
+    @Insert
+    fun insertAll(entities: List<DevotionEntity>)
+
+    /**
+     * Delete-then-insert by `(name, date)`. Mirrors the legacy
+     * [yuku.alkitab.base.storage.DevotionDao.storeArticle] semantics: the
+     * table has no uniqueness constraint, so the facade upserts by clearing
+     * any row that already has the same `(name, date)` and inserting fresh.
+     * Wrapped in a single Room transaction so a concurrent reader can't
+     * observe an in-between state with zero rows.
+     */
+    @Transaction
+    fun upsertByNameAndDate(entity: DevotionEntity) {
+        val name = entity.name
+            ?: error("upsertByNameAndDate requires a non-null name")
+        val date = entity.date
+            ?: error("upsertByNameAndDate requires a non-null date")
+        deleteByNameAndDate(name, date)
+        insert(entity)
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/DevotionDaoTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/DevotionDaoTest.kt
@@ -1,6 +1,7 @@
 package yuku.alkitab.base.storage
 
 import android.app.Application
+import androidx.room.Room
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -16,24 +17,42 @@ import org.robolectric.annotation.Config
 import yuku.alkitab.base.ac.DevotionActivity
 import yuku.alkitab.base.devotion.ArticleRenunganHarian
 import yuku.alkitab.base.devotion.ArticleSantapanHarian
+import yuku.alkitab.base.storage.room.AppDatabase
 import java.util.Date
 
+/**
+ * Robolectric tests for [DevotionDao]. Originally exercised the SQLite-backed
+ * implementation against [InternalDbHelper]; after the Devotion → Room
+ * migration the facade routes through Room, so this test now installs an
+ * in-memory [AppDatabase] in [setUp].
+ *
+ * The behavioural contract is unchanged — these tests are the parity gate for
+ * the Room migration.
+ */
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class, sdk = [34])
 class DevotionDaoTest {
     private lateinit var helper: InternalDbHelper
+    private lateinit var roomDb: AppDatabase
     private lateinit var dao: DevotionDao
 
     @Before
     fun setUp() {
         val app = RuntimeEnvironment.getApplication()
         yuku.afw.App.context = app
+        // InternalDbHelper is still needed by the legacy DevotionDao
+        // constructor signature, but the facade ignores it now.
         helper = InternalDbHelper(app)
+        roomDb = Room.inMemoryDatabaseBuilder(app, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        AppDatabase.setForTesting(roomDb)
         dao = DevotionDao(helper)
     }
 
     @After
     fun tearDown() {
+        AppDatabase.setForTesting(null)
         helper.close()
     }
 

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/AppDatabaseMigrationTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/AppDatabaseMigrationTest.kt
@@ -98,7 +98,7 @@ class AppDatabaseMigrationTest {
         }
 
         // Now open the DB the normal way — Room validates the schema against
-        // the entity annotations and applies the registered migration on the
+        // the entity annotations and applies the registered migrations on the
         // way from v1 to the current version. Mismatches throw at this point.
         val room = Room.databaseBuilder(
             InstrumentationRegistry.getInstrumentation().targetContext,
@@ -106,7 +106,7 @@ class AppDatabaseMigrationTest {
             TEST_DB,
         )
             .allowMainThreadQueries()
-            .addMigrations(AppDatabase.MIGRATION_1_2)
+            .addMigrations(AppDatabase.MIGRATION_1_2, AppDatabase.MIGRATION_2_3)
             .build()
         AppDatabase.setForTesting(room)
 
@@ -201,6 +201,73 @@ class AppDatabaseMigrationTest {
     }
 
     /**
+     * v2 → v3 adds the `devotion` table. The migration must:
+     *
+     * - Preserve every row already in the v2 tables (`version`, `marker`,
+     *   `label`, `marker_label`).
+     * - Create the `devotion` table with the schema Room's entity definitions
+     *   emit (verified by [MigrationTestHelper.runMigrationsAndValidate] when
+     *   `validateDroppedTables = true`).
+     * - Leave the new table empty (data copy is a separate concern handled
+     *   by [DevotionDataMigration]).
+     */
+    @Test
+    fun migrates2To3() {
+        // Seed a v2 row in the `version` table so we can verify the migration
+        // doesn't drop pre-existing data. Apply v1 → v2 first so the v2
+        // tables exist.
+        helper.createDatabase(TEST_DB, 1).close()
+        helper.runMigrationsAndValidate(TEST_DB, 2, true, AppDatabase.MIGRATION_1_2).use { db ->
+            val cv = ContentValues().apply {
+                put("filename", "/data/a.yes")
+                put("preset_name", "kjv")
+                put("locale", "en")
+                put("shortName", "KJV")
+                put("longName", "King James")
+                put("description", "desc")
+                put("modifyTime", 1_700_000_000)
+                put("active", 1)
+                put("ordering", 101)
+            }
+            db.insert("version", android.database.sqlite.SQLiteDatabase.CONFLICT_REPLACE, cv)
+        }
+
+        // Run v2 → v3.
+        helper.runMigrationsAndValidate(TEST_DB, 3, true, AppDatabase.MIGRATION_2_3).use { db ->
+            // v2 row survived
+            db.query("SELECT longName FROM version WHERE filename = '/data/a.yes'").use { c ->
+                assertTrue(c.moveToFirst())
+                assertEquals("King James", c.getString(0))
+            }
+            // The new table exists
+            db.query("SELECT name FROM sqlite_master WHERE type='table' AND name = 'devotion'").use { c ->
+                assertTrue(c.moveToFirst())
+                assertEquals("devotion", c.getString(0))
+            }
+            // … and is empty
+            db.query("SELECT COUNT(*) FROM devotion").use { c ->
+                assertTrue(c.moveToFirst())
+                assertEquals(0, c.getInt(0))
+            }
+            // Both indexes were created
+            db.query(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='devotion' ORDER BY name",
+            ).use { c ->
+                val indexes = mutableListOf<String>()
+                while (c.moveToNext()) indexes += c.getString(0)
+                assertTrue(
+                    "expected index_devotion_name_date_dataFormatVersion among $indexes",
+                    indexes.contains("index_devotion_name_date_dataFormatVersion"),
+                )
+                assertTrue(
+                    "expected index_devotion_touchTime among $indexes",
+                    indexes.contains("index_devotion_touchTime"),
+                )
+            }
+        }
+    }
+
+    /**
      * The post-migration schema must round-trip a row through every new
      * entity. Catches drift between the [AppDatabase.MIGRATION_1_2] SQL and
      * the entity declarations (e.g. forgetting an index, getting a column
@@ -218,7 +285,7 @@ class AppDatabaseMigrationTest {
             TEST_DB,
         )
             .allowMainThreadQueries()
-            .addMigrations(AppDatabase.MIGRATION_1_2)
+            .addMigrations(AppDatabase.MIGRATION_1_2, AppDatabase.MIGRATION_2_3)
             .build()
         AppDatabase.setForTesting(room)
 
@@ -239,6 +306,48 @@ class AppDatabaseMigrationTest {
             val loaded = room.markerDao().findByGid("g1")
             assertNotNull(loaded)
             assertEquals(100, loaded!!.ari)
+        } finally {
+            room.close()
+        }
+    }
+
+    /**
+     * Companion to the v1→v2 marker round-trip test: verify that after
+     * v1 → v3 (i.e. both migrations applied in sequence) Room can open the
+     * DB and round-trip a row through the new [DevotionEntity] DAO. Catches
+     * drift between [AppDatabase.MIGRATION_2_3] and the entity declaration.
+     */
+    @Test
+    fun `after migrating from v1 to v3 Room opens cleanly and round-trips a devotion through the new DAO`() {
+        helper.createDatabase(TEST_DB, 1).close()
+
+        val room = Room.databaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            AppDatabase::class.java,
+            TEST_DB,
+        )
+            .allowMainThreadQueries()
+            .addMigrations(AppDatabase.MIGRATION_1_2, AppDatabase.MIGRATION_2_3)
+            .build()
+        AppDatabase.setForTesting(room)
+
+        try {
+            val id = room.devotionDao().insert(
+                DevotionEntity(
+                    _id = 0L,
+                    name = "RH",
+                    date = "2026-05-14",
+                    body = "body",
+                    readyToUse = 1,
+                    touchTime = 1_700_000_000,
+                    dataFormatVersion = 1,
+                ),
+            )
+            assertTrue(id > 0)
+            val loaded = room.devotionDao()
+                .findByNameDateAndDataFormatVersion("RH", "2026-05-14", 1)
+            assertNotNull(loaded)
+            assertEquals("body", loaded!!.body)
         } finally {
             room.close()
         }

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/DevotionDataMigrationTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/DevotionDataMigrationTest.kt
@@ -1,0 +1,213 @@
+package yuku.alkitab.base.storage.room
+
+import android.app.Application
+import android.content.ContentValues
+import android.preference.PreferenceManager
+import androidx.room.Room
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import yuku.afw.storage.Preferences
+import yuku.alkitab.base.storage.InternalDbHelper
+import yuku.alkitab.base.storage.Prefkey
+import yuku.alkitab.base.storage.Table
+
+/**
+ * Verifies the one-time copy from the legacy `Devotion` table into Room.
+ * Robolectric is required because [InternalDbHelper] extends
+ * [android.database.sqlite.SQLiteOpenHelper].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class DevotionDataMigrationTest {
+    private lateinit var legacy: InternalDbHelper
+    private lateinit var room: AppDatabase
+
+    @Before
+    fun setUp() {
+        val app = RuntimeEnvironment.getApplication()
+        yuku.afw.App.context = app
+        // Idempotency is anchored on a SharedPreferences flag. Clear it (and
+        // the [Preferences] static cache that may hold a previous test's
+        // SharedPreferences instance) so every test starts with a clean slate.
+        PreferenceManager.getDefaultSharedPreferences(app).edit().clear().commit()
+        Preferences.invalidate()
+        legacy = InternalDbHelper(app)
+        room = Room.inMemoryDatabaseBuilder(app, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        room.close()
+        legacy.close()
+    }
+
+    private fun insertLegacyDevotion(
+        name: String,
+        date: String,
+        body: String? = "body",
+        readyToUse: Int = 1,
+        touchTime: Int = 1_700_000_000,
+        dataFormatVersion: Int = 1,
+    ) {
+        val cv = ContentValues().apply {
+            put(Table.Devotion.name.name, name)
+            put(Table.Devotion.date.name, date)
+            put(Table.Devotion.body.name, body)
+            put(Table.Devotion.readyToUse.name, readyToUse)
+            put(Table.Devotion.touchTime.name, touchTime)
+            put(Table.Devotion.dataFormatVersion.name, dataFormatVersion)
+        }
+        legacy.writableDatabase.insert(Table.Devotion.tableName(), null, cv)
+    }
+
+    @Test
+    fun `copy is a no-op when both databases are empty`() {
+        DevotionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertTrue(room.devotionDao().listAll().isEmpty())
+    }
+
+    @Test
+    fun `copy moves every legacy row into Room and round-trips every persisted field`() {
+        insertLegacyDevotion(
+            name = "RH",
+            date = "2026-05-14",
+            body = "renungan-body",
+            readyToUse = 1,
+            touchTime = 1_700_000_111,
+            dataFormatVersion = 1,
+        )
+
+        DevotionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val rows = room.devotionDao().listAll()
+        assertEquals(1, rows.size)
+        with(rows.single()) {
+            assertEquals("RH", name)
+            assertEquals("2026-05-14", date)
+            assertEquals("renungan-body", body)
+            assertEquals(1, readyToUse)
+            assertEquals(1_700_000_111, touchTime)
+            assertEquals(1, dataFormatVersion)
+        }
+    }
+
+    @Test
+    fun `copy preserves a null body for not-ready-to-use rows`() {
+        insertLegacyDevotion(name = "SH", date = "2026-05-14", body = null, readyToUse = 0)
+
+        DevotionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val row = room.devotionDao().findByNameDateAndDataFormatVersion("SH", "2026-05-14", 1)
+        assertNotNull(row)
+        assertEquals(null, row!!.body)
+        assertEquals(0, row.readyToUse)
+    }
+
+    @Test
+    fun `copy is idempotent — running twice does not duplicate rows`() {
+        insertLegacyDevotion(name = "RH", date = "2026-05-14")
+
+        DevotionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        DevotionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        assertEquals(1, room.devotionDao().listAll().size)
+    }
+
+    @Test
+    fun `copy assigns fresh _ids and does not carry over legacy _ids`() {
+        insertLegacyDevotion(name = "RH", date = "2026-05-14")
+
+        DevotionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val row = room.devotionDao().findByNameDateAndDataFormatVersion("RH", "2026-05-14", 1)
+        assertNotNull(row)
+        // Room AUTOINCREMENT starts at 1 for a fresh in-memory DB; the only
+        // contract is that _id is positive (fresh) rather than the legacy
+        // _id literal we never asserted.
+        assertTrue("expected positive Room _id, got ${row!!._id}", row._id > 0)
+    }
+
+    @Test
+    fun `does not resurrect deleted cache entries after the user clears every row (issue #195)`() {
+        // Setup: legacy table has a cached devotion, mirroring a real upgrade
+        // from the pre-Room schema. The legacy row is intentionally preserved
+        // as a rollback safety net even after migration.
+        insertLegacyDevotion(name = "RH", date = "2026-05-14")
+
+        // First launch on the Room build: migration copies it across.
+        DevotionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertEquals(1, room.devotionDao().listAll().size)
+
+        // The cache-eviction sweep (deleteDevotionsWithTouchTimeBefore) clears
+        // the row from Room. The legacy table in AlkitabDb is deliberately
+        // not touched by any write path.
+        room.devotionDao().deleteWithTouchTimeBefore(Int.MAX_VALUE)
+        assertTrue(room.devotionDao().listAll().isEmpty())
+
+        // Next launch: migration runs again. With a count-based gate it
+        // would re-copy the legacy row. The flag-based gate must be a strict
+        // no-op.
+        DevotionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        assertTrue(
+            "legacy devotion row was resurrected",
+            room.devotionDao().listAll().isEmpty(),
+        )
+    }
+
+    @Test
+    fun `successful copy sets the persistent done flag`() {
+        insertLegacyDevotion(name = "RH", date = "2026-05-14")
+
+        assertFalse(Preferences.getBoolean(Prefkey.devotion_data_migration_v1_done, false))
+        DevotionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertTrue(Preferences.getBoolean(Prefkey.devotion_data_migration_v1_done, false))
+    }
+
+    @Test
+    fun `fresh install with no legacy data also sets the done flag`() {
+        // No legacy rows inserted. The migration has nothing to copy but must
+        // still mark itself done so subsequent launches don't keep querying
+        // the legacy DB.
+        assertFalse(Preferences.getBoolean(Prefkey.devotion_data_migration_v1_done, false))
+        DevotionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertTrue(Preferences.getBoolean(Prefkey.devotion_data_migration_v1_done, false))
+    }
+
+    @Test
+    fun `upgrade path - flag unset but Room already has rows sets the flag without re-copying`() {
+        // Simulates a hypothetical user who somehow ended up with rows in
+        // Room but no done flag set. The migration must NOT re-insert the
+        // legacy rows on top of the existing Room state.
+        room.devotionDao().insert(
+            DevotionEntity(
+                _id = 0L,
+                name = "already-migrated",
+                date = "2026-05-14",
+                body = "body",
+                readyToUse = 1,
+                touchTime = 0,
+                dataFormatVersion = 1,
+            ),
+        )
+        insertLegacyDevotion(name = "legacy-RH", date = "2026-05-14")
+
+        DevotionDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val rows = room.devotionDao().listAll()
+        assertEquals(1, rows.size)
+        assertEquals("already-migrated", rows.single().name)
+        assertTrue(Preferences.getBoolean(Prefkey.devotion_data_migration_v1_done, false))
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/DevotionRoomDaoTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/DevotionRoomDaoTest.kt
@@ -1,0 +1,155 @@
+package yuku.alkitab.base.storage.room
+
+import android.app.Application
+import androidx.room.Room
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for the Room-generated [DevotionRoomDao]. Verifies the `(name, date)`
+ * upsert semantics that mirror the legacy [yuku.alkitab.base.storage.DevotionDao]
+ * delete-then-insert pattern, plus the `dataFormatVersion`-filtered lookup
+ * and the touchTime-based cache eviction.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class DevotionRoomDaoTest {
+    private lateinit var db: AppDatabase
+    private lateinit var dao: DevotionRoomDao
+
+    @Before
+    fun setUp() {
+        val app = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(app, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.devotionDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private fun entity(
+        name: String,
+        date: String,
+        body: String? = "body",
+        readyToUse: Int = 1,
+        touchTime: Int = 1_700_000_000,
+        dataFormatVersion: Int = 1,
+    ) = DevotionEntity(
+        _id = 0L,
+        name = name,
+        date = date,
+        body = body,
+        readyToUse = readyToUse,
+        touchTime = touchTime,
+        dataFormatVersion = dataFormatVersion,
+    )
+
+    @Test
+    fun `listAll on an empty database returns an empty list`() {
+        assertTrue(dao.listAll().isEmpty())
+    }
+
+    @Test
+    fun `insert assigns a positive _id and the row can be read back via findByNameDate`() {
+        val id = dao.insert(entity("RH", "2026-05-14"))
+        assertTrue("expected positive _id, got $id", id > 0)
+        val loaded = dao.findByNameDateAndDataFormatVersion("RH", "2026-05-14", 1)
+        assertNotNull(loaded)
+        assertEquals("body", loaded!!.body)
+    }
+
+    @Test
+    fun `findByNameDateAndDataFormatVersion returns null when no row matches the dataFormatVersion`() {
+        dao.insert(entity("RH", "2026-05-14", dataFormatVersion = 1))
+        // No v2 row exists.
+        assertNull(dao.findByNameDateAndDataFormatVersion("RH", "2026-05-14", 2))
+    }
+
+    @Test
+    fun `findByNameDateAndDataFormatVersion returns null for an unknown (name, date) pair`() {
+        dao.insert(entity("RH", "2026-05-14"))
+        assertNull(dao.findByNameDateAndDataFormatVersion("SH", "2026-05-14", 1))
+        assertNull(dao.findByNameDateAndDataFormatVersion("RH", "2026-05-15", 1))
+    }
+
+    @Test
+    fun `upsertByNameAndDate replaces the existing row for the same (name, date) pair`() {
+        dao.insert(entity("RH", "2026-05-14", body = "v1", touchTime = 100))
+        dao.upsertByNameAndDate(entity("RH", "2026-05-14", body = "v2", touchTime = 200))
+
+        val rows = dao.listAll()
+        assertEquals(1, rows.size)
+        with(rows.single()) {
+            assertEquals("v2", body)
+            assertEquals(200, touchTime)
+        }
+    }
+
+    @Test
+    fun `upsertByNameAndDate inserts when no row exists for the (name, date) pair`() {
+        dao.upsertByNameAndDate(entity("RH", "2026-05-14"))
+        assertEquals(1, dao.count())
+    }
+
+    @Test
+    fun `upsertByNameAndDate does not touch rows with a different (name, date) pair`() {
+        dao.insert(entity("RH", "2026-05-14", body = "rh"))
+        dao.insert(entity("SH", "2026-05-14", body = "sh"))
+
+        dao.upsertByNameAndDate(entity("RH", "2026-05-14", body = "rh-v2"))
+
+        assertEquals("sh", dao.findByNameDateAndDataFormatVersion("SH", "2026-05-14", 1)!!.body)
+        assertEquals("rh-v2", dao.findByNameDateAndDataFormatVersion("RH", "2026-05-14", 1)!!.body)
+    }
+
+    @Test
+    fun `deleteByNameAndDate returns the number of rows deleted and leaves unrelated rows in place`() {
+        dao.insert(entity("RH", "2026-05-14"))
+        dao.insert(entity("SH", "2026-05-14"))
+
+        assertEquals(1, dao.deleteByNameAndDate("RH", "2026-05-14"))
+        assertEquals(0, dao.deleteByNameAndDate("RH", "2026-05-14"))
+        assertEquals(1, dao.count())
+        assertNotNull(dao.findByNameDateAndDataFormatVersion("SH", "2026-05-14", 1))
+    }
+
+    @Test
+    fun `deleteWithTouchTimeBefore evicts only rows older than the cutoff`() {
+        dao.insert(entity("RH", "2026-05-10", touchTime = 100))
+        dao.insert(entity("RH", "2026-05-12", touchTime = 200))
+        dao.insert(entity("RH", "2026-05-14", touchTime = 300))
+
+        // Cutoff is exclusive — rows with touchTime exactly equal to the cutoff are kept.
+        assertEquals(1, dao.deleteWithTouchTimeBefore(200))
+
+        val remaining = dao.listAll().map { it.date }
+        assertTrue("2026-05-12 should still be present: $remaining", remaining.contains("2026-05-12"))
+        assertTrue("2026-05-14 should still be present: $remaining", remaining.contains("2026-05-14"))
+        assertEquals(2, remaining.size)
+    }
+
+    @Test
+    fun `insertAll persists every row in a single call`() {
+        dao.insertAll(
+            listOf(
+                entity("RH", "2026-05-12"),
+                entity("RH", "2026-05-13"),
+                entity("SH", "2026-05-12"),
+            ),
+        )
+        assertEquals(3, dao.count())
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,19 +169,19 @@ Used everywhere: database storage, intent extras, sync protocol, content provide
 
 The app uses two SQLite files:
 
-- **`AlkitabRoomDb`** — Room database (`yuku.alkitab.base.storage.room.AppDatabase`, currently at `@Database(version = 2)`). Holds the tables migrated as part of the REM-10/REM-11 plan:
+- **`AlkitabRoomDb`** — Room database (`yuku.alkitab.base.storage.room.AppDatabase`, currently at `@Database(version = 3)`). Holds the tables migrated as part of the REM-10/REM-11/REM-27 plan:
   - **version** (REM-11) — metadata for downloaded Bible versions (filename, locale, active flag, ordering).
   - **marker** (REM-10) — bookmarks, notes, highlights (distinguished by `kind` column). Each row has a `gid` (globally unique ID) for sync.
   - **label** (REM-10) — bookmark categories with custom background colors.
   - **marker_label** (REM-10) — many-to-many junction between markers and labels.
+  - **devotion** (REM-27) — cached devotional articles keyed by `(name, date, dataFormatVersion)`.
 - **`AlkitabDb`** — legacy hand-rolled `SQLiteOpenHelper` (`InternalDbHelper`). Still owns the not-yet-migrated tables:
   - **ProgressMark** — 5 reading progress pins with ARI positions.
   - **ReadingPlan** / **ReadingPlanProgress** — reading plan data and daily completion tracking.
-  - **Devotion** — cached devotional articles.
   - **SyncShadow** / **SyncLog** — sync state tracking.
   - **PerVersion** — per-version settings.
 
-The legacy `Marker` / `Label` / `Marker_Label` / `Version` tables are still created in `AlkitabDb` as a rollback safety net; a one-time copy in `MarkerDataMigration` / `VersionDataMigration` (wired from `S.db`'s lazy initializer) moves their rows into Room on first launch with the migrated code. `InternalDb` plus the per-table facades (`MarkerDao`, `LabelDao`, `Marker_LabelDao`, `VersionDao`, etc.) preserve the public surface so callers don't change; the facades route through Room for the migrated tables and through raw SQL for the rest.
+The legacy `Marker` / `Label` / `Marker_Label` / `Version` / `Devotion` tables are still created in `AlkitabDb` as a rollback safety net; a one-time copy in `MarkerDataMigration` / `VersionDataMigration` / `DevotionDataMigration` (wired from `S.db`'s lazy initializer) moves their rows into Room on first launch with the migrated code. `InternalDb` plus the per-table facades (`MarkerDao`, `LabelDao`, `Marker_LabelDao`, `VersionDao`, `DevotionDao`, etc.) preserve the public surface so callers don't change; the facades route through Room for the migrated tables and through raw SQL for the rest.
 
 ### Verse Text Formatting Codes
 

--- a/docs/tech-debt-remediation.md
+++ b/docs/tech-debt-remediation.md
@@ -32,6 +32,7 @@ This document is an index over the prioritized remediation plan for each tech de
 - [REM-09: Introduce ViewModel for IsiActivity](tech-debt-remediation/REM-09-isiactivity-viewmodel.md) — **3.4**
 - [REM-10: Migrate InternalDb to Room (Markers Table)](tech-debt-remediation/REM-10-room-markers.md) ✅ **3.4**
 - [REM-11: Migrate InternalDb to Room (Version Table)](tech-debt-remediation/REM-11-room-version.md) ✅ **3.2**
+- [REM-27: Migrate InternalDb to Room (Devotion Table)](tech-debt-remediation/REM-27-room-devotion.md) ✅ **3.2**
 - [REM-12: Replace DragSortListView with ItemTouchHelper](tech-debt-remediation/REM-12-itemtouchhelper.md) ✅ **3.4**
 - [REM-14: Replace material-dialogs with Material 3](tech-debt-remediation/REM-14-material-dialogs.md) ✅ **3.4**
 - [REM-18: Add Test Coverage for Core Modules](tech-debt-remediation/REM-18-test-coverage.md) ✅ **3.4**
@@ -77,6 +78,7 @@ This document is an index over the prioritized remediation plan for each tech de
 | [REM-24](tech-debt-remediation/REM-24-s-service-locator.md) | ~~Refactor S.kt service locator (steps 24a–24d complete)~~ ✅ | **3.2** | 2 |
 | [REM-08](tech-debt-remediation/REM-08-isiactivity-split-view.md) | ~~Extract split view manager~~ ✅ | **3.2** | 2 |
 | [REM-11](tech-debt-remediation/REM-11-room-version.md) | ~~Room migration (Version)~~ ✅ | **3.2** | 2 |
+| [REM-27](tech-debt-remediation/REM-27-room-devotion.md) | ~~Room migration (Devotion)~~ ✅ | **3.2** | 2 |
 | [REM-15](tech-debt-remediation/REM-15-coroutines.md) | Introduce coroutines | **3.2** | 3 |
 | [REM-16](tech-debt-remediation/REM-16-java-to-kotlin.md) | Java→Kotlin conversion (9/11 done) | **3.0** | 3 |
 | [REM-17](tech-debt-remediation/REM-17-kotlin-dsl-build.md) | ~~Kotlin DSL build migration~~ ✅ | **3.0** | 3 |
@@ -91,6 +93,6 @@ This document is an index over the prioritized remediation plan for each tech de
 **Sprint 2 (1 week):** ~~REM-03~~✅ — LocalBroadcastManager removal (done)
 **Sprint 3 (2 weeks):** ~~REM-07~~✅, ~~REM-06~~✅, ~~REM-08~~✅ — IsiActivity decomposition (all done)
 **Sprint 4 (1 week):** ~~REM-12~~✅, ~~REM-14~~✅ — deprecated library replacements (done)
-**Sprint 5 (2 weeks):** ~~REM-10~~✅, ~~REM-11~~✅ — Room migration for core tables (both done; remaining tables — `ReadingPlan`, `Devotion`, `SyncShadow`, `SyncLog`, `PerVersion`, `ProgressMark` — can follow the same pattern)
+**Sprint 5 (2 weeks):** ~~REM-10~~✅, ~~REM-11~~✅, ~~REM-27~~✅ — Room migration for core tables (Marker / Version / Devotion done; remaining tables — `ReadingPlan`, `SyncShadow`, `SyncLog`, `PerVersion`, `ProgressMark` — can follow the same pattern)
 **Sprint 6 (2 weeks):** REM-09, ~~REM-18a-f~~✅ — ViewModel + test coverage (REM-18a/b/c/d/e/f done)
 **Ongoing:** REM-15, REM-16, ~~REM-17~~✅ — modernization work mixed into feature sprints (REM-17 done)

--- a/docs/tech-debt-remediation/REM-10-room-markers.md
+++ b/docs/tech-debt-remediation/REM-10-room-markers.md
@@ -26,7 +26,7 @@
 
 **Verification.** `./gradlew :Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest` — 494 tests, all green. `./gradlew :Alkitab:assemblePlainDebug` produces a working APK. On-device smoke (Pixel emulator API 35, pre-existing dataset of 1456 markers / 18 labels / 152 marker_label associations from a v1 Room install): installing the new APK ran `MarkerDataMigration` once on first launch (logged `Copied 1456 marker(s), 18 label(s), 152 marker_label row(s) from legacy tables to Room`), counts match the legacy table exactly, second launch is idempotent (no row growth), spot-check confirms `gid` / `ari` / `caption` round-trip verbatim.
 
-**Difficulty:** Hard. Took ~1 day with the REM-11 pattern already established. Subsequent tables (`ReadingPlan`, `Devotion`, `SyncShadow`, `SyncLog`, `PerVersion`, `ProgressMark`) can follow the same pattern.
+**Difficulty:** Hard. Took ~1 day with the REM-11 pattern already established. Subsequent tables can follow the same pattern — `Devotion` shipped as [REM-27](REM-27-room-devotion.md); `ReadingPlan`, `SyncShadow`, `SyncLog`, `PerVersion`, `ProgressMark` remain.
 
 ---
 

--- a/docs/tech-debt-remediation/REM-27-room-devotion.md
+++ b/docs/tech-debt-remediation/REM-27-room-devotion.md
@@ -1,0 +1,30 @@
+# REM-27: Migrate InternalDb to Room (Devotion Table) ✅ COMPLETED (2026-05-14)
+
+**Addresses:** TD-02 (continuation of [REM-10](REM-10-room-markers.md) / [REM-11](REM-11-room-version.md))
+**Module:** Storage — Devotion cache
+**BRICE:** B=3 R=3 I=2 C=3 E=5 → **3.2**
+**Phase:** 2 — Architecture Improvements
+
+**Outcome.** The legacy hand-rolled `Devotion` SQLite table is now backed by Room in `AlkitabRoomDb` (the same separate-file Room database introduced by REM-11 and extended by REM-10). `AppDatabase` bumped `version = 2 → 3`; the SQL inside `MIGRATION_2_3` mirrors what Room's entity definition emits (verified by `MigrationTestHelper.runMigrationsAndValidate` with `validateDroppedTables = true`).
+
+**Shipped:**
+- **Entity:** `DevotionEntity.kt` mirrors the legacy columns (`name`, `date`, `body`, `readyToUse`, `touchTime`, `dataFormatVersion`). Indexes match the legacy ones (`(name, date, dataFormatVersion)` and `(touchTime)`). Numeric columns are non-nullable in Room even though the legacy schema allowed NULLs; `DevotionDataMigration` coalesces legacy NULLs to 0 — matches the REM-11 nullability handling.
+- **Room DAO:** `DevotionRoomDao.kt` exposes `findByNameDateAndDataFormatVersion`, `deleteByNameAndDate`, `deleteWithTouchTimeBefore`, and an `@Transaction upsertByNameAndDate` that mirrors the legacy delete-then-insert semantics for the (name, date) identity key.
+- **Schema bump:** `AppDatabase.kt` now `@Database(version = 3)` with `@JvmField val MIGRATION_2_3`. `Alkitab/schemas/yuku.alkitab.base.storage.room.AppDatabase/3.json` is checked in alongside `1.json` and `2.json`.
+- **Data migration:** `DevotionDataMigration.kt` — idempotent one-time copy from the legacy `Devotion` table into Room. Idempotency uses the persistent `Prefkey.devotion_data_migration_v1_done` flag (same approach as the post-[#198](https://github.com/yukuku/androidbible/pull/198) fix for marker/version), so the user-driven cache eviction in `deleteDevotionsWithTouchTimeBefore` cannot resurrect deleted rows on the next launch. Wired into `S.kt`'s `db` lazy initializer next to `MarkerDataMigration` and `VersionDataMigration`.
+- **Facade preservation:** `DevotionDao.kt` rewritten to delegate to the Room DAO, mapping between `DevotionEntity` and the `DevotionArticle` subclass hierarchy. Public method signatures unchanged — call sites in `InternalDb` (`storeArticleToDevotions`, `deleteDevotionsWithTouchTimeBefore`, `tryGetDevotion`) did not need to be touched.
+- **Legacy table left in place.** `Devotion` is still created by `InternalDbHelper.onCreate` so the rollback safety net is preserved; a future release can drop it once the Room path has baked.
+
+**Tests (2 new files, 1 existing extended, 1 existing updated):**
+- `DevotionRoomDaoTest.kt` (10 tests) — Room-level primitives: `(name, date, dataFormatVersion)` lookup, `upsertByNameAndDate` replace/insert/isolation, `deleteWithTouchTimeBefore` cutoff semantics.
+- `DevotionDataMigrationTest.kt` (8 tests) — empty/full copies, null-body preservation, idempotency, no-stomp-on-existing-Room-rows, fresh `_id` assignment, and the issue #195 regression guard against resurrecting cache-evicted rows.
+- `AppDatabaseMigrationTest.kt` — added `migrates2To3` test plus an end-to-end `v1 → v3` open-via-Room round-trip; updated the two existing tests that open the DB via `Room.databaseBuilder` to register both `MIGRATION_1_2` and `MIGRATION_2_3` now that the entity-driven schema is at v3.
+- `DevotionDaoTest.kt` — `@Before` now installs an in-memory `AppDatabase` via `AppDatabase.setForTesting` (necessary harness change because the facade DAO routes through Room), same as `VersionDaoTest`.
+
+**Verification.** `./gradlew :Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest` — all green. `./gradlew :Alkitab:assemblePlainDebug` produces a working APK.
+
+**Difficulty:** Easy. Took ~half a day with the REM-10 / REM-11 pattern already established. Remaining tables (`ReadingPlan`, `SyncShadow`, `SyncLog`, `PerVersion`, `ProgressMark`) can follow the same pattern.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)


### PR DESCRIPTION
## Summary

Continues the InternalDb → Room migration started in [#188](https://github.com/yukuku/androidbible/pull/188) (REM-11, Version) and [#191](https://github.com/yukuku/androidbible/pull/191) (REM-10, Marker / Label / Marker_Label). The legacy `Devotion` cache table now lives in `AlkitabRoomDb`; `AppDatabase` bumps to `@Database(version = 3)` with `MIGRATION_2_3`.

- **Entity:** `DevotionEntity` (`(name, date, dataFormatVersion)` and `(touchTime)` indexes, mirroring legacy `index_Devotion_01` / `index_Devotion_02`).
- **DAO:** `DevotionRoomDao` exposes `findByNameDateAndDataFormatVersion`, `deleteByNameAndDate`, `deleteWithTouchTimeBefore`, and an `@Transaction upsertByNameAndDate` that preserves the legacy delete-then-insert semantics for the `(name, date)` identity key.
- **Data migration:** `DevotionDataMigration` — idempotent one-time copy gated on the persistent `Prefkey.devotion_data_migration_v1_done` flag (same approach as the post-[#198](https://github.com/yukuku/androidbible/pull/198) fix for marker/version), so the cache-eviction sweep in `deleteDevotionsWithTouchTimeBefore` cannot resurrect deleted rows on the next launch.
- **Facade preservation:** `DevotionDao` rewritten to delegate to the Room DAO. Public API (`storeArticle`, `deleteWithTouchTimeBefore`, `tryGet`) unchanged — `InternalDb` and `DevotionActivity` call sites are not touched.
- **Legacy table left in place** as a rollback safety net per the REM-10 / REM-11 convention.

## Test plan

- [x] `./gradlew :Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest` — all green
- [x] `./gradlew :Alkitab:assemblePlainDebug` — produces a working APK
- [x] New `DevotionRoomDaoTest` (10 tests) covers the DAO surface
- [x] New `DevotionDataMigrationTest` (8 tests) — empty/full copies, null-body preservation, idempotency, no-stomp-on-existing-Room-rows, fresh `_id` assignment, and the [#195](https://github.com/yukuku/androidbible/issues/195) resurrect-after-eviction regression guard
- [x] `AppDatabaseMigrationTest` — added `migrates2To3` and a v1 → v3 end-to-end open-via-Room round-trip; updated the two existing tests that open the DB via `Room.databaseBuilder` to register both `MIGRATION_1_2` and `MIGRATION_2_3`
- [x] Existing `DevotionDaoTest` updated to install an in-memory `AppDatabase` via `AppDatabase.setForTesting` (matches the harness change from `VersionDaoTest`)
- [ ] On-device smoke (left to reviewer / next CI run with a real dataset): first launch should log `Copied N devotion row(s) from legacy Devotion table to Room`; second launch should be a no-op; cached devotions should continue to display.

## Notes for reviewer

- Schema JSON `Alkitab/schemas/.../3.json` is regenerated and checked in. The `MIGRATION_2_3` SQL mirrors what Room emits for the entity — no per-column `COLLATE NOCASE` workaround needed here (there's no equivalent of `index_Marker_05` on `Devotion`).
- `docs/tech-debt-remediation/REM-27-room-devotion.md` is the new task file; the main index and the REM-10 "remaining tables" note are updated. `CLAUDE.md` reflects v3 and the new table list.
- Remaining legacy tables for future PRs (in suggested order): `PerVersion`, `ReadingPlan` + `ReadingPlanProgress`, `SyncShadow` + `SyncLog`, `ProgressMark` + `ProgressMarkHistory`.