### PR TITLE
build: upgrade to AGP 9.2.1 + fix Gradle deprecation warnings

### DIFF
--- a/Afw/build.gradle.kts
+++ b/Afw/build.gradle.kts
@@ -7,6 +7,9 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    testOptions {
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
@@ -19,6 +22,12 @@ android {
     namespace = "yuku.afw"
     lint {
         abortOnError = false
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.android.build.gradle.api.ApkVariantOutput
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileSystemOperations
@@ -15,7 +14,6 @@ import javax.inject.Inject
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlin.compose)
@@ -130,8 +128,6 @@ android {
         versionCode = buildVersionCode
         versionName = "5.0.0-b0"
         multiDexEnabled = true
-        // Keep this synced with integrate_translations.sh! Also update pref_language.xml and ConfigurationWrapper!
-        resourceConfigurations += listOf("af", "bg", "ceb", "cs", "da", "de", "el", "es", "fr", "hu", "in", "it", "ja", "ko", "lv", "ms", "my", "nl", "pl", "pt-rBR", "pt", "ro", "ru", "th", "tl", "tr", "uk", "vi", "zh-rCN", "zh-rTW")
         buildConfigField("String", "SERVER_HOST", "\"$serverHost\"")
         buildConfigField("String", "RIBKA_FUNCTIONS_HOST", "\"$ribkaFunctionsHost\"")
         buildConfigField("String", "LAST_COMMIT_HASH", "\"$gitCommitHash\"")
@@ -143,6 +139,11 @@ android {
         // reading the internal version. Empty string means "internal has no
         // audio for this flavor". Each productFlavor overrides this below.
         buildConfigField("String", "INTERNAL_VERSION_AUDIO_ID", "\"\"")
+    }
+
+    androidResources {
+        // Keep this synced with integrate_translations.sh! Also update pref_language.xml and ConfigurationWrapper!
+        localeFilters += listOf("af", "bg", "ceb", "cs", "da", "de", "el", "es", "fr", "hu", "in", "it", "ja", "ko", "lv", "ms", "my", "nl", "pl", "pt-rBR", "pt", "ro", "ru", "th", "tl", "tr", "uk", "vi", "zh-rCN", "zh-rTW")
     }
 
     // Room schema export — JSON snapshots of each @Database version land here.
@@ -161,7 +162,7 @@ android {
         // alternative (an instrumented-test setup that needs an emulator in
         // CI).
         // See Alkitab/src/test/java/.../room/AppDatabaseMigrationTest.kt.
-        getByName("main").assets.srcDir("$projectDir/schemas")
+        getByName("main").assets.directories.add("$projectDir/schemas")
     }
     buildTypes {
         debug {
@@ -318,59 +319,79 @@ androidComponents {
     }
 }
 
-android.applicationVariants.all {
-    val variant = this
-    // Custom APK output filename, mirroring the legacy ybuild.sh naming:
-    //   Alkitab-<versionCode>-<versionName>-<gitHash>-<applicationId>-<BUILD_DIST>.apk
-    // BUILD_DIST defaults to "dev" so local builds get a recognisable name.
-    val buildDist = providers.environmentVariable("BUILD_DIST").getOrElse("dev")
-    outputs.all {
-        (this as? ApkVariantOutput)?.outputFileName =
-            "Alkitab-${variant.versionCode}-${variant.versionName}-$gitCommitHash-${variant.applicationId}-$buildDist.apk"
+androidComponents {
+    // AGP 9 disables host (unit) tests for release variants by default; CI still
+    // runs testPlainReleaseUnitTest, so re-enable them for every variant.
+    beforeVariants(selector().all()) { variant ->
+        variant.hostTests[com.android.build.api.variant.HostTestBuilder.UNIT_TEST_TYPE]?.enable = true
     }
 
-    // Wire the proprietary google-services.json copy task into the GMS plugin
-    // task that consumes it, for each production flavor variant. Using
-    // tasks.matching { }.configureEach { } rather than tasks.named() so the
-    // build doesn't break if the GMS plugin is ever removed or renames its task.
-    if (proprietaryFlavors.containsKey(variant.flavorName)) {
-        val copyTaskName = "copyProprietaryGoogleServices${variant.flavorName.replaceFirstChar { it.uppercaseChar() }}"
-        val gmsTaskName = "process${variant.name.replaceFirstChar { it.uppercaseChar() }}GoogleServices"
-        tasks.matching { it.name == gmsTaskName }.configureEach {
-            dependsOn(copyTaskName)
+    onVariants(selector().all()) { variant ->
+        // Custom APK output filename, mirroring the legacy ybuild.sh naming:
+        //   Alkitab-<versionCode>-<versionName>-<gitHash>-<applicationId>-<BUILD_DIST>.apk
+        // BUILD_DIST defaults to "dev" so local builds get a recognisable name.
+        val buildDist = providers.environmentVariable("BUILD_DIST").getOrElse("dev")
+        val appIdProvider = variant.applicationId
+        variant.outputs.forEach { output ->
+            val apkOutput = output as? com.android.build.api.variant.VariantOutput ?: return@forEach
+            apkOutput.outputFileName.set(
+                appIdProvider.flatMap { appId ->
+                    apkOutput.versionCode.flatMap { vc ->
+                        apkOutput.versionName.map { vn ->
+                            "Alkitab-$vc-$vn-$gitCommitHash-$appId-$buildDist.apk"
+                        }
+                    }
+                }
+            )
         }
-    }
 
-    // Validate Firebase config for non-plain release builds. Reads from the
-    // flavor source set (populated by copyProprietaryGoogleServices<Flavor>),
-    // falling back to the root google-services.json the GMS plugin would
-    // otherwise use.
-    if (!variant.buildType.isDebuggable && variant.flavorName != "plain") {
-        val applicationId = variant.applicationId
         val flavorName = variant.flavorName
-        val validateTask = tasks.register("validate${variant.name.replaceFirstChar { it.uppercaseChar() }}FirebaseConfig") {
-            if (proprietaryFlavors.containsKey(flavorName)) {
-                dependsOn("copyProprietaryGoogleServices${flavorName.replaceFirstChar { it.uppercaseChar() }}")
+        val variantName = variant.name
+
+        // Wire the proprietary google-services.json copy task into the GMS plugin
+        // task that consumes it, for each production flavor variant. Using
+        // tasks.matching { }.configureEach { } rather than tasks.named() so the
+        // build doesn't break if the GMS plugin is ever removed or renames its task.
+        if (flavorName != null && proprietaryFlavors.containsKey(flavorName)) {
+            val copyTaskName = "copyProprietaryGoogleServices${flavorName.replaceFirstChar { it.uppercaseChar() }}"
+            val gmsTaskName = "process${variantName.replaceFirstChar { it.uppercaseChar() }}GoogleServices"
+            tasks.matching { it.name == gmsTaskName }.configureEach {
+                dependsOn(copyTaskName)
             }
-            doLast {
-                val candidates = listOf(
-                    file("src/$flavorName/google-services.json"),
-                    file("google-services.json"),
-                )
-                val jsonFile = candidates.find { it.isFile }
-                val reason = firebaseApiKeyProblem(jsonFile, applicationId)
-                if (reason != null) {
-                    throw GradleException(
-                        "Release build '${variant.name}' has unusable Firebase config: $reason. " +
-                            "For production flavors, set ALKITAB_PROPRIETARY_DIR to a directory containing " +
-                            "a real google-services.json with a client entry for '$applicationId'."
+        }
+
+        // Validate Firebase config for non-plain release builds. Reads from the
+        // flavor source set (populated by copyProprietaryGoogleServices<Flavor>),
+        // falling back to the root google-services.json the GMS plugin would
+        // otherwise use.
+        if (variant.buildType == "release" && flavorName != null && flavorName != "plain") {
+            val applicationIdProvider = variant.applicationId
+            val validateTask = tasks.register("validate${variantName.replaceFirstChar { it.uppercaseChar() }}FirebaseConfig") {
+                if (proprietaryFlavors.containsKey(flavorName)) {
+                    dependsOn("copyProprietaryGoogleServices${flavorName.replaceFirstChar { it.uppercaseChar() }}")
+                }
+                doLast {
+                    val applicationId = applicationIdProvider.get()
+                    val candidates = listOf(
+                        file("src/$flavorName/google-services.json"),
+                        file("google-services.json"),
                     )
+                    val jsonFile = candidates.find { it.isFile }
+                    val reason = firebaseApiKeyProblem(jsonFile, applicationId)
+                    if (reason != null) {
+                        throw GradleException(
+                            "Release build '$variantName' has unusable Firebase config: $reason. " +
+                                "For production flavors, set ALKITAB_PROPRIETARY_DIR to a directory containing " +
+                                "a real google-services.json with a client entry for '$applicationId'."
+                        )
+                    }
                 }
             }
-        }
 
-        tasks.named("pre${variant.name.replaceFirstChar { it.uppercaseChar() }}Build").configure {
-            dependsOn(validateTask)
+            val preBuildTaskName = "pre${variantName.replaceFirstChar { it.uppercaseChar() }}Build"
+            tasks.matching { it.name == preBuildTaskName }.configureEach {
+                dependsOn(validateTask)
+            }
         }
     }
 }

--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -333,11 +333,10 @@ androidComponents {
         val buildDist = providers.environmentVariable("BUILD_DIST").getOrElse("dev")
         val appIdProvider = variant.applicationId
         variant.outputs.forEach { output ->
-            val apkOutput = output as? com.android.build.api.variant.VariantOutput ?: return@forEach
-            apkOutput.outputFileName.set(
+            output.outputFileName.set(
                 appIdProvider.flatMap { appId ->
-                    apkOutput.versionCode.flatMap { vc ->
-                        apkOutput.versionName.map { vn ->
+                    output.versionCode.flatMap { vc ->
+                        output.versionName.map { vn ->
                             "Alkitab-$vc-$vn-$gitCommitHash-$appId-$buildDist.apk"
                         }
                     }

--- a/AlkitabFeedback/build.gradle.kts
+++ b/AlkitabFeedback/build.gradle.kts
@@ -7,8 +7,11 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        targetSdk = libs.versions.targetSdk.get().toInt()
         buildConfigField("String", "SERVER_HOST", "\"https://api.alkitab.app\"")
+    }
+
+    testOptions {
+        targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
     buildTypes {
@@ -25,6 +28,12 @@ android {
     namespace = "yuku.alkitabfeedback"
     lint {
         abortOnError = false
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/AlkitabIntegration/build.gradle.kts
+++ b/AlkitabIntegration/build.gradle.kts
@@ -7,8 +7,11 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
-        targetSdk = libs.versions.targetSdk.get().toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    testOptions {
+        targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
     buildTypes {
@@ -20,6 +23,12 @@ android {
     namespace = "yuku.alkitabintegration"
     lint {
         abortOnError = false
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/AlkitabIo/build.gradle.kts
+++ b/AlkitabIo/build.gradle.kts
@@ -7,6 +7,9 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    testOptions {
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
@@ -19,6 +22,12 @@ android {
     namespace = "yuku.alkitab.io"
     lint {
         abortOnError = false
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/AlkitabModel/build.gradle.kts
+++ b/AlkitabModel/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {
@@ -8,6 +7,9 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    testOptions {
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
 

--- a/AlkitabYes2/build.gradle.kts
+++ b/AlkitabYes2/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {
@@ -8,6 +7,9 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    testOptions {
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
 

--- a/BiblePlus/build.gradle.kts
+++ b/BiblePlus/build.gradle.kts
@@ -7,6 +7,9 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    testOptions {
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
@@ -19,5 +22,11 @@ android {
     namespace = "com.compactbyte.android.bible"
     lint {
         abortOnError = false
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }

--- a/BintexReader/build.gradle.kts
+++ b/BintexReader/build.gradle.kts
@@ -7,6 +7,9 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    testOptions {
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
@@ -19,5 +22,11 @@ android {
     namespace = "yuku.bintex.reader"
     lint {
         abortOnError = false
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }

--- a/BintexWriter/build.gradle.kts
+++ b/BintexWriter/build.gradle.kts
@@ -7,6 +7,9 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    testOptions {
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
@@ -19,5 +22,11 @@ android {
     namespace = "yuku.bintex.writer"
     lint {
         abortOnError = false
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }

--- a/FlowLayout/build.gradle.kts
+++ b/FlowLayout/build.gradle.kts
@@ -7,6 +7,9 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    testOptions {
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
@@ -19,5 +22,11 @@ android {
     namespace = "yuku.devoxx.flowlayout"
     lint {
         abortOnError = false
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }

--- a/ImportedDesktopVerseUtil/build.gradle.kts
+++ b/ImportedDesktopVerseUtil/build.gradle.kts
@@ -7,6 +7,9 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    testOptions {
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
@@ -19,6 +22,12 @@ android {
     namespace = "yuku.alkitabconverter.util"
     lint {
         abortOnError = false
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/KpriModel/build.gradle.kts
+++ b/KpriModel/build.gradle.kts
@@ -7,6 +7,9 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    testOptions {
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
@@ -19,5 +22,11 @@ android {
     namespace = "yuku.kpri.model"
     lint {
         abortOnError = false
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }

--- a/Snappy/build.gradle.kts
+++ b/Snappy/build.gradle.kts
@@ -7,6 +7,9 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
+    }
+
+    testOptions {
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
 
@@ -30,4 +33,10 @@ android {
         }
     }
     namespace = "yuku.snappy.codec"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-agp = "8.13.0"
-kotlin = "2.2.0"
-ksp = "2.2.0-2.0.2"
+agp = "9.2.1"
+kotlin = "2.3.21"
+ksp = "2.3.8"
 googleServices = "4.4.3"
 firebaseCrashlyticsGradle = "3.0.6"
 foojayResolver = "1.0.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- Upgrade to **AGP 9.2.1**, **Gradle 9.5.1**, **Kotlin 2.3.21**, **KSP 2.3.8**.
- Migrate breaking APIs removed in AGP 9 (`ApkVariantOutput`, `android.applicationVariants.all`, deprecated `assets.srcDir`).
- Re-enable host unit tests for release variants (AGP 9 disables them by default; CI still runs `testPlainReleaseUnitTest`).
- Fix three Gradle deprecation warnings:
  - Java compiler `source/target 8` → `java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }` on Java-only modules. Kotlin modules already had `kotlin { jvmToolchain(17) }` which configures the Java toolchain too.
  - Library DSL `targetSdk` → `testOptions.targetSdk`.
  - `defaultConfig.resourceConfigurations` → `androidResources.localeFilters`.

## AGP 9 migration notes

- AGP 9 ships built-in Kotlin support, so `alias(libs.plugins.kotlin.android)` was removed from `Alkitab`, `AlkitabModel`, and `AlkitabYes2`.
- The legacy `android.applicationVariants.all { outputs.all { (this as? ApkVariantOutput)?.outputFileName = ... } }` block was rewritten on the new `androidComponents.onVariants` API. The APK filename is now set via `output.outputFileName.set(provider)` with lazy `Provider.flatMap`/`.map` over `applicationId`, `versionCode`, and `versionName`.
- Variant tasks aren't realized inside `onVariants`, so the `pre<Variant>Build` wiring switched to lazy `tasks.matching { ... }.configureEach` (same pattern already used for the GMS task).

## Test plan

- [x] `./gradlew assemblePlainDebug` succeeds locally.
- [x] APK filename is preserved: `Alkitab-21920500-5.0.0-b0-41b9e262-yuku.alkitab.debug-dev.apk`.
- [x] `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` — 1148 passed / 0 failed.
- [x] No `Java compiler has deprecated support for compiling with source/target compatibility version 8`, `var targetSdk` library deprecation, or `resourceConfigurations` deprecation warning emitted.
- [ ] CI green on this branch.