### PR TITLE
ci: flip android.nonFinalResIds to true to unblock signed release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-android.nonFinalResIds=false
+android.nonFinalResIds=true
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4G


### PR DESCRIPTION
## Summary

The `signed-release` workflow job has been failing since the AGP 9.2.1 upgrade (#207). Every `minify<ProductionFlavor>ReleaseWithR8` task fails with:

```
Optimized resource shrinking requires non-final IDs.
Suggestion: opt back in to non-final resource IDs by setting
android.nonFinalResIds=true in gradle.properties.
```

AGP 9 enables optimized resource shrinking by default, and that path requires non-final resource IDs. The legacy `android.nonFinalResIds=false` left over from an earlier migration is now incompatible. `plain-debug` passed because debug builds skip R8 / resource shrinking — only release variants exercise the failing code path, which is why #207 was able to merge with this latent breakage.

## Why flip the flag rather than disable optimized shrinking

Two options surfaced in the error message:

1. `android.nonFinalResIds=true` — opt into non-final IDs (forward-compatible)
2. `android.r8.optimizedResourceShrinking=false` — keep the deprecated code path alive

Non-final resource IDs only break code that uses them as compile-time constants — i.e. Java `switch (R.id...)` / `case R.id...`. A grep across the whole repo finds zero such statements, so option 1 is safe and aligned with the AGP direction.

## Test plan

- [x] Repro: `:Alkitab:assemblePlainRelease` failed locally with the AGP 9.2.1 + `nonFinalResIds=false` combo (same error as CI).
- [x] After the flip: `:Alkitab:assemblePlainRelease` succeeds.
- [x] `:Alkitab:testPlainDebugUnitTest :Alkitab:testPlainReleaseUnitTest` still green.
- [ ] CI green on this branch (requires repo secrets — confirms the production flavor builds too).

https://claude.ai/code/session_01DBHeNGecZjPCsaMDH4T7RU

---
_Generated by [Claude Code](https://claude.ai/code/session_01DBHeNGecZjPCsaMDH4T7RU)_