### PR TITLE
REM-29: migrate ProgressMark tables from SQLite to Room

### DIFF
--- a/Alkitab/schemas/yuku.alkitab.base.storage.room.AppDatabase/5.json
+++ b/Alkitab/schemas/yuku.alkitab.base.storage.room.AppDatabase/5.json
@@ -1,0 +1,564 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "5c61c570555cda488601f521094d6701",
+    "entities": [
+      {
+        "tableName": "version",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `locale` TEXT, `shortName` TEXT, `longName` TEXT, `description` TEXT, `filename` TEXT, `preset_name` TEXT, `modifyTime` INTEGER NOT NULL, `active` INTEGER NOT NULL, `ordering` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "locale",
+            "columnName": "locale",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shortName",
+            "columnName": "shortName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "longName",
+            "columnName": "longName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filename",
+            "columnName": "filename",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "preset_name",
+            "columnName": "preset_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "modifyTime",
+            "columnName": "modifyTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "active",
+            "columnName": "active",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ordering",
+            "columnName": "ordering",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_version_ordering",
+            "unique": false,
+            "columnNames": [
+              "ordering"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_version_ordering` ON `${TABLE_NAME}` (`ordering`)"
+          },
+          {
+            "name": "index_version_active_longName",
+            "unique": false,
+            "columnNames": [
+              "active",
+              "longName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_version_active_longName` ON `${TABLE_NAME}` (`active`, `longName`)"
+          },
+          {
+            "name": "index_version_preset_name",
+            "unique": false,
+            "columnNames": [
+              "preset_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_version_preset_name` ON `${TABLE_NAME}` (`preset_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "marker",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `gid` TEXT, `ari` INTEGER NOT NULL, `kind` INTEGER NOT NULL, `caption` TEXT, `verseCount` INTEGER NOT NULL, `createTime` INTEGER NOT NULL, `modifyTime` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gid",
+            "columnName": "gid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ari",
+            "columnName": "ari",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kind",
+            "columnName": "kind",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "caption",
+            "columnName": "caption",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "verseCount",
+            "columnName": "verseCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createTime",
+            "columnName": "createTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifyTime",
+            "columnName": "modifyTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_marker_ari",
+            "unique": false,
+            "columnNames": [
+              "ari"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_ari` ON `${TABLE_NAME}` (`ari`)"
+          },
+          {
+            "name": "index_marker_kind_ari",
+            "unique": false,
+            "columnNames": [
+              "kind",
+              "ari"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_kind_ari` ON `${TABLE_NAME}` (`kind`, `ari`)"
+          },
+          {
+            "name": "index_marker_kind_modifyTime",
+            "unique": false,
+            "columnNames": [
+              "kind",
+              "modifyTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_kind_modifyTime` ON `${TABLE_NAME}` (`kind`, `modifyTime`)"
+          },
+          {
+            "name": "index_marker_kind_createTime",
+            "unique": false,
+            "columnNames": [
+              "kind",
+              "createTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_kind_createTime` ON `${TABLE_NAME}` (`kind`, `createTime`)"
+          },
+          {
+            "name": "index_marker_gid",
+            "unique": false,
+            "columnNames": [
+              "gid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_gid` ON `${TABLE_NAME}` (`gid`)"
+          },
+          {
+            "name": "index_marker_kind_caption",
+            "unique": false,
+            "columnNames": [
+              "kind",
+              "caption"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_kind_caption` ON `${TABLE_NAME}` (`kind`, `caption`)"
+          }
+        ]
+      },
+      {
+        "tableName": "label",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `gid` TEXT, `title` TEXT, `ordering` INTEGER NOT NULL, `backgroundColor` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gid",
+            "columnName": "gid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ordering",
+            "columnName": "ordering",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundColor",
+            "columnName": "backgroundColor",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_label_ordering",
+            "unique": false,
+            "columnNames": [
+              "ordering"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_label_ordering` ON `${TABLE_NAME}` (`ordering`)"
+          },
+          {
+            "name": "index_label_gid",
+            "unique": false,
+            "columnNames": [
+              "gid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_label_gid` ON `${TABLE_NAME}` (`gid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "marker_label",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `gid` TEXT, `marker_gid` TEXT, `label_gid` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "gid",
+            "columnName": "gid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "marker_gid",
+            "columnName": "marker_gid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label_gid",
+            "columnName": "label_gid",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_marker_label_marker_gid",
+            "unique": false,
+            "columnNames": [
+              "marker_gid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_label_marker_gid` ON `${TABLE_NAME}` (`marker_gid`)"
+          },
+          {
+            "name": "index_marker_label_label_gid",
+            "unique": false,
+            "columnNames": [
+              "label_gid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_marker_label_label_gid` ON `${TABLE_NAME}` (`label_gid`)"
+          },
+          {
+            "name": "index_marker_label_gid",
+            "unique": true,
+            "columnNames": [
+              "gid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_marker_label_gid` ON `${TABLE_NAME}` (`gid`)"
+          }
+        ]
+      },
+      {
+        "tableName": "devotion",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `date` TEXT, `body` TEXT, `readyToUse` INTEGER NOT NULL, `touchTime` INTEGER NOT NULL, `dataFormatVersion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readyToUse",
+            "columnName": "readyToUse",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "touchTime",
+            "columnName": "touchTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dataFormatVersion",
+            "columnName": "dataFormatVersion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_devotion_name_date_dataFormatVersion",
+            "unique": false,
+            "columnNames": [
+              "name",
+              "date",
+              "dataFormatVersion"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_devotion_name_date_dataFormatVersion` ON `${TABLE_NAME}` (`name`, `date`, `dataFormatVersion`)"
+          },
+          {
+            "name": "index_devotion_touchTime",
+            "unique": false,
+            "columnNames": [
+              "touchTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_devotion_touchTime` ON `${TABLE_NAME}` (`touchTime`)"
+          }
+        ]
+      },
+      {
+        "tableName": "per_version",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `versionId` TEXT NOT NULL, `settings` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "versionId",
+            "columnName": "versionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "settings",
+            "columnName": "settings",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_per_version_versionId",
+            "unique": true,
+            "columnNames": [
+              "versionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_per_version_versionId` ON `${TABLE_NAME}` (`versionId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "progress_mark",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `preset_id` INTEGER NOT NULL, `caption` TEXT, `ari` INTEGER NOT NULL, `modifyTime` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "preset_id",
+            "columnName": "preset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "caption",
+            "columnName": "caption",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ari",
+            "columnName": "ari",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modifyTime",
+            "columnName": "modifyTime",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_progress_mark_preset_id",
+            "unique": false,
+            "columnNames": [
+              "preset_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_progress_mark_preset_id` ON `${TABLE_NAME}` (`preset_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "progress_mark_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `progress_mark_preset_id` INTEGER NOT NULL, `progress_mark_caption` TEXT, `ari` INTEGER NOT NULL, `createTime` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "_id",
+            "columnName": "_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress_mark_preset_id",
+            "columnName": "progress_mark_preset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress_mark_caption",
+            "columnName": "progress_mark_caption",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ari",
+            "columnName": "ari",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createTime",
+            "columnName": "createTime",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_progress_mark_history_preset_id_createTime",
+            "unique": false,
+            "columnNames": [
+              "progress_mark_preset_id",
+              "createTime"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_progress_mark_history_preset_id_createTime` ON `${TABLE_NAME}` (`progress_mark_preset_id`, `createTime`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5c61c570555cda488601f521094d6701')"
+    ]
+  }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/S.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/S.kt
@@ -240,6 +240,9 @@ object S {
         // One-time copy of the legacy `PerVersion` table into Room (REM-28).
         // Same idempotency / retry properties.
         yuku.alkitab.base.storage.room.PerVersionDataMigration.copyFromLegacyDbIfNeeded(roomDb, helper)
+        // One-time copy of the legacy `ProgressMark` and `ProgressMarkHistory`
+        // tables into Room (REM-29). Same idempotency / retry properties.
+        yuku.alkitab.base.storage.room.ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(roomDb, helper)
         InternalDb(helper)
     }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/Prefkey.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/Prefkey.kt
@@ -174,4 +174,14 @@ enum class Prefkey {
      * count-based gate would resurrect cleared rows on the next launch.
      */
     per_version_data_migration_v1_done,
+
+    /**
+     * One-shot completion flag for the REM-29 `ProgressMark` /
+     * `ProgressMarkHistory` copy from the legacy `AlkitabDb` tables into
+     * Room. Same rationale as [marker_data_migration_v1_done] — see GitHub
+     * issue #195. The progress-mark table is user-mutable (pins can be
+     * overwritten with the empty placeholder), so a count-based gate would
+     * resurrect cleared rows on the next launch.
+     */
+    progress_mark_data_migration_v1_done,
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/ProgressMarkDao.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/ProgressMarkDao.kt
@@ -1,128 +1,90 @@
 package yuku.alkitab.base.storage
 
-import android.content.ContentValues
-import android.database.Cursor
-import android.database.DatabaseUtils
-import android.provider.BaseColumns
+import yuku.alkitab.base.storage.room.AppDatabase
+import yuku.alkitab.base.storage.room.ProgressMarkEntity
+import yuku.alkitab.base.storage.room.ProgressMarkHistoryEntity
+import yuku.alkitab.base.storage.room.ProgressMarkRoomDao
 import yuku.alkitab.base.util.Sqlitil
 import yuku.alkitab.model.ProgressMark
 import yuku.alkitab.model.ProgressMarkHistory
 
 /**
- * Type-safe accessor for the `ProgressMark` and `ProgressMarkHistory` tables.
- * Both live in the same DAO because they are always written together:
- * [insertOrUpdate] writes to history first, then upserts the mark.
+ * Facade over the Room-backed [ProgressMarkRoomDao] that preserves the
+ * legacy `ProgressMark` / `ProgressMarkHistory` public surface. Existing
+ * call sites in [InternalDb] don't need to change.
  *
- * Schema ownership (create-table / onUpgrade) still lives in [InternalDbHelper].
+ * Rows in `progress_mark` are addressed by `preset_id`. The Room schema
+ * keeps the legacy non-unique index — the facade's
+ * `insertHistoryAndUpsertMark` does its own existence check inside a
+ * `@Transaction`, mirroring the legacy `beginTransactionNonExclusive`
+ * pattern.
+ *
+ * Cross-file note: this DAO is constructed with [InternalDbHelper] only so
+ * its constructor signature stays unchanged. The helper is no longer used
+ * internally; [AppDatabase] supplies the underlying SQLite file. The
+ * one-time data copy runs in
+ * [yuku.alkitab.base.storage.room.ProgressMarkDataMigration].
  *
  * Note: the sync-notify call (`Sync.notifySyncNeeded(SYNC_SET_PINS)`) that
  * follows an upsert is kept in [InternalDb.insertOrUpdateProgressMark] so
  * this DAO stays pure persistence.
  */
-class ProgressMarkDao(private val helper: InternalDbHelper) {
+@Suppress("UNUSED_PARAMETER")
+class ProgressMarkDao(helper: InternalDbHelper) {
+
+    private val roomDao: ProgressMarkRoomDao
+        get() = AppDatabase.get(yuku.afw.App.context).progressMarkDao()
 
     /** Progress marks with `ari == 0` are the five default "empty" slots — excluded. */
-    fun listAll(): List<ProgressMark> {
-        val res = ArrayList<ProgressMark>()
-        helper.readableDatabase.query(
-            Db.TABLE_ProgressMark, null, Db.ProgressMark.ari + " != 0",
-            null, null, null, null,
-        ).use { cursor ->
-            while (cursor.moveToNext()) res += progressMarkFromCursor(cursor)
-        }
-        return res
-    }
+    fun listAll(): List<ProgressMark> =
+        roomDao.listAllWithNonZeroAri().map { it.toModel() }
 
     /** Matches [listAll]'s `ari != 0` filter. */
-    fun countAll(): Int = DatabaseUtils.queryNumEntries(
-        helper.readableDatabase, Db.TABLE_ProgressMark, Db.ProgressMark.ari + " != 0",
-    ).toInt()
+    fun countAll(): Int = roomDao.countAllWithNonZeroAri()
 
-    fun getByPresetId(presetId: Int): ProgressMark? {
-        helper.readableDatabase.query(
-            Db.TABLE_ProgressMark, null,
-            Db.ProgressMark.preset_id + "=?", arrayOf(presetId.toString()),
-            null, null, null,
-        ).use { cursor ->
-            return if (cursor.moveToNext()) progressMarkFromCursor(cursor) else null
-        }
-    }
+    fun getByPresetId(presetId: Int): ProgressMark? =
+        roomDao.findByPresetId(presetId)?.toModel()
 
     /** Appends a history row, then inserts or updates the mark (by preset_id). */
     fun insertOrUpdate(progressMark: ProgressMark) {
-        val db = helper.writableDatabase
-        val historyCv = ContentValues().apply {
-            put(Db.ProgressMarkHistory.progress_mark_preset_id, progressMark.preset_id)
-            put(Db.ProgressMarkHistory.progress_mark_caption, progressMark.caption)
-            put(Db.ProgressMarkHistory.ari, progressMark.ari)
-            put(Db.ProgressMarkHistory.createTime, Sqlitil.toInt(progressMark.modifyTime))
-        }
-
-        db.beginTransactionNonExclusive()
-        try {
-            db.insert(Db.TABLE_ProgressMarkHistory, null, historyCv)
-
-            val existing = DatabaseUtils.queryNumEntries(
-                db, Db.TABLE_ProgressMark,
-                Db.ProgressMark.preset_id + "=?", arrayOf(progressMark.preset_id.toString()),
-            )
-            if (existing > 0) {
-                db.update(
-                    Db.TABLE_ProgressMark, progressMarkToContentValues(progressMark),
-                    Db.ProgressMark.preset_id + "=?", arrayOf(progressMark.preset_id.toString()),
-                )
-            } else {
-                db.insert(Db.TABLE_ProgressMark, null, progressMarkToContentValues(progressMark))
-            }
-            db.setTransactionSuccessful()
-        } finally {
-            db.endTransaction()
-        }
+        val createTime = Sqlitil.toInt(progressMark.modifyTime)
+        roomDao.insertHistoryAndUpsertMark(
+            history = ProgressMarkHistoryEntity(
+                _id = 0L,
+                progress_mark_preset_id = progressMark.preset_id,
+                progress_mark_caption = progressMark.caption,
+                ari = progressMark.ari,
+                createTime = createTime,
+            ),
+            mark = ProgressMarkEntity(
+                _id = 0L,
+                preset_id = progressMark.preset_id,
+                caption = progressMark.caption,
+                ari = progressMark.ari,
+                modifyTime = Sqlitil.toInt(progressMark.modifyTime),
+            ),
+        )
     }
 
-    fun listHistoryByPresetId(presetId: Int): List<ProgressMarkHistory> {
-        helper.readableDatabase.rawQuery(
-            "select * from ${Db.TABLE_ProgressMarkHistory}" +
-                " where ${Db.ProgressMarkHistory.progress_mark_preset_id}=?" +
-                " order by ${Db.ProgressMarkHistory.createTime} asc",
-            arrayOf(presetId.toString()),
-        ).use { c ->
-            val res = ArrayList<ProgressMarkHistory>()
-            while (c.moveToNext()) res += progressMarkHistoryFromCursor(c)
-            return res
-        }
+    fun listHistoryByPresetId(presetId: Int): List<ProgressMarkHistory> =
+        roomDao.listHistoryByPresetId(presetId).map { it.toModel() }
+
+    private fun ProgressMarkEntity.toModel(): ProgressMark = ProgressMark().also { m ->
+        m._id = _id
+        m.preset_id = preset_id
+        m.caption = caption
+        m.ari = ari
+        // Legacy cursor read used `getInt` which returns 0 for NULL — round-trip
+        // that as epoch (Date(0)) to preserve behaviour for the placeholder rows
+        // that the table is seeded with.
+        m.modifyTime = Sqlitil.toDate(modifyTime ?: 0)
     }
 
-    companion object {
-        fun progressMarkFromCursor(c: Cursor): ProgressMark = ProgressMark().apply {
-            _id = c.getLong(c.getColumnIndexOrThrow(BaseColumns._ID))
-            preset_id = c.getInt(c.getColumnIndexOrThrow(Db.ProgressMark.preset_id))
-            caption = c.getString(c.getColumnIndexOrThrow(Db.ProgressMark.caption))
-            ari = c.getInt(c.getColumnIndexOrThrow(Db.ProgressMark.ari))
-            modifyTime = Sqlitil.toDate(c.getInt(c.getColumnIndexOrThrow(Db.ProgressMark.modifyTime)))
-        }
-
-        fun progressMarkToContentValues(progressMark: ProgressMark): ContentValues =
-            ContentValues().apply {
-                put(Db.ProgressMark.preset_id, progressMark.preset_id)
-                put(Db.ProgressMark.caption, progressMark.caption)
-                put(Db.ProgressMark.ari, progressMark.ari)
-                put(Db.ProgressMark.modifyTime, Sqlitil.toInt(progressMark.modifyTime))
-            }
-
-        fun progressMarkHistoryFromCursor(c: Cursor): ProgressMarkHistory =
-            ProgressMarkHistory().apply {
-                _id = c.getLong(c.getColumnIndexOrThrow(BaseColumns._ID))
-                progress_mark_preset_id = c.getInt(
-                    c.getColumnIndexOrThrow(Db.ProgressMarkHistory.progress_mark_preset_id),
-                )
-                progress_mark_caption = c.getString(
-                    c.getColumnIndexOrThrow(Db.ProgressMarkHistory.progress_mark_caption),
-                )
-                ari = c.getInt(c.getColumnIndexOrThrow(Db.ProgressMarkHistory.ari))
-                createTime = Sqlitil.toDate(
-                    c.getInt(c.getColumnIndexOrThrow(Db.ProgressMarkHistory.createTime)),
-                )
-            }
+    private fun ProgressMarkHistoryEntity.toModel(): ProgressMarkHistory = ProgressMarkHistory().also { h ->
+        h._id = _id
+        h.progress_mark_preset_id = progress_mark_preset_id
+        h.progress_mark_caption = progress_mark_caption
+        h.ari = ari
+        h.createTime = Sqlitil.toDate(createTime ?: 0)
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/AppDatabase.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/AppDatabase.kt
@@ -29,6 +29,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
  * - v4 — added the `per_version` table and its unique index on `versionId`.
  *   See [MIGRATION_3_4]. Same rollback-safety convention: the legacy
  *   `PerVersion` table in `AlkitabDb` is left intact.
+ * - v5 — added the `progress_mark` and `progress_mark_history` tables and
+ *   their indexes. See [MIGRATION_4_5]. Same rollback-safety convention:
+ *   the legacy `ProgressMark` / `ProgressMarkHistory` tables in `AlkitabDb`
+ *   are left intact.
  *
  * REM-10 follow-up note: [MIGRATION_1_2] creates the
  * `index_marker_kind_caption` index with `COLLATE NOCASE` (matching the
@@ -46,8 +50,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         MarkerLabelEntity::class,
         DevotionEntity::class,
         PerVersionEntity::class,
+        ProgressMarkEntity::class,
+        ProgressMarkHistoryEntity::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -57,6 +63,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun markerLabelDao(): MarkerLabelRoomDao
     abstract fun devotionDao(): DevotionRoomDao
     abstract fun perVersionDao(): PerVersionRoomDao
+    abstract fun progressMarkDao(): ProgressMarkRoomDao
 
     companion object {
         const val DB_NAME = "AlkitabRoomDb"
@@ -196,6 +203,48 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * v4 → v5: create the `progress_mark` and `progress_mark_history`
+         * tables and their indexes. SQL mirrors what Room emits for the v5
+         * entities (compare against `Alkitab/schemas/.../5.json`) — keep
+         * them in sync if [ProgressMarkEntity] / [ProgressMarkHistoryEntity]
+         * change.
+         *
+         * A v4 device upgrading runs this migration once; a fresh install
+         * skips straight to v5 via Room's `onCreate` (Room uses the entity
+         * definitions, not this migration, for fresh schemas — that's why
+         * the SQL here must match what Room would emit).
+         */
+        @JvmField
+        val MIGRATION_4_5: Migration = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `progress_mark` (" +
+                        "`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`preset_id` INTEGER NOT NULL, " +
+                        "`caption` TEXT, " +
+                        "`ari` INTEGER NOT NULL, " +
+                        "`modifyTime` INTEGER)",
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_progress_mark_preset_id` " +
+                        "ON `progress_mark` (`preset_id`)",
+                )
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `progress_mark_history` (" +
+                        "`_id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                        "`progress_mark_preset_id` INTEGER NOT NULL, " +
+                        "`progress_mark_caption` TEXT, " +
+                        "`ari` INTEGER NOT NULL, " +
+                        "`createTime` INTEGER)",
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_progress_mark_history_preset_id_createTime` " +
+                        "ON `progress_mark_history` (`progress_mark_preset_id`, `createTime`)",
+                )
+            }
+        }
+
         @Volatile
         private var instance: AppDatabase? = null
 
@@ -213,7 +262,7 @@ abstract class AppDatabase : RoomDatabase() {
                 // methods) are synchronous. Coroutine-based callers can be
                 // introduced later — see REM-15 in tech-debt-remediation.md.
                 .allowMainThreadQueries()
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
                 .build()
 
         /**

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/ProgressMarkDataMigration.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/ProgressMarkDataMigration.kt
@@ -1,0 +1,141 @@
+package yuku.alkitab.base.storage.room
+
+import yuku.afw.storage.Preferences
+import yuku.alkitab.base.storage.Db
+import yuku.alkitab.base.storage.InternalDbHelper
+import yuku.alkitab.base.storage.Prefkey
+import yuku.alkitab.base.util.AppLog
+
+/**
+ * One-time data copy from the legacy `ProgressMark` and `ProgressMarkHistory`
+ * tables in `AlkitabDb` (managed by `InternalDbHelper`) into Room's
+ * `progress_mark` / `progress_mark_history` tables in `AlkitabRoomDb`
+ * (managed by [AppDatabase]).
+ *
+ * Idempotency is anchored on the persistent
+ * [Prefkey.progress_mark_data_migration_v1_done] flag rather than on a
+ * `dao.count() > 0` check. The count check would resurrect deleted user
+ * data: any row the user clears (e.g. by overwriting a pin with the empty
+ * placeholder) would be re-copied from the legacy table on the next launch.
+ * See GitHub issue #195.
+ *
+ * Memory profile: rows are streamed from each legacy cursor straight into
+ * Room inside a single `runInTransaction` block. The progress-mark table is
+ * tiny (~5 rows in normal use) but the history table grows monotonically
+ * with every pin update, so streaming bounds the migration footprint by one
+ * row at a time.
+ *
+ * Crash safety:
+ *  - If any insert fails mid-flight, Room rolls back the whole transaction
+ *    and the flag is never set; the next launch retries.
+ *  - If the process is killed after the transaction commits but before the
+ *    flag is set, the next launch sees Room rows already present and takes
+ *    the upgrade-path branch (sets the flag, does not re-copy).
+ *
+ * The legacy tables are intentionally left intact so a future release can
+ * audit/rollback.
+ */
+object ProgressMarkDataMigration {
+    private const val TAG = "ProgressMarkDataMigration"
+
+    fun copyFromLegacyDbIfNeeded(roomDb: AppDatabase, legacyHelper: InternalDbHelper) {
+        if (Preferences.getBoolean(Prefkey.progress_mark_data_migration_v1_done, false)) {
+            return
+        }
+
+        val dao = roomDb.progressMarkDao()
+
+        // Upgrade path: if a future build ever ships the count-based gate
+        // accidentally (mirroring the pre-#198 mistakes for marker/version),
+        // a non-empty Room table means the copy already happened. Set the
+        // flag and bail.
+        if (dao.countAll() > 0 || dao.countAllHistory() > 0) {
+            Preferences.setBoolean(Prefkey.progress_mark_data_migration_v1_done, true)
+            return
+        }
+
+        val (marks, histories) = streamCopyInsideTransaction(roomDb, dao, legacyHelper)
+        // Set the flag only after a successful commit. A crash between here
+        // and the next launch is handled by the upgrade-path branch above.
+        Preferences.setBoolean(Prefkey.progress_mark_data_migration_v1_done, true)
+        if (marks > 0 || histories > 0) {
+            AppLog.d(
+                TAG,
+                "Copied $marks progress_mark row(s) and $histories progress_mark_history " +
+                    "row(s) from legacy tables to Room",
+            )
+        }
+    }
+
+    /**
+     * Reads rows from each legacy cursor and inserts them into Room one at a
+     * time inside a single Room transaction. Returns the number of rows
+     * copied to each table.
+     *
+     * Rows missing a non-null Room column (`preset_id`, `ari`) are dropped.
+     * Coalescing a NULL `preset_id` to 0 would collide with the legitimate
+     * `preset_id = 0` placeholder row that the legacy schema always carries
+     * — dropping is safer than corrupting the placeholder set. The same
+     * skip-on-NULL rule covers the history table's `progress_mark_preset_id`
+     * and `ari`.
+     */
+    private fun streamCopyInsideTransaction(
+        roomDb: AppDatabase,
+        dao: ProgressMarkRoomDao,
+        legacyHelper: InternalDbHelper,
+    ): Pair<Int, Int> {
+        var marks = 0
+        var histories = 0
+        val legacyDb = legacyHelper.readableDatabase
+        roomDb.runInTransaction {
+            legacyDb.query(
+                Db.TABLE_ProgressMark, null, null, null, null, null, "_id ASC",
+            ).use { c ->
+                val colPresetId = c.getColumnIndexOrThrow(Db.ProgressMark.preset_id)
+                val colCaption = c.getColumnIndexOrThrow(Db.ProgressMark.caption)
+                val colAri = c.getColumnIndexOrThrow(Db.ProgressMark.ari)
+                val colModifyTime = c.getColumnIndexOrThrow(Db.ProgressMark.modifyTime)
+                while (c.moveToNext()) {
+                    val presetId = if (c.isNull(colPresetId)) continue else c.getInt(colPresetId)
+                    val ari = if (c.isNull(colAri)) continue else c.getInt(colAri)
+                    dao.insert(
+                        ProgressMarkEntity(
+                            // Don't carry over `_id` — Room assigns a fresh one. Nothing
+                            // outside the table referenced the legacy `_id`; callers
+                            // address rows by `preset_id`.
+                            _id = 0L,
+                            preset_id = presetId,
+                            caption = c.getString(colCaption),
+                            ari = ari,
+                            modifyTime = if (c.isNull(colModifyTime)) null else c.getInt(colModifyTime),
+                        ),
+                    )
+                    marks++
+                }
+            }
+            legacyDb.query(
+                Db.TABLE_ProgressMarkHistory, null, null, null, null, null, "_id ASC",
+            ).use { c ->
+                val colPresetId = c.getColumnIndexOrThrow(Db.ProgressMarkHistory.progress_mark_preset_id)
+                val colCaption = c.getColumnIndexOrThrow(Db.ProgressMarkHistory.progress_mark_caption)
+                val colAri = c.getColumnIndexOrThrow(Db.ProgressMarkHistory.ari)
+                val colCreateTime = c.getColumnIndexOrThrow(Db.ProgressMarkHistory.createTime)
+                while (c.moveToNext()) {
+                    val presetId = if (c.isNull(colPresetId)) continue else c.getInt(colPresetId)
+                    val ari = if (c.isNull(colAri)) continue else c.getInt(colAri)
+                    dao.insertHistory(
+                        ProgressMarkHistoryEntity(
+                            _id = 0L,
+                            progress_mark_preset_id = presetId,
+                            progress_mark_caption = c.getString(colCaption),
+                            ari = ari,
+                            createTime = if (c.isNull(colCreateTime)) null else c.getInt(colCreateTime),
+                        ),
+                    )
+                    histories++
+                }
+            }
+        }
+        return marks to histories
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/ProgressMarkEntity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/ProgressMarkEntity.kt
@@ -1,0 +1,47 @@
+package yuku.alkitab.base.storage.room
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Room entity for the reading-progress pin row. Lives in [AppDatabase] (file
+ * `AlkitabRoomDb`), distinct from the legacy `ProgressMark` table in
+ * `AlkitabDb` which is still created by `InternalDbHelper` but no longer
+ * written to. The one-time data copy on first launch is wired up in
+ * [ProgressMarkDataMigration].
+ *
+ * Identity: rows are addressed by `preset_id` (1..5 in caller code, plus the
+ * five `ari = 0` placeholder rows inserted at table creation with
+ * `preset_id` 0..4). The legacy index on `preset_id` was non-unique even
+ * though callers treat the column as a primary key — the facade's
+ * insert-or-update path does its own existence check. The Room schema keeps
+ * that same non-unique index to avoid introducing a new constraint that
+ * legacy data might violate.
+ *
+ * Column types — `preset_id` and `ari` are non-nullable here even though the
+ * legacy schema permitted NULL. [ProgressMarkDataMigration] drops any legacy
+ * rows where either column is NULL (those rows are unreachable by the
+ * facade's keyed lookups, and coalescing a NULL `preset_id` to 0 would
+ * collide with the legitimate `preset_id = 0` placeholder row that the table
+ * always carries). `modifyTime` is nullable to round-trip the placeholder
+ * rows which were inserted without a `modifyTime` value.
+ *
+ * Index mirrors the legacy `index_601` on `preset_id`.
+ */
+@Entity(
+    tableName = "progress_mark",
+    indices = [
+        Index(value = ["preset_id"], name = "index_progress_mark_preset_id"),
+    ],
+)
+data class ProgressMarkEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "_id")
+    val _id: Long,
+    val preset_id: Int,
+    val caption: String?,
+    val ari: Int,
+    val modifyTime: Int?,
+)

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/ProgressMarkHistoryEntity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/ProgressMarkHistoryEntity.kt
@@ -1,0 +1,49 @@
+package yuku.alkitab.base.storage.room
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Room entity for the reading-progress pin history row. Lives in
+ * [AppDatabase] (file `AlkitabRoomDb`) alongside [ProgressMarkEntity]; the
+ * legacy `ProgressMarkHistory` table in `AlkitabDb` is still created by
+ * `InternalDbHelper` but no longer written to. The one-time data copy on
+ * first launch is wired up in [ProgressMarkDataMigration].
+ *
+ * Identity: history rows are append-only and indexed by
+ * `(progress_mark_preset_id, createTime)` for the `listHistoryByPresetId`
+ * lookup. No uniqueness constraint — multiple history entries per preset
+ * are the point of the table.
+ *
+ * Column types — the legacy `progress_mark_caption` column was declared
+ * `INTEGER` in `InternalDbHelper.createTableProgressMarkHistory` but the DAO
+ * always wrote a `String` into it (SQLite type affinity makes this work).
+ * Room can't keep the affinity mismatch, so this entity declares the column
+ * as `String?` to match real usage; the migration SQL inside
+ * [AppDatabase.MIGRATION_4_5] also writes `TEXT`. `progress_mark_preset_id`
+ * and `ari` are non-nullable in Room even though the legacy schema permitted
+ * NULL — [ProgressMarkDataMigration] drops any legacy rows where either
+ * column is NULL (they are unreachable by [ProgressMarkRoomDao.listHistoryByPresetId]).
+ *
+ * Index mirrors the legacy `index_701` on `(progress_mark_preset_id, createTime)`.
+ */
+@Entity(
+    tableName = "progress_mark_history",
+    indices = [
+        Index(
+            value = ["progress_mark_preset_id", "createTime"],
+            name = "index_progress_mark_history_preset_id_createTime",
+        ),
+    ],
+)
+data class ProgressMarkHistoryEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "_id")
+    val _id: Long,
+    val progress_mark_preset_id: Int,
+    val progress_mark_caption: String?,
+    val ari: Int,
+    val createTime: Int?,
+)

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/ProgressMarkRoomDao.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/ProgressMarkRoomDao.kt
@@ -1,0 +1,85 @@
+package yuku.alkitab.base.storage.room
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.Transaction
+import androidx.room.Update
+
+/**
+ * Room DAO for the `progress_mark` and `progress_mark_history` tables.
+ * Consumed by the facade in [yuku.alkitab.base.storage.ProgressMarkDao].
+ *
+ * Two tables, one DAO: the facade always writes to history first then upserts
+ * the mark inside a transaction (the legacy
+ * `SQLiteDatabase.beginTransactionNonExclusive` pattern). [insertHistoryAndUpsertMark]
+ * preserves that atomicity using Room's `@Transaction` so partial failures
+ * don't leave the two tables out of sync.
+ *
+ * Naming convention: this DAO speaks in [ProgressMarkEntity] /
+ * [ProgressMarkHistoryEntity]; the mapping to/from the public
+ * [yuku.alkitab.model.ProgressMark] / [yuku.alkitab.model.ProgressMarkHistory]
+ * models lives in the facade so call sites in `InternalDb` don't need to
+ * change.
+ */
+@Dao
+abstract class ProgressMarkRoomDao {
+
+    /** Matches the legacy facade's `ari != 0` filter — excludes placeholder rows. */
+    @Query("SELECT * FROM progress_mark WHERE ari != 0")
+    abstract fun listAllWithNonZeroAri(): List<ProgressMarkEntity>
+
+    /** Matches the legacy facade's `ari != 0` filter. */
+    @Query("SELECT COUNT(*) FROM progress_mark WHERE ari != 0")
+    abstract fun countAllWithNonZeroAri(): Int
+
+    @Query("SELECT COUNT(*) FROM progress_mark")
+    abstract fun countAll(): Int
+
+    @Query("SELECT * FROM progress_mark WHERE preset_id = :presetId LIMIT 1")
+    abstract fun findByPresetId(presetId: Int): ProgressMarkEntity?
+
+    @Query("SELECT * FROM progress_mark ORDER BY _id")
+    abstract fun listAllForTest(): List<ProgressMarkEntity>
+
+    @Insert
+    abstract fun insert(entity: ProgressMarkEntity): Long
+
+    @Update
+    abstract fun update(entity: ProgressMarkEntity)
+
+    @Insert
+    abstract fun insertHistory(entity: ProgressMarkHistoryEntity): Long
+
+    @Query(
+        "SELECT * FROM progress_mark_history " +
+            "WHERE progress_mark_preset_id = :presetId " +
+            "ORDER BY createTime ASC",
+    )
+    abstract fun listHistoryByPresetId(presetId: Int): List<ProgressMarkHistoryEntity>
+
+    @Query("SELECT COUNT(*) FROM progress_mark_history")
+    abstract fun countAllHistory(): Int
+
+    @Query("SELECT * FROM progress_mark_history ORDER BY _id")
+    abstract fun listAllHistoryForTest(): List<ProgressMarkHistoryEntity>
+
+    /**
+     * Mirrors the legacy facade's transactional insert-or-update: append a
+     * history row, then either update the existing mark with the same
+     * `preset_id` or insert a new one. Atomic via Room's `@Transaction`.
+     */
+    @Transaction
+    open fun insertHistoryAndUpsertMark(
+        history: ProgressMarkHistoryEntity,
+        mark: ProgressMarkEntity,
+    ) {
+        insertHistory(history)
+        val existing = findByPresetId(mark.preset_id)
+        if (existing != null) {
+            update(mark.copy(_id = existing._id))
+        } else {
+            insert(mark)
+        }
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/ProgressMarkDaoTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/ProgressMarkDaoTest.kt
@@ -1,6 +1,7 @@
 package yuku.alkitab.base.storage
 
 import android.app.Application
+import androidx.room.Room
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -11,26 +12,63 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import yuku.alkitab.base.storage.room.AppDatabase
+import yuku.alkitab.base.storage.room.ProgressMarkEntity
 import yuku.alkitab.model.ProgressMark
 import yuku.alkitab.util.Ari
 import java.util.Date
 
+/**
+ * Robolectric tests for [ProgressMarkDao]. Originally exercised the
+ * SQLite-backed implementation against [InternalDbHelper]; after the
+ * ProgressMark → Room migration the facade routes through Room, so this
+ * test now installs an in-memory [AppDatabase] in [setUp] and pre-seeds the
+ * five placeholder rows that legacy `InternalDbHelper.onCreate` used to
+ * insert via `insertDefaultProgressMarks`.
+ *
+ * The behavioural contract is unchanged — these tests are the parity gate
+ * for the Room migration.
+ */
 @RunWith(RobolectricTestRunner::class)
 @Config(application = Application::class, sdk = [34])
 class ProgressMarkDaoTest {
     private lateinit var helper: InternalDbHelper
+    private lateinit var roomDb: AppDatabase
     private lateinit var dao: ProgressMarkDao
 
     @Before
     fun setUp() {
         val app = RuntimeEnvironment.getApplication()
         yuku.afw.App.context = app
+        // InternalDbHelper is still needed by the legacy ProgressMarkDao
+        // constructor signature, but the facade ignores it now.
         helper = InternalDbHelper(app)
+        roomDb = Room.inMemoryDatabaseBuilder(app, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        AppDatabase.setForTesting(roomDb)
         dao = ProgressMarkDao(helper)
+
+        // Pre-seed the five placeholder rows the way ProgressMarkDataMigration
+        // would have on first launch (sourced from
+        // `InternalDbHelper.insertDefaultProgressMarks`).
+        val roomDao = roomDb.progressMarkDao()
+        for (presetId in 0..4) {
+            roomDao.insert(
+                ProgressMarkEntity(
+                    _id = 0L,
+                    preset_id = presetId,
+                    caption = null,
+                    ari = 0,
+                    modifyTime = null,
+                ),
+            )
+        }
     }
 
     @After
     fun tearDown() {
+        AppDatabase.setForTesting(null)
         helper.close()
     }
 
@@ -43,8 +81,7 @@ class ProgressMarkDaoTest {
 
     @Test
     fun `listAll returns only marks whose ari is non-zero so empty defaults are excluded`() {
-        // InternalDbHelper.onCreate seeds 5 default marks with ari=0; they must
-        // all be filtered out until ari is set.
+        // The seeded placeholder rows all have ari=0 and must be filtered out.
         assertTrue(dao.listAll().isEmpty())
 
         dao.insertOrUpdate(newMark(presetId = 0, ari = Ari.encode(0, 1, 1)))
@@ -65,8 +102,9 @@ class ProgressMarkDaoTest {
 
     @Test
     fun `getByPresetId returns the seeded empty mark for preset ids 0 through 4`() {
-        // insertDefaultProgressMarks seeds five rows with ari=0; getByPresetId
-        // has no ari filter, so the empty seeds are reachable before any upsert.
+        // The seed in @Before mirrors `insertDefaultProgressMarks`: five
+        // placeholder rows with ari=0 that are reachable via getByPresetId
+        // before any upsert.
         for (presetId in 0..4) {
             val seeded = dao.getByPresetId(presetId)!!
             assertEquals(0, seeded.ari)

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/AppDatabaseMigrationTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/AppDatabaseMigrationTest.kt
@@ -106,7 +106,12 @@ class AppDatabaseMigrationTest {
             TEST_DB,
         )
             .allowMainThreadQueries()
-            .addMigrations(AppDatabase.MIGRATION_1_2, AppDatabase.MIGRATION_2_3, AppDatabase.MIGRATION_3_4)
+            .addMigrations(
+                AppDatabase.MIGRATION_1_2,
+                AppDatabase.MIGRATION_2_3,
+                AppDatabase.MIGRATION_3_4,
+                AppDatabase.MIGRATION_4_5,
+            )
             .build()
         AppDatabase.setForTesting(room)
 
@@ -285,7 +290,12 @@ class AppDatabaseMigrationTest {
             TEST_DB,
         )
             .allowMainThreadQueries()
-            .addMigrations(AppDatabase.MIGRATION_1_2, AppDatabase.MIGRATION_2_3, AppDatabase.MIGRATION_3_4)
+            .addMigrations(
+                AppDatabase.MIGRATION_1_2,
+                AppDatabase.MIGRATION_2_3,
+                AppDatabase.MIGRATION_3_4,
+                AppDatabase.MIGRATION_4_5,
+            )
             .build()
         AppDatabase.setForTesting(room)
 
@@ -391,7 +401,12 @@ class AppDatabaseMigrationTest {
             TEST_DB,
         )
             .allowMainThreadQueries()
-            .addMigrations(AppDatabase.MIGRATION_1_2, AppDatabase.MIGRATION_2_3, AppDatabase.MIGRATION_3_4)
+            .addMigrations(
+                AppDatabase.MIGRATION_1_2,
+                AppDatabase.MIGRATION_2_3,
+                AppDatabase.MIGRATION_3_4,
+                AppDatabase.MIGRATION_4_5,
+            )
             .build()
         AppDatabase.setForTesting(room)
 
@@ -418,6 +433,83 @@ class AppDatabaseMigrationTest {
     }
 
     /**
+     * v4 → v5 adds the `progress_mark` and `progress_mark_history` tables.
+     * The migration must:
+     *
+     * - Preserve every row already in the v4 tables (`version`, `marker`,
+     *   `label`, `marker_label`, `devotion`, `per_version`).
+     * - Create the two new tables with the schema Room's entity definitions
+     *   emit (verified by [MigrationTestHelper.runMigrationsAndValidate]
+     *   when `validateDroppedTables = true`).
+     * - Leave the new tables empty (data copy is a separate concern handled
+     *   by [ProgressMarkDataMigration]).
+     */
+    @Test
+    fun migrates4To5() {
+        // Seed a v4 row in the `per_version` table so we can verify the
+        // migration doesn't drop pre-existing data. Walk v1 → v2 → v3 → v4
+        // first so the v4 tables exist.
+        helper.createDatabase(TEST_DB, 1).close()
+        helper.runMigrationsAndValidate(TEST_DB, 2, true, AppDatabase.MIGRATION_1_2).close()
+        helper.runMigrationsAndValidate(TEST_DB, 3, true, AppDatabase.MIGRATION_2_3).close()
+        helper.runMigrationsAndValidate(TEST_DB, 4, true, AppDatabase.MIGRATION_3_4).use { db ->
+            val cv = ContentValues().apply {
+                put("versionId", "preset/kjv")
+                put("settings", """{"fontSizeMultiplier":1.5}""")
+            }
+            db.insert("per_version", android.database.sqlite.SQLiteDatabase.CONFLICT_REPLACE, cv)
+        }
+
+        // Run v4 → v5.
+        helper.runMigrationsAndValidate(TEST_DB, 5, true, AppDatabase.MIGRATION_4_5).use { db ->
+            // v4 row survived
+            db.query("SELECT settings FROM per_version WHERE versionId = 'preset/kjv'").use { c ->
+                assertTrue(c.moveToFirst())
+                assertEquals("""{"fontSizeMultiplier":1.5}""", c.getString(0))
+            }
+            // The two new tables exist
+            db.query(
+                "SELECT name FROM sqlite_master WHERE type='table' " +
+                    "AND name IN ('progress_mark', 'progress_mark_history') ORDER BY name",
+            ).use { c ->
+                val tables = mutableListOf<String>()
+                while (c.moveToNext()) tables += c.getString(0)
+                assertEquals(listOf("progress_mark", "progress_mark_history"), tables)
+            }
+            // … and are empty
+            db.query("SELECT COUNT(*) FROM progress_mark").use { c ->
+                assertTrue(c.moveToFirst())
+                assertEquals(0, c.getInt(0))
+            }
+            db.query("SELECT COUNT(*) FROM progress_mark_history").use { c ->
+                assertTrue(c.moveToFirst())
+                assertEquals(0, c.getInt(0))
+            }
+            // Indexes on both tables exist
+            db.query(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='progress_mark'",
+            ).use { c ->
+                val indexes = mutableListOf<String>()
+                while (c.moveToNext()) indexes += c.getString(0)
+                assertTrue(
+                    "expected index_progress_mark_preset_id among $indexes",
+                    indexes.contains("index_progress_mark_preset_id"),
+                )
+            }
+            db.query(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='progress_mark_history'",
+            ).use { c ->
+                val indexes = mutableListOf<String>()
+                while (c.moveToNext()) indexes += c.getString(0)
+                assertTrue(
+                    "expected index_progress_mark_history_preset_id_createTime among $indexes",
+                    indexes.contains("index_progress_mark_history_preset_id_createTime"),
+                )
+            }
+        }
+    }
+
+    /**
      * Companion to the v1→v3 devotion round-trip test: verify that after
      * v1 → v4 (i.e. all three migrations applied in sequence) Room can open
      * the DB and round-trip a row through the new [PerVersionEntity] DAO.
@@ -434,7 +526,12 @@ class AppDatabaseMigrationTest {
             TEST_DB,
         )
             .allowMainThreadQueries()
-            .addMigrations(AppDatabase.MIGRATION_1_2, AppDatabase.MIGRATION_2_3, AppDatabase.MIGRATION_3_4)
+            .addMigrations(
+                AppDatabase.MIGRATION_1_2,
+                AppDatabase.MIGRATION_2_3,
+                AppDatabase.MIGRATION_3_4,
+                AppDatabase.MIGRATION_4_5,
+            )
             .build()
         AppDatabase.setForTesting(room)
 
@@ -450,6 +547,64 @@ class AppDatabaseMigrationTest {
             val loaded = room.perVersionDao().findByVersionId("preset/kjv")
             assertNotNull(loaded)
             assertEquals("""{"fontSizeMultiplier":1.5}""", loaded!!.settings)
+        } finally {
+            room.close()
+        }
+    }
+
+    /**
+     * Companion to the v1→v4 per_version round-trip test: verify that after
+     * v1 → v5 (i.e. all four migrations applied in sequence) Room can open
+     * the DB and round-trip a row through the new [ProgressMarkEntity] DAO.
+     * Catches drift between [AppDatabase.MIGRATION_4_5] and the entity
+     * declarations.
+     */
+    @Test
+    fun `after migrating from v1 to v5 Room opens cleanly and round-trips a progress_mark row through the new DAO`() {
+        helper.createDatabase(TEST_DB, 1).close()
+
+        val room = Room.databaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            AppDatabase::class.java,
+            TEST_DB,
+        )
+            .allowMainThreadQueries()
+            .addMigrations(
+                AppDatabase.MIGRATION_1_2,
+                AppDatabase.MIGRATION_2_3,
+                AppDatabase.MIGRATION_3_4,
+                AppDatabase.MIGRATION_4_5,
+            )
+            .build()
+        AppDatabase.setForTesting(room)
+
+        try {
+            val markId = room.progressMarkDao().insert(
+                ProgressMarkEntity(
+                    _id = 0L,
+                    preset_id = 2,
+                    caption = "John 3:16",
+                    ari = 12345,
+                    modifyTime = 1_700_000_000,
+                ),
+            )
+            assertTrue(markId > 0)
+            val loaded = room.progressMarkDao().findByPresetId(2)
+            assertNotNull(loaded)
+            assertEquals(12345, loaded!!.ari)
+            assertEquals("John 3:16", loaded.caption)
+
+            val historyId = room.progressMarkDao().insertHistory(
+                ProgressMarkHistoryEntity(
+                    _id = 0L,
+                    progress_mark_preset_id = 2,
+                    progress_mark_caption = "John 3:16",
+                    ari = 12345,
+                    createTime = 1_700_000_000,
+                ),
+            )
+            assertTrue(historyId > 0)
+            assertEquals(1, room.progressMarkDao().listHistoryByPresetId(2).size)
         } finally {
             room.close()
         }

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/ProgressMarkDataMigrationTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/ProgressMarkDataMigrationTest.kt
@@ -1,0 +1,299 @@
+package yuku.alkitab.base.storage.room
+
+import android.app.Application
+import android.content.ContentValues
+import android.preference.PreferenceManager
+import androidx.room.Room
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import yuku.afw.storage.Preferences
+import yuku.alkitab.base.storage.Db
+import yuku.alkitab.base.storage.InternalDbHelper
+import yuku.alkitab.base.storage.Prefkey
+
+/**
+ * Verifies the one-time copy from the legacy `ProgressMark` and
+ * `ProgressMarkHistory` tables into Room. Robolectric is required because
+ * [InternalDbHelper] extends [android.database.sqlite.SQLiteOpenHelper].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class ProgressMarkDataMigrationTest {
+    private lateinit var legacy: InternalDbHelper
+    private lateinit var room: AppDatabase
+
+    @Before
+    fun setUp() {
+        val app = RuntimeEnvironment.getApplication()
+        yuku.afw.App.context = app
+        // Idempotency is anchored on a SharedPreferences flag. Clear it (and
+        // the [Preferences] static cache that may hold a previous test's
+        // SharedPreferences instance) so every test starts with a clean slate.
+        PreferenceManager.getDefaultSharedPreferences(app).edit().clear().commit()
+        Preferences.invalidate()
+        legacy = InternalDbHelper(app)
+        // InternalDbHelper.onCreate seeds five placeholder ProgressMark rows
+        // (preset_id 0..4, ari = 0). Drop them before each test so individual
+        // tests start with a known empty legacy table and only insert exactly
+        // what they care about — otherwise the seed mixes with the test's
+        // own inserts and obscures the assertions.
+        legacy.writableDatabase.execSQL("DELETE FROM " + Db.TABLE_ProgressMark)
+        room = Room.inMemoryDatabaseBuilder(app, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        room.close()
+        legacy.close()
+    }
+
+    private fun insertLegacyMark(
+        presetId: Int?,
+        ari: Int?,
+        caption: String? = null,
+        modifyTime: Int? = null,
+    ) {
+        val cv = ContentValues().apply {
+            if (presetId != null) put(Db.ProgressMark.preset_id, presetId) else putNull(Db.ProgressMark.preset_id)
+            if (ari != null) put(Db.ProgressMark.ari, ari) else putNull(Db.ProgressMark.ari)
+            if (caption != null) put(Db.ProgressMark.caption, caption) else putNull(Db.ProgressMark.caption)
+            if (modifyTime != null) put(Db.ProgressMark.modifyTime, modifyTime) else putNull(Db.ProgressMark.modifyTime)
+        }
+        legacy.writableDatabase.insert(Db.TABLE_ProgressMark, null, cv)
+    }
+
+    private fun insertLegacyHistory(
+        presetId: Int?,
+        ari: Int?,
+        caption: String? = null,
+        createTime: Int? = null,
+    ) {
+        val cv = ContentValues().apply {
+            if (presetId != null) put(Db.ProgressMarkHistory.progress_mark_preset_id, presetId)
+            else putNull(Db.ProgressMarkHistory.progress_mark_preset_id)
+            if (ari != null) put(Db.ProgressMarkHistory.ari, ari) else putNull(Db.ProgressMarkHistory.ari)
+            if (caption != null) put(Db.ProgressMarkHistory.progress_mark_caption, caption)
+            else putNull(Db.ProgressMarkHistory.progress_mark_caption)
+            if (createTime != null) put(Db.ProgressMarkHistory.createTime, createTime)
+            else putNull(Db.ProgressMarkHistory.createTime)
+        }
+        legacy.writableDatabase.insert(Db.TABLE_ProgressMarkHistory, null, cv)
+    }
+
+    @Test
+    fun `copy is a no-op when both databases are empty`() {
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertTrue(room.progressMarkDao().listAllForTest().isEmpty())
+        assertTrue(room.progressMarkDao().listAllHistoryForTest().isEmpty())
+    }
+
+    @Test
+    fun `copy moves every legacy mark row into Room and round-trips every persisted field`() {
+        insertLegacyMark(presetId = 0, ari = 100, caption = "John 3:16", modifyTime = 1_700_000_000)
+        insertLegacyMark(presetId = 1, ari = 200, caption = "Gen 1:1", modifyTime = 1_700_000_100)
+
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val byPreset = room.progressMarkDao().listAllForTest().associateBy { it.preset_id }
+        assertEquals(2, byPreset.size)
+        assertEquals(100, byPreset.getValue(0).ari)
+        assertEquals("John 3:16", byPreset.getValue(0).caption)
+        assertEquals(1_700_000_000, byPreset.getValue(0).modifyTime)
+        assertEquals(200, byPreset.getValue(1).ari)
+        assertEquals("Gen 1:1", byPreset.getValue(1).caption)
+    }
+
+    @Test
+    fun `copy moves every legacy history row into Room`() {
+        insertLegacyHistory(presetId = 0, ari = 100, caption = "h1", createTime = 1_700_000_000)
+        insertLegacyHistory(presetId = 0, ari = 101, caption = "h2", createTime = 1_700_000_100)
+        insertLegacyHistory(presetId = 1, ari = 200, caption = "other", createTime = 1_700_000_200)
+
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        assertEquals(2, room.progressMarkDao().listHistoryByPresetId(0).size)
+        assertEquals(1, room.progressMarkDao().listHistoryByPresetId(1).size)
+    }
+
+    @Test
+    fun `copy preserves the placeholder seed with null modifyTime and null caption`() {
+        // Mirrors what `InternalDbHelper.insertDefaultProgressMarks` writes:
+        // five rows with `ari = 0`, no caption, no modifyTime. Room declares
+        // those nullable so the migration must round-trip them as NULL rather
+        // than coercing to 0/"".
+        insertLegacyMark(presetId = 0, ari = 0)
+        insertLegacyMark(presetId = 1, ari = 0)
+        insertLegacyMark(presetId = 2, ari = 0)
+        insertLegacyMark(presetId = 3, ari = 0)
+        insertLegacyMark(presetId = 4, ari = 0)
+
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val rows = room.progressMarkDao().listAllForTest().sortedBy { it.preset_id }
+        assertEquals(5, rows.size)
+        for ((idx, row) in rows.withIndex()) {
+            assertEquals(idx, row.preset_id)
+            assertEquals(0, row.ari)
+            assertNull(row.caption)
+            assertNull(row.modifyTime)
+        }
+    }
+
+    @Test
+    fun `copy drops legacy mark rows with a null preset_id`() {
+        // The legacy schema permits NULL preset_id; Room enforces non-null on
+        // that column. ProgressMarkDataMigration skips these rows because
+        // they are unreachable by the facade's keyed lookups, and coalescing
+        // a NULL preset_id to 0 would collide with the legitimate
+        // `preset_id = 0` placeholder row that the legacy schema always
+        // carries.
+        insertLegacyMark(presetId = null, ari = 100)
+        insertLegacyMark(presetId = 0, ari = 200)
+
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val rows = room.progressMarkDao().listAllForTest()
+        assertEquals(1, rows.size)
+        assertEquals(0, rows.single().preset_id)
+    }
+
+    @Test
+    fun `copy drops legacy mark rows with a null ari`() {
+        insertLegacyMark(presetId = 0, ari = null)
+        insertLegacyMark(presetId = 1, ari = 100)
+
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val rows = room.progressMarkDao().listAllForTest()
+        assertEquals(1, rows.size)
+        assertEquals(1, rows.single().preset_id)
+    }
+
+    @Test
+    fun `copy survives multiple legacy mark rows with a null preset_id without crashing the migration`() {
+        // Regression guard for the failure mode Gemini caught on REM-28: if
+        // the migration coalesced NULL preset_ids to 0 the placeholder row
+        // for preset_id = 0 would be quietly stomped over (or — with several
+        // such rows — corrupted by duplicate entries). Skip-on-NULL must
+        // keep the migration green even with several NULL-keyed rows in the
+        // legacy table.
+        insertLegacyMark(presetId = null, ari = 1)
+        insertLegacyMark(presetId = null, ari = 2)
+        insertLegacyMark(presetId = null, ari = 3)
+        insertLegacyMark(presetId = 0, ari = 99, caption = "real-zero")
+
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val rows = room.progressMarkDao().listAllForTest()
+        assertEquals(1, rows.size)
+        assertEquals(0, rows.single().preset_id)
+        assertEquals("real-zero", rows.single().caption)
+        assertTrue(Preferences.getBoolean(Prefkey.progress_mark_data_migration_v1_done, false))
+    }
+
+    @Test
+    fun `copy is idempotent — running twice does not duplicate rows`() {
+        insertLegacyMark(presetId = 0, ari = 100)
+        insertLegacyHistory(presetId = 0, ari = 100, caption = "h")
+
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        assertEquals(1, room.progressMarkDao().listAllForTest().size)
+        assertEquals(1, room.progressMarkDao().listAllHistoryForTest().size)
+    }
+
+    @Test
+    fun `copy assigns fresh _ids and does not carry over legacy _ids`() {
+        insertLegacyMark(presetId = 0, ari = 100)
+
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val row = room.progressMarkDao().findByPresetId(0)
+        assertNotNull(row)
+        assertTrue("expected positive Room _id, got ${row!!._id}", row._id > 0)
+    }
+
+    @Test
+    fun `does not resurrect rows after the user overwrites every pin (issue #195)`() {
+        // Setup: legacy table has a user pin, mirroring a real upgrade from
+        // the pre-Room schema. The legacy row is intentionally preserved as
+        // a rollback safety net even after migration.
+        insertLegacyMark(presetId = 0, ari = 100, caption = "user-pin")
+
+        // First launch on the Room build: migration copies it across.
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertEquals(1, room.progressMarkDao().listAllForTest().size)
+
+        // The user overwrites every pin with the empty placeholder (or a
+        // future "reset pins" path clears them). The legacy table in
+        // AlkitabDb is deliberately not touched by any write path.
+        room.clearAllTables()
+        assertTrue(room.progressMarkDao().listAllForTest().isEmpty())
+
+        // Next launch: migration runs again. With a count-based gate it
+        // would re-copy the legacy row. The flag-based gate must be a strict
+        // no-op.
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        assertTrue(
+            "legacy progress_mark row was resurrected",
+            room.progressMarkDao().listAllForTest().isEmpty(),
+        )
+    }
+
+    @Test
+    fun `successful copy sets the persistent done flag`() {
+        insertLegacyMark(presetId = 0, ari = 100)
+
+        assertFalse(Preferences.getBoolean(Prefkey.progress_mark_data_migration_v1_done, false))
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertTrue(Preferences.getBoolean(Prefkey.progress_mark_data_migration_v1_done, false))
+    }
+
+    @Test
+    fun `fresh install with no legacy data also sets the done flag`() {
+        // No legacy rows inserted. The migration has nothing to copy but
+        // must still mark itself done so subsequent launches don't keep
+        // querying the legacy DB.
+        assertFalse(Preferences.getBoolean(Prefkey.progress_mark_data_migration_v1_done, false))
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+        assertTrue(Preferences.getBoolean(Prefkey.progress_mark_data_migration_v1_done, false))
+    }
+
+    @Test
+    fun `upgrade path - flag unset but Room already has rows sets the flag without re-copying`() {
+        // Simulates a user who somehow ended up with rows in Room but no
+        // done flag set. The migration must NOT re-insert the legacy rows
+        // on top of the existing Room state.
+        room.progressMarkDao().insert(
+            ProgressMarkEntity(
+                _id = 0L,
+                preset_id = 0,
+                caption = "already-migrated",
+                ari = 100,
+                modifyTime = 1_700_000_000,
+            ),
+        )
+        insertLegacyMark(presetId = 0, ari = 999, caption = "legacy")
+
+        ProgressMarkDataMigration.copyFromLegacyDbIfNeeded(room, legacy)
+
+        val rows = room.progressMarkDao().listAllForTest()
+        assertEquals(1, rows.size)
+        assertEquals("already-migrated", rows.single().caption)
+        assertTrue(Preferences.getBoolean(Prefkey.progress_mark_data_migration_v1_done, false))
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/ProgressMarkRoomDaoTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/ProgressMarkRoomDaoTest.kt
@@ -1,0 +1,165 @@
+package yuku.alkitab.base.storage.room
+
+import android.app.Application
+import androidx.room.Room
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+/**
+ * Tests for the Room-generated [ProgressMarkRoomDao]. Verifies the
+ * `preset_id`-keyed lookups and the transactional history-plus-mark write
+ * path that mirrors the legacy [yuku.alkitab.base.storage.ProgressMarkDao]
+ * `beginTransactionNonExclusive` semantics.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34])
+class ProgressMarkRoomDaoTest {
+    private lateinit var db: AppDatabase
+    private lateinit var dao: ProgressMarkRoomDao
+
+    @Before
+    fun setUp() {
+        val app = RuntimeEnvironment.getApplication()
+        db = Room.inMemoryDatabaseBuilder(app, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.progressMarkDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private fun mark(presetId: Int, ari: Int, caption: String? = "m", modifyTime: Int? = 1_700_000_000) =
+        ProgressMarkEntity(
+            _id = 0L,
+            preset_id = presetId,
+            caption = caption,
+            ari = ari,
+            modifyTime = modifyTime,
+        )
+
+    private fun history(presetId: Int, ari: Int, caption: String? = "h", createTime: Int? = 1_700_000_000) =
+        ProgressMarkHistoryEntity(
+            _id = 0L,
+            progress_mark_preset_id = presetId,
+            progress_mark_caption = caption,
+            ari = ari,
+            createTime = createTime,
+        )
+
+    @Test
+    fun `listAllWithNonZeroAri excludes rows whose ari is zero`() {
+        dao.insert(mark(presetId = 0, ari = 0))
+        dao.insert(mark(presetId = 1, ari = 100))
+        dao.insert(mark(presetId = 2, ari = 0))
+
+        val rows = dao.listAllWithNonZeroAri()
+        assertEquals(1, rows.size)
+        assertEquals(1, rows.single().preset_id)
+    }
+
+    @Test
+    fun `countAllWithNonZeroAri matches the listAllWithNonZeroAri size`() {
+        dao.insert(mark(presetId = 0, ari = 100))
+        dao.insert(mark(presetId = 1, ari = 0))
+        dao.insert(mark(presetId = 2, ari = 200))
+        assertEquals(2, dao.countAllWithNonZeroAri())
+    }
+
+    @Test
+    fun `findByPresetId returns the matching row`() {
+        dao.insert(mark(presetId = 2, ari = 42, caption = "two"))
+        val loaded = dao.findByPresetId(2)
+        assertNotNull(loaded)
+        assertEquals(42, loaded!!.ari)
+        assertEquals("two", loaded.caption)
+    }
+
+    @Test
+    fun `findByPresetId returns null when no row exists`() {
+        dao.insert(mark(presetId = 0, ari = 1))
+        assertNull(dao.findByPresetId(7))
+    }
+
+    @Test
+    fun `insertHistoryAndUpsertMark inserts a fresh mark when none exists for the preset`() {
+        dao.insertHistoryAndUpsertMark(
+            history = history(presetId = 0, ari = 100, caption = "h"),
+            mark = mark(presetId = 0, ari = 100, caption = "m"),
+        )
+
+        val loaded = dao.findByPresetId(0)
+        assertNotNull(loaded)
+        assertEquals("m", loaded!!.caption)
+        assertEquals(1, dao.listHistoryByPresetId(0).size)
+    }
+
+    @Test
+    fun `insertHistoryAndUpsertMark updates the existing mark in place for the same preset`() {
+        dao.insertHistoryAndUpsertMark(history(0, 1, "h1"), mark(0, 1, "first"))
+        dao.insertHistoryAndUpsertMark(history(0, 2, "h2"), mark(0, 2, "second"))
+
+        val rows = dao.listAllForTest().filter { it.preset_id == 0 }
+        assertEquals(1, rows.size)
+        assertEquals("second", rows.single().caption)
+    }
+
+    @Test
+    fun `insertHistoryAndUpsertMark appends a history row on every call`() {
+        dao.insertHistoryAndUpsertMark(history(0, 1, "h1"), mark(0, 1))
+        dao.insertHistoryAndUpsertMark(history(0, 2, "h2"), mark(0, 2))
+        dao.insertHistoryAndUpsertMark(history(0, 3, "h3"), mark(0, 3))
+
+        val history = dao.listHistoryByPresetId(0)
+        assertEquals(3, history.size)
+        assertEquals(listOf("h1", "h2", "h3"), history.map { it.progress_mark_caption })
+    }
+
+    @Test
+    fun `listHistoryByPresetId orders by createTime ascending`() {
+        dao.insertHistory(history(presetId = 0, ari = 3, caption = "third", createTime = 300))
+        dao.insertHistory(history(presetId = 0, ari = 1, caption = "first", createTime = 100))
+        dao.insertHistory(history(presetId = 0, ari = 2, caption = "second", createTime = 200))
+
+        val history = dao.listHistoryByPresetId(0)
+        assertEquals(listOf("first", "second", "third"), history.map { it.progress_mark_caption })
+    }
+
+    @Test
+    fun `listHistoryByPresetId is scoped to the requested preset_id only`() {
+        dao.insertHistory(history(presetId = 0, ari = 1, caption = "preset0"))
+        dao.insertHistory(history(presetId = 1, ari = 1, caption = "preset1"))
+        dao.insertHistory(history(presetId = 2, ari = 1, caption = "preset2"))
+
+        val history = dao.listHistoryByPresetId(1)
+        assertEquals(1, history.size)
+        assertEquals("preset1", history.single().progress_mark_caption)
+    }
+
+    @Test
+    fun `null modifyTime and caption round-trip through insert`() {
+        dao.insert(mark(presetId = 0, ari = 0, caption = null, modifyTime = null))
+        val loaded = dao.findByPresetId(0)!!
+        assertNull(loaded.caption)
+        assertNull(loaded.modifyTime)
+    }
+
+    @Test
+    fun `insert assigns positive _ids and history is independent of mark _id`() {
+        val markId = dao.insert(mark(presetId = 0, ari = 1))
+        val historyId = dao.insertHistory(history(presetId = 0, ari = 1))
+        assertTrue("expected positive mark _id, got $markId", markId > 0)
+        assertTrue("expected positive history _id, got $historyId", historyId > 0)
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,19 +169,19 @@ Used everywhere: database storage, intent extras, sync protocol, content provide
 
 The app uses two SQLite files:
 
-- **`AlkitabRoomDb`** — Room database (`yuku.alkitab.base.storage.room.AppDatabase`, currently at `@Database(version = 4)`). Holds the tables migrated as part of the REM-10/REM-11/REM-27/REM-28 plan:
+- **`AlkitabRoomDb`** — Room database (`yuku.alkitab.base.storage.room.AppDatabase`, currently at `@Database(version = 5)`). Holds the tables migrated as part of the REM-10/REM-11/REM-27/REM-28/REM-29 plan:
   - **version** (REM-11) — metadata for downloaded Bible versions (filename, locale, active flag, ordering).
   - **marker** (REM-10) — bookmarks, notes, highlights (distinguished by `kind` column). Each row has a `gid` (globally unique ID) for sync.
   - **label** (REM-10) — bookmark categories with custom background colors.
   - **marker_label** (REM-10) — many-to-many junction between markers and labels.
   - **devotion** (REM-27) — cached devotional articles keyed by `(name, date, dataFormatVersion)`.
   - **per_version** (REM-28) — per-version settings keyed uniquely by `versionId`.
+  - **progress_mark** / **progress_mark_history** (REM-29) — 5 reading progress pins (addressed by `preset_id`) plus the append-only history of every pin update.
 - **`AlkitabDb`** — legacy hand-rolled `SQLiteOpenHelper` (`InternalDbHelper`). Still owns the not-yet-migrated tables:
-  - **ProgressMark** — 5 reading progress pins with ARI positions.
   - **ReadingPlan** / **ReadingPlanProgress** — reading plan data and daily completion tracking.
   - **SyncShadow** / **SyncLog** — sync state tracking.
 
-The legacy `Marker` / `Label` / `Marker_Label` / `Version` / `Devotion` / `PerVersion` tables are still created in `AlkitabDb` as a rollback safety net; a one-time copy in `MarkerDataMigration` / `VersionDataMigration` / `DevotionDataMigration` / `PerVersionDataMigration` (wired from `S.db`'s lazy initializer) moves their rows into Room on first launch with the migrated code. `InternalDb` plus the per-table facades (`MarkerDao`, `LabelDao`, `Marker_LabelDao`, `VersionDao`, `DevotionDao`, `PerVersionDao`, etc.) preserve the public surface so callers don't change; the facades route through Room for the migrated tables and through raw SQL for the rest.
+The legacy `Marker` / `Label` / `Marker_Label` / `Version` / `Devotion` / `PerVersion` / `ProgressMark` / `ProgressMarkHistory` tables are still created in `AlkitabDb` as a rollback safety net; a one-time copy in `MarkerDataMigration` / `VersionDataMigration` / `DevotionDataMigration` / `PerVersionDataMigration` / `ProgressMarkDataMigration` (wired from `S.db`'s lazy initializer) moves their rows into Room on first launch with the migrated code. `InternalDb` plus the per-table facades (`MarkerDao`, `LabelDao`, `Marker_LabelDao`, `VersionDao`, `DevotionDao`, `PerVersionDao`, `ProgressMarkDao`, etc.) preserve the public surface so callers don't change; the facades route through Room for the migrated tables and through raw SQL for the rest.
 
 ### Verse Text Formatting Codes
 

--- a/docs/tech-debt-remediation.md
+++ b/docs/tech-debt-remediation.md
@@ -34,6 +34,7 @@ This document is an index over the prioritized remediation plan for each tech de
 - [REM-11: Migrate InternalDb to Room (Version Table)](tech-debt-remediation/REM-11-room-version.md) ✅ **3.2**
 - [REM-27: Migrate InternalDb to Room (Devotion Table)](tech-debt-remediation/REM-27-room-devotion.md) ✅ **3.2**
 - [REM-28: Migrate InternalDb to Room (PerVersion Table)](tech-debt-remediation/REM-28-room-per-version.md) ✅ **3.2**
+- [REM-29: Migrate InternalDb to Room (ProgressMark Tables)](tech-debt-remediation/REM-29-room-progress-mark.md) ✅ **3.2**
 - [REM-12: Replace DragSortListView with ItemTouchHelper](tech-debt-remediation/REM-12-itemtouchhelper.md) ✅ **3.4**
 - [REM-14: Replace material-dialogs with Material 3](tech-debt-remediation/REM-14-material-dialogs.md) ✅ **3.4**
 - [REM-18: Add Test Coverage for Core Modules](tech-debt-remediation/REM-18-test-coverage.md) ✅ **3.4**
@@ -81,6 +82,7 @@ This document is an index over the prioritized remediation plan for each tech de
 | [REM-11](tech-debt-remediation/REM-11-room-version.md) | ~~Room migration (Version)~~ ✅ | **3.2** | 2 |
 | [REM-27](tech-debt-remediation/REM-27-room-devotion.md) | ~~Room migration (Devotion)~~ ✅ | **3.2** | 2 |
 | [REM-28](tech-debt-remediation/REM-28-room-per-version.md) | ~~Room migration (PerVersion)~~ ✅ | **3.2** | 2 |
+| [REM-29](tech-debt-remediation/REM-29-room-progress-mark.md) | ~~Room migration (ProgressMark)~~ ✅ | **3.2** | 2 |
 | [REM-15](tech-debt-remediation/REM-15-coroutines.md) | Introduce coroutines | **3.2** | 3 |
 | [REM-16](tech-debt-remediation/REM-16-java-to-kotlin.md) | Java→Kotlin conversion (9/11 done) | **3.0** | 3 |
 | [REM-17](tech-debt-remediation/REM-17-kotlin-dsl-build.md) | ~~Kotlin DSL build migration~~ ✅ | **3.0** | 3 |
@@ -95,6 +97,6 @@ This document is an index over the prioritized remediation plan for each tech de
 **Sprint 2 (1 week):** ~~REM-03~~✅ — LocalBroadcastManager removal (done)
 **Sprint 3 (2 weeks):** ~~REM-07~~✅, ~~REM-06~~✅, ~~REM-08~~✅ — IsiActivity decomposition (all done)
 **Sprint 4 (1 week):** ~~REM-12~~✅, ~~REM-14~~✅ — deprecated library replacements (done)
-**Sprint 5 (2 weeks):** ~~REM-10~~✅, ~~REM-11~~✅, ~~REM-27~~✅, ~~REM-28~~✅ — Room migration for core tables (Marker / Version / Devotion / PerVersion done; remaining tables — `ReadingPlan`, `SyncShadow`, `SyncLog`, `ProgressMark` — can follow the same pattern)
+**Sprint 5 (2 weeks):** ~~REM-10~~✅, ~~REM-11~~✅, ~~REM-27~~✅, ~~REM-28~~✅, ~~REM-29~~✅ — Room migration for core tables (Marker / Version / Devotion / PerVersion / ProgressMark done; remaining tables — `ReadingPlan`, `SyncShadow`, `SyncLog` — can follow the same pattern)
 **Sprint 6 (2 weeks):** REM-09, ~~REM-18a-f~~✅ — ViewModel + test coverage (REM-18a/b/c/d/e/f done)
 **Ongoing:** REM-15, REM-16, ~~REM-17~~✅ — modernization work mixed into feature sprints (REM-17 done)

--- a/docs/tech-debt-remediation/REM-10-room-markers.md
+++ b/docs/tech-debt-remediation/REM-10-room-markers.md
@@ -26,7 +26,7 @@
 
 **Verification.** `./gradlew :Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest` — 494 tests, all green. `./gradlew :Alkitab:assemblePlainDebug` produces a working APK. On-device smoke (Pixel emulator API 35, pre-existing dataset of 1456 markers / 18 labels / 152 marker_label associations from a v1 Room install): installing the new APK ran `MarkerDataMigration` once on first launch (logged `Copied 1456 marker(s), 18 label(s), 152 marker_label row(s) from legacy tables to Room`), counts match the legacy table exactly, second launch is idempotent (no row growth), spot-check confirms `gid` / `ari` / `caption` round-trip verbatim.
 
-**Difficulty:** Hard. Took ~1 day with the REM-11 pattern already established. Subsequent tables can follow the same pattern — `Devotion` shipped as [REM-27](REM-27-room-devotion.md), `PerVersion` as [REM-28](REM-28-room-per-version.md); `ReadingPlan`, `SyncShadow`, `SyncLog`, `ProgressMark` remain.
+**Difficulty:** Hard. Took ~1 day with the REM-11 pattern already established. Subsequent tables can follow the same pattern — `Devotion` shipped as [REM-27](REM-27-room-devotion.md), `PerVersion` as [REM-28](REM-28-room-per-version.md), `ProgressMark` / `ProgressMarkHistory` as [REM-29](REM-29-room-progress-mark.md); `ReadingPlan`, `SyncShadow`, `SyncLog` remain.
 
 ---
 

--- a/docs/tech-debt-remediation/REM-27-room-devotion.md
+++ b/docs/tech-debt-remediation/REM-27-room-devotion.md
@@ -23,7 +23,7 @@
 
 **Verification.** `./gradlew :Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest` — all green. `./gradlew :Alkitab:assemblePlainDebug` produces a working APK.
 
-**Difficulty:** Easy. Took ~half a day with the REM-10 / REM-11 pattern already established. `PerVersion` followed as [REM-28](REM-28-room-per-version.md); remaining tables (`ReadingPlan`, `SyncShadow`, `SyncLog`, `ProgressMark`) can follow the same pattern.
+**Difficulty:** Easy. Took ~half a day with the REM-10 / REM-11 pattern already established. `PerVersion` followed as [REM-28](REM-28-room-per-version.md), `ProgressMark` / `ProgressMarkHistory` as [REM-29](REM-29-room-progress-mark.md); remaining tables (`ReadingPlan`, `SyncShadow`, `SyncLog`) can follow the same pattern.
 
 ---
 

--- a/docs/tech-debt-remediation/REM-29-room-progress-mark.md
+++ b/docs/tech-debt-remediation/REM-29-room-progress-mark.md
@@ -1,0 +1,32 @@
+# REM-29: Migrate InternalDb to Room (ProgressMark Tables) ✅ COMPLETED (2026-05-14)
+
+**Addresses:** TD-02 (continuation of [REM-10](REM-10-room-markers.md) / [REM-11](REM-11-room-version.md) / [REM-27](REM-27-room-devotion.md) / [REM-28](REM-28-room-per-version.md))
+**Module:** Storage — Reading-progress pins
+**BRICE:** B=3 R=3 I=2 C=3 E=5 → **3.2**
+**Phase:** 2 — Architecture Improvements
+
+**Outcome.** The legacy hand-rolled `ProgressMark` and `ProgressMarkHistory` SQLite tables are now backed by Room in `AlkitabRoomDb` (the same separate-file Room database introduced by REM-11 and extended by REM-10/REM-27/REM-28). `AppDatabase` bumped `version = 4 → 5`; the SQL inside `MIGRATION_4_5` mirrors what Room's entity definitions emit (verified by `MigrationTestHelper.runMigrationsAndValidate` with `validateDroppedTables = true`).
+
+Two tables, one DAO: the legacy facade's `insertOrUpdate` writes a history row then upserts the matching mark inside a single transaction. The Room DAO preserves that atomicity with a `@Transaction`-annotated `insertHistoryAndUpsertMark` that runs the existence check + insert/update inside Room's transaction primitive, matching the legacy `SQLiteDatabase.beginTransactionNonExclusive` semantics exactly.
+
+**Shipped:**
+- **Entities:** `ProgressMarkEntity.kt` mirrors the legacy mark columns (`preset_id`, `caption`, `ari`, `modifyTime`); `ProgressMarkHistoryEntity.kt` mirrors the history columns (`progress_mark_preset_id`, `progress_mark_caption`, `ari`, `createTime`). `preset_id` / `progress_mark_preset_id` / `ari` are non-nullable in Room even though the legacy schema permitted NULL; `ProgressMarkDataMigration` drops any legacy rows where those columns are NULL (they are unreachable by the facade's keyed lookups, and coalescing a NULL `preset_id` to 0 would collide with the legitimate `preset_id = 0` placeholder row that the legacy schema seeds). `modifyTime` / `createTime` stay nullable to round-trip the placeholder rows that `InternalDbHelper.insertDefaultProgressMarks` inserts without those values. The `progress_mark_caption` column was declared `INTEGER` in legacy SQL but written as `String` by the DAO (SQLite type affinity); Room normalises this to `TEXT`. Non-unique indexes `index_progress_mark_preset_id` and `index_progress_mark_history_preset_id_createTime` mirror the legacy `index_601` / `index_701`.
+- **Room DAO:** `ProgressMarkRoomDao.kt` exposes `findByPresetId`, `listAllWithNonZeroAri`, `countAllWithNonZeroAri`, `listHistoryByPresetId`, plain `insert` / `insertHistory` / `update` used by the data migration, and the transactional `insertHistoryAndUpsertMark` that mirrors the legacy facade's write path.
+- **Schema bump:** `AppDatabase.kt` now `@Database(version = 5)` with `@JvmField val MIGRATION_4_5`. `Alkitab/schemas/yuku.alkitab.base.storage.room.AppDatabase/5.json` is checked in alongside `1.json`, `2.json`, `3.json`, and `4.json`.
+- **Data migration:** `ProgressMarkDataMigration.kt` — idempotent one-time copy from the legacy `ProgressMark` and `ProgressMarkHistory` tables into Room. Idempotency uses the persistent `Prefkey.progress_mark_data_migration_v1_done` flag (same approach as REM-10/REM-11/REM-27/REM-28 post-#198), so a user who overwrites their pins cannot resurrect the deleted ari on the next launch. Streams rows from each legacy cursor into Room inside a single `runInTransaction` to bound memory — the history table grows monotonically with every pin update. Wired into `S.kt`'s `db` lazy initializer next to `MarkerDataMigration`, `VersionDataMigration`, `DevotionDataMigration`, and `PerVersionDataMigration`.
+- **Facade preservation:** `ProgressMarkDao.kt` rewritten to delegate to the Room DAO, mapping between the new entities and the public `ProgressMark` / `ProgressMarkHistory` models. Public method signatures unchanged — call sites in `InternalDb` (`listAllProgressMarks`, `countAllProgressMarks`, `getProgressMarkByPresetId`, `insertOrUpdateProgressMark`, `listProgressMarkHistoryByPresetId`) did not need to be touched.
+- **Legacy tables left in place.** `ProgressMark` and `ProgressMarkHistory` are still created by `InternalDbHelper.onCreate` (and still seeded with the five placeholder rows via `insertDefaultProgressMarks`) so the rollback safety net is preserved; a future release can drop them once the Room path has baked. The legacy seed doubles as the fresh-install seed source for Room — `ProgressMarkDataMigration` copies the five placeholder rows out of the legacy table on first launch, so callers like `IsiActivity.onPinDropped` that rely on a row already existing for each preset slot continue to work unchanged.
+
+**Tests (2 new files, 1 existing extended, 1 existing rewritten):**
+- `ProgressMarkRoomDaoTest.kt` (11 tests) — Room-level primitives: `preset_id` lookup, `ari != 0` filter, history ordering, transactional history-plus-mark write, null-column round-trip.
+- `ProgressMarkDataMigrationTest.kt` (13 tests) — empty/full copies, history copy, placeholder-seed round-trip with null `modifyTime`/`caption`, drop-on-NULL-preset_id, drop-on-NULL-ari, multi-NULL-preset_id no-crash regression guard, idempotency, no-stomp-on-existing-Room-rows, fresh `_id` assignment, and the issue #195 regression guard against resurrecting cleared rows.
+- `AppDatabaseMigrationTest.kt` — added `migrates4To5` test plus an end-to-end `v1 → v5` open-via-Room round-trip; updated the existing `Room.databaseBuilder` calls to register `MIGRATION_4_5` now that the entity-driven schema is at v5.
+- `ProgressMarkDaoTest.kt` — `@Before` now installs an in-memory `AppDatabase` via `AppDatabase.setForTesting` and pre-seeds the five placeholder rows the way `InternalDbHelper.insertDefaultProgressMarks` used to, same harness change as `DevotionDaoTest` / `VersionDaoTest` / `PerVersionDaoTest`.
+
+**Verification.** `./gradlew :Alkitab:assemblePlainDebug :Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest` — all green.
+
+**Difficulty:** Easy. Took ~half a day with the REM-10 / REM-11 / REM-27 / REM-28 pattern already established. The new wrinkle vs. REM-28 was handling two coupled tables that the legacy facade writes atomically — `@Transaction` covers that cleanly. Remaining tables (`ReadingPlan`, `SyncShadow`, `SyncLog`) can follow the same pattern.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)


### PR DESCRIPTION
## Summary
- Migrate the legacy `ProgressMark` and `ProgressMarkHistory` tables out of `AlkitabDb` and into Room's `AlkitabRoomDb` (`AppDatabase` → `@Database(version = 5)` with `MIGRATION_4_5`). Continues the InternalDb → Room migration shipped in REM-10 / REM-11 / REM-27 / REM-28.
- Two tables, one DAO: the legacy facade writes a history row and upserts the matching mark inside a single transaction. A new `@Transaction insertHistoryAndUpsertMark` preserves that atomicity.
- Idempotency gated on `Prefkey.progress_mark_data_migration_v1_done` (matches the REM-10/REM-11/REM-27/REM-28 post-#198 pattern); legacy `preset_id`/`ari` NULLs are skipped rather than coalesced, so a multi-NULL legacy table cannot collide with the legitimate `preset_id = 0` placeholder row (same class of bug Gemini caught on REM-28 / PR #204).
- Legacy tables stay in place as a rollback safety net, and continue to seed the five placeholder rows on fresh install. `ProgressMarkDataMigration` copies them across so `IsiActivity.onPinDropped` and other call sites that rely on a row already existing per preset slot keep working unchanged.
- Public `ProgressMarkDao` API is unchanged — `InternalDb` call sites untouched.

## Test plan
- [x] `./gradlew :Alkitab:assemblePlainDebug :Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest` — green.
- [x] `ProgressMarkRoomDaoTest` (11) — Room primitives, history ordering, transactional write.
- [x] `ProgressMarkDataMigrationTest` (13) — copies marks + history, placeholder-seed round-trip with NULL `modifyTime`/`caption`, drop-on-NULL preset_id/ari, multi-NULL-preset_id no-crash regression guard, idempotency, issue #195 resurrect-after-clear guard, fresh `_id` assignment.
- [x] `AppDatabaseMigrationTest` — added `migrates4To5` plus a v1 → v5 round-trip through the new DAO; existing Room-builder tests register `MIGRATION_4_5`.
- [x] Existing `ProgressMarkDaoTest` rewired through in-memory Room via `AppDatabase.setForTesting` and pre-seeds the five placeholder rows the way `InternalDbHelper.insertDefaultProgressMarks` used to.
- [ ] On-device smoke: install the build over a pre-existing dataset of pinned verses, confirm `ProgressMarkDataMigration` runs once on first launch, pin drop / rename / sync still work, second launch is a no-op.