### PR TITLE
Restore legacy Goto screen as default; gate Compose port behind experimental flag

### DIFF
--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -404,6 +404,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.fragment.ktx)
     implementation(libs.androidx.multidex)
+    implementation(libs.androidx.percentlayout)
     implementation(libs.androidx.preference.ktx)
     implementation(libs.androidx.recyclerview)
     implementation(libs.androidx.swiperefreshlayout)

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/GotoActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/GotoActivity.kt
@@ -1,22 +1,33 @@
 package yuku.alkitab.base.ac
 
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import android.view.inputmethod.InputMethodManager
 import androidx.activity.compose.setContent
+import androidx.appcompat.widget.Toolbar
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentPagerAdapter
+import androidx.viewpager.widget.ViewPager
+import com.google.android.material.tabs.TabLayout
 import yuku.afw.App
 import yuku.afw.storage.Preferences
+import yuku.alkitab.base.ac.base.BaseActivity
 import yuku.alkitab.base.compose.BibleAppTheme
 import yuku.alkitab.base.compose.goto.GotoScreen
+import yuku.alkitab.base.fr.GotoDialerFragment
+import yuku.alkitab.base.fr.GotoDirectFragment
+import yuku.alkitab.base.fr.GotoGridFragment
+import yuku.alkitab.base.fr.base.BaseGotoFragment
+import yuku.alkitab.base.settings.ExperimentalFlags
+import yuku.alkitab.base.storage.GOTO_ASK_FOR_VERSE_DEFAULT
 import yuku.alkitab.base.storage.Prefkey
-import yuku.alkitab.base.widget.ConfigurationWrapper
+import yuku.alkitab.debug.R
 
-class GotoActivity : ComponentActivity() {
-
-    override fun attachBaseContext(newBase: Context) {
-        super.attachBaseContext(ConfigurationWrapper.wrap(newBase))
-    }
+class GotoActivity : BaseActivity(), BaseGotoFragment.GotoFinishListener {
 
     class Result {
         @JvmField var bookId: Int = -1
@@ -28,6 +39,8 @@ class GotoActivity : ComponentActivity() {
         private const val EXTRA_bookId = "bookId"
         private const val EXTRA_chapter = "chapter"
         private const val EXTRA_verse = "verse"
+
+        private const val INSTANCE_STATE_tab = "tab"
 
         @JvmStatic
         fun createIntent(bookId: Int, chapter_1: Int, verse_1: Int): Intent {
@@ -48,32 +61,166 @@ class GotoActivity : ComponentActivity() {
         }
     }
 
+    private var useCompose = false
+
+    // Legacy mode state. Only valid when [useCompose] is false.
+    private var bookId: Int = -1
+    private var chapter_1: Int = 0
+    private var verse_1: Int = 0
+    private var viewPager: ViewPager? = null
+    private var okToHideKeyboard = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val initialBookId = intent.getIntExtra(EXTRA_bookId, -1)
-        val initialChapter = intent.getIntExtra(EXTRA_chapter, 0)
-        val initialVerse = intent.getIntExtra(EXTRA_verse, 0)
+        bookId = intent.getIntExtra(EXTRA_bookId, -1)
+        chapter_1 = intent.getIntExtra(EXTRA_chapter, 0)
+        verse_1 = intent.getIntExtra(EXTRA_verse, 0)
 
-        setContent {
-            BibleAppTheme {
-                GotoScreen(
-                    initialBookId = initialBookId,
-                    initialChapter_1 = initialChapter,
-                    initialVerse_1 = initialVerse,
-                    onUp = { finish() },
-                    onGotoFinished = { tab, bookId, chapter, verse ->
-                        Preferences.setInt(Prefkey.goto_last_tab, tab.ordinal1Based)
-                        val data = Intent().apply {
-                            putExtra(EXTRA_bookId, bookId)
-                            putExtra(EXTRA_chapter, chapter)
-                            putExtra(EXTRA_verse, verse)
-                        }
-                        setResult(RESULT_OK, data)
-                        finish()
-                    },
-                )
+        useCompose = ExperimentalFlags.useComposeGoto()
+
+        if (useCompose) {
+            setContent {
+                BibleAppTheme {
+                    GotoScreen(
+                        initialBookId = bookId,
+                        initialChapter_1 = chapter_1,
+                        initialVerse_1 = verse_1,
+                        onUp = { finish() },
+                        onGotoFinished = { tab, bookId, chapter, verse ->
+                            Preferences.setInt(Prefkey.goto_last_tab, tab.ordinal1Based)
+                            val data = Intent().apply {
+                                putExtra(EXTRA_bookId, bookId)
+                                putExtra(EXTRA_chapter, chapter)
+                                putExtra(EXTRA_verse, verse)
+                            }
+                            setResult(RESULT_OK, data)
+                            finish()
+                        },
+                    )
+                }
+            }
+        } else {
+            setupLegacyUi(savedInstanceState)
+        }
+    }
+
+    private fun setupLegacyUi(savedInstanceState: Bundle?) {
+        setContentView(R.layout.activity_goto)
+
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+        supportActionBar?.apply {
+            setDisplayShowTitleEnabled(false)
+            setDisplayHomeAsUpEnabled(true)
+        }
+        toolbar.setNavigationOnClickListener { navigateUp() }
+
+        val viewPager = findViewById<ViewPager>(R.id.viewPager)
+        this.viewPager = viewPager
+        viewPager.adapter = GotoPagerAdapter(supportFragmentManager)
+        viewPager.addOnPageChangeListener(object : ViewPager.SimpleOnPageChangeListener() {
+            override fun onPageSelected(position: Int) {
+                if (okToHideKeyboard && position != 1) {
+                    val editText = findViewById<View?>(R.id.tDirectReference)
+                    if (editText != null) {
+                        val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                        imm.hideSoftInputFromWindow(editText.windowToken, InputMethodManager.HIDE_IMPLICIT_ONLY)
+                        imm.hideSoftInputFromWindow(editText.windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
+                    }
+                }
+            }
+        })
+
+        val tablayout = findViewById<TabLayout>(R.id.tablayout)
+        tablayout.tabMode = TabLayout.MODE_SCROLLABLE
+        tablayout.setupWithViewPager(viewPager)
+
+        if (savedInstanceState == null) {
+            val tabUsed = Preferences.getInt(Prefkey.goto_last_tab, 0)
+            if (tabUsed in 1..3) {
+                viewPager.setCurrentItem(tabUsed - 1, false)
+            }
+
+            if (tabUsed == 2) {
+                viewPager.postDelayed({
+                    val editText = findViewById<View?>(R.id.tDirectReference)
+                    if (editText != null) {
+                        val imm = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
+                        imm.showSoftInput(editText, InputMethodManager.SHOW_IMPLICIT)
+                    }
+                    okToHideKeyboard = true
+                }, 100)
+            } else {
+                okToHideKeyboard = true
+            }
+        } else {
+            viewPager.setCurrentItem(savedInstanceState.getInt(INSTANCE_STATE_tab, 0), false)
+        }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        if (useCompose) return super.onCreateOptionsMenu(menu)
+
+        menuInflater.inflate(R.menu.activity_goto, menu)
+        return true
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu): Boolean {
+        if (!useCompose) {
+            val menuAskForVerse = menu.findItem(R.id.menuAskForVerse)
+            val v = Preferences.getBoolean(Prefkey.gotoAskForVerse, GOTO_ASK_FOR_VERSE_DEFAULT)
+            menuAskForVerse.isChecked = v
+        }
+        return super.onPrepareOptionsMenu(menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (!useCompose && item.itemId == R.id.menuAskForVerse) {
+            val v = Preferences.getBoolean(Prefkey.gotoAskForVerse, GOTO_ASK_FOR_VERSE_DEFAULT)
+            Preferences.setBoolean(Prefkey.gotoAskForVerse, !v)
+            invalidateOptionsMenu()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        if (!useCompose) {
+            viewPager?.let { outState.putInt(INSTANCE_STATE_tab, it.currentItem) }
+        }
+    }
+
+    private inner class GotoPagerAdapter(fm: FragmentManager) : FragmentPagerAdapter(fm) {
+        private val pageTitleResIds = intArrayOf(
+            R.string.goto_tab_dialer_label,
+            R.string.goto_tab_direct_label,
+            R.string.goto_tab_grid_label,
+        )
+
+        override fun getItem(position: Int): Fragment {
+            return when (position) {
+                0 -> Fragment.instantiate(this@GotoActivity, GotoDialerFragment::class.java.name, GotoDialerFragment.createArgs(bookId, chapter_1, verse_1))
+                1 -> Fragment.instantiate(this@GotoActivity, GotoDirectFragment::class.java.name, GotoDirectFragment.createArgs(bookId, chapter_1, verse_1))
+                else -> Fragment.instantiate(this@GotoActivity, GotoGridFragment::class.java.name, GotoGridFragment.createArgs(bookId, chapter_1, verse_1))
             }
         }
+
+        override fun getCount(): Int = pageTitleResIds.size
+
+        override fun getPageTitle(position: Int): CharSequence = getString(pageTitleResIds[position])
+    }
+
+    override fun onGotoFinished(gotoTabUsed: Int, bookId: Int, chapter_1: Int, verse_1: Int) {
+        Preferences.setInt(Prefkey.goto_last_tab, gotoTabUsed)
+
+        val data = Intent().apply {
+            putExtra(EXTRA_bookId, bookId)
+            putExtra(EXTRA_chapter, chapter_1)
+            putExtra(EXTRA_verse, verse_1)
+        }
+        setResult(RESULT_OK, data)
+        finish()
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/fr/GotoDialerFragment.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/fr/GotoDialerFragment.java
@@ -1,0 +1,360 @@
+package yuku.alkitab.base.fr;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.BaseAdapter;
+import android.widget.Button;
+import android.widget.CheckedTextView;
+import android.widget.Spinner;
+import android.widget.TextView;
+import yuku.afw.storage.Preferences;
+import yuku.alkitab.base.S;
+import yuku.alkitab.base.fr.base.BaseGotoFragment;
+import yuku.alkitab.base.storage.Prefkey;
+import yuku.alkitab.base.storage.PrefkeyKt;
+import yuku.alkitab.base.util.BookColorUtil;
+import yuku.alkitab.base.util.BookNameSorter;
+import yuku.alkitab.debug.R;
+import yuku.alkitab.model.Book;
+
+public class GotoDialerFragment extends BaseGotoFragment {
+	private static final String EXTRA_verse = "verse";
+	private static final String EXTRA_chapter = "chapter";
+	private static final String EXTRA_bookId = "bookId";
+
+	TextView active;
+	TextView passive;
+
+	Button bOk;
+	TextView tChapter;
+	View tChapterLabel;
+	TextView tVerse;
+	View tVerseLabel;
+	Spinner cbBook;
+
+	boolean tChapter_firstTime = true;
+	boolean tVerse_firstTime = true;
+
+	int maxChapter = 0;
+	int maxVerse = 0;
+	BookAdapter adapter;
+	
+	int bookId;
+	int chapter_1;
+	int verse_1;
+	
+	public static Bundle createArgs(int bookId, int chapter_1, int verse_1) {
+		Bundle args = new Bundle();
+		args.putInt(EXTRA_bookId, bookId);
+		args.putInt(EXTRA_chapter, chapter_1);
+		args.putInt(EXTRA_verse, verse_1);
+		return args;
+	}
+
+	@Override public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		
+		Bundle args = getArguments();
+		if (args != null) {
+			bookId = args.getInt(EXTRA_bookId, -1);
+			chapter_1 = args.getInt(EXTRA_chapter);
+			verse_1 = args.getInt(EXTRA_verse);
+		}
+	}
+
+	@Override public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+		View res = inflater.inflate(R.layout.fragment_goto_dialer, container, false);
+
+		bOk = res.findViewById(R.id.bOk);
+		tChapter = res.findViewById(R.id.tChapter);
+		tChapterLabel = res.findViewById(R.id.tChapterLabel);
+		tVerse = res.findViewById(R.id.tVerse);
+		tVerseLabel = res.findViewById(R.id.tVerseLabel);
+		cbBook = res.findViewById(R.id.cbBook);
+		cbBook.setAdapter(adapter = new BookAdapter());
+
+		tChapter.setOnClickListener(tChapter_click);
+		tChapterLabel.setOnClickListener(tChapter_click);
+
+		tVerse.setOnClickListener(tVerse_click);
+		tVerseLabel.setOnClickListener(tVerse_click);
+
+		res.findViewById(R.id.bDigit0).setOnClickListener(button_click);
+		res.findViewById(R.id.bDigit1).setOnClickListener(button_click);
+		res.findViewById(R.id.bDigit2).setOnClickListener(button_click);
+		res.findViewById(R.id.bDigit3).setOnClickListener(button_click);
+		res.findViewById(R.id.bDigit4).setOnClickListener(button_click);
+		res.findViewById(R.id.bDigit5).setOnClickListener(button_click);
+		res.findViewById(R.id.bDigit6).setOnClickListener(button_click);
+		res.findViewById(R.id.bDigit7).setOnClickListener(button_click);
+		res.findViewById(R.id.bDigit8).setOnClickListener(button_click);
+		res.findViewById(R.id.bDigit9).setOnClickListener(button_click);
+		res.findViewById(R.id.bDigitBackspace).setOnClickListener(button_click);
+
+		showOrHideVerse();
+		Preferences.registerObserver(preferenceChangeListener);
+
+		return res;
+	}
+
+	@Override
+	public void onDestroy() {
+		super.onDestroy();
+
+		Preferences.unregisterObserver(preferenceChangeListener);
+	}
+
+	final SharedPreferences.OnSharedPreferenceChangeListener preferenceChangeListener = (sharedPreferences, key) -> {
+		if (key.equals(Prefkey.gotoAskForVerse.name())) {
+			showOrHideVerse();
+		}
+	};
+
+	void showOrHideVerse() {
+		if (Preferences.getBoolean(Prefkey.gotoAskForVerse, PrefkeyKt.GOTO_ASK_FOR_VERSE_DEFAULT)) {
+			tVerse.setVisibility(View.VISIBLE);
+			tVerseLabel.setVisibility(View.VISIBLE);
+		} else {
+			if (active == tVerse) {
+				activate(tChapter, tVerse);
+			}
+			tVerse.setVisibility(View.GONE);
+			tVerseLabel.setVisibility(View.GONE);
+		}
+	}
+
+	@Override public void onActivityCreated(Bundle savedInstanceState) {
+		super.onActivityCreated(savedInstanceState);
+
+		// check current bookId, chapter, and verse
+		cbBook.setSelection(adapter.getPositionFromBookId(bookId));
+		cbBook.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+			@Override public void onNothingSelected(AdapterView<?> parent) {}
+
+			@Override
+			public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+				Book book = adapter.getItem(position);
+				maxChapter = book.chapter_count;
+
+				int chapter_0 = tryReadChapter() - 1;
+				if (chapter_0 >= 0 && chapter_0 < book.chapter_count) {
+					maxVerse = book.verse_counts[chapter_0];
+				}
+
+				fixChapterOverflow();
+				fixVerseOverflow();
+			}
+		});
+
+		bOk.setOnClickListener(v -> {
+			int selectedChapter_1 = 0;
+			int selectedVerse_1 = 0;
+
+			try {
+				selectedChapter_1 = Integer.parseInt(tChapter.getText().toString());
+
+				if (Preferences.getBoolean(Prefkey.gotoAskForVerse, PrefkeyKt.GOTO_ASK_FOR_VERSE_DEFAULT)) {
+					selectedVerse_1 = Integer.parseInt(tVerse.getText().toString());
+				}
+			} catch (NumberFormatException e) {
+				// let it still be 0
+			}
+
+			final int selectedBookId = adapter.getItem(cbBook.getSelectedItemPosition()).bookId;
+
+			final GotoFinishListener activity = (GotoFinishListener) getActivity();
+			if (activity != null) {
+				activity.onGotoFinished(GotoFinishListener.GOTO_TAB_dialer, selectedBookId, selectedChapter_1, selectedVerse_1);
+			}
+		});
+
+		active = tChapter;
+		passive = tVerse;
+
+		{
+			if (chapter_1 != 0) {
+				tChapter.setText(String.valueOf(chapter_1));
+			}
+			if (verse_1 != 0) {
+				tVerse.setText(String.valueOf(verse_1));
+			}
+		}
+
+		colorize();
+	}
+
+	final View.OnClickListener tChapter_click = v -> activate(tChapter, tVerse);
+
+	final View.OnClickListener tVerse_click = v -> activate(tVerse, tChapter);
+
+	final View.OnClickListener button_click = v -> {
+		final int id = v.getId();
+		if (id == R.id.bDigit0) press("0");
+		else if (id == R.id.bDigit1) press("1");
+		else if (id == R.id.bDigit2) press("2");
+		else if (id == R.id.bDigit3) press("3");
+		else if (id == R.id.bDigit4) press("4");
+		else if (id == R.id.bDigit5) press("5");
+		else if (id == R.id.bDigit6) press("6");
+		else if (id == R.id.bDigit7) press("7");
+		else if (id == R.id.bDigit8) press("8");
+		else if (id == R.id.bDigit9) press("9");
+		else if (id == R.id.bDigitBackspace) press("backspace");
+	};
+
+	int tryReadChapter() {
+		try {
+			return Integer.parseInt("0" + tChapter.getText().toString());
+		} catch (NumberFormatException e) {
+			return 0;
+		}
+	}
+
+	int tryReadVerse() {
+		try {
+			return Integer.parseInt("0" + tVerse.getText().toString());
+		} catch (NumberFormatException e) {
+			return 0;
+		}
+	}
+
+	void fixVerseOverflow() {
+		int verse = tryReadVerse();
+
+		if (verse > maxVerse) {
+			verse = maxVerse;
+		} else if (verse <= 0) {
+			verse = 1;
+		}
+
+		tVerse.setText(String.valueOf(verse));
+	}
+
+	void fixChapterOverflow() {
+		int chapter = tryReadChapter();
+
+		if (chapter > maxChapter) {
+			chapter = maxChapter;
+		} else if (chapter <= 0) {
+			chapter = 1;
+		}
+
+		tChapter.setText(String.valueOf(chapter));
+	}
+
+	void press(String s) {
+		if (active != null) {
+			if (s.equals("backspace")) {
+				if (active.length() > 0) {
+					final CharSequence txt = active.getText();
+					active.setText(TextUtils.substring(txt, 0, txt.length() - 1));
+				}
+				return;
+			}
+
+			if (active == tChapter) {
+				if (tChapter_firstTime) {
+					active.setText(s);
+					tChapter_firstTime = false;
+				} else {
+					active.append(s);
+				}
+
+				if (tryReadChapter() > maxChapter || tryReadChapter() <= 0) {
+					active.setText(s);
+				}
+				
+				Book book = adapter.getItem(cbBook.getSelectedItemPosition());
+				int chapter_1 = tryReadChapter();
+				if (chapter_1 >= 1 && chapter_1 <= book.verse_counts.length) {
+					maxVerse = book.verse_counts[chapter_1 - 1];
+				}
+			} else if (active == tVerse) {
+				if (tVerse_firstTime) {
+					active.setText(s);
+					tVerse_firstTime = false;
+				} else {
+					active.append(s);
+				}
+
+				if (tryReadVerse() > maxVerse || tryReadVerse() <= 0) {
+					active.setText(s);
+				}
+			}
+		}
+	}
+
+	void activate(TextView active, TextView passive) {
+		this.active = active;
+		this.passive = passive;
+		colorize();
+	}
+
+	private void colorize() {
+		if (active != null) active.setBackgroundResource(R.drawable.goto_dialer_active);
+		if (passive != null) passive.setBackgroundColor(0x0);
+	}
+
+	private class BookAdapter extends BaseAdapter {
+		Book[] booksc_;
+		
+		public BookAdapter() {
+			Book[] booksc = S.activeVersion().getConsecutiveBooks();
+			
+			if (Preferences.getBoolean(R.string.pref_alphabeticBookSort_key, R.bool.pref_alphabeticBookSort_default)) {
+				booksc_ = BookNameSorter.sortAlphabetically(booksc); 
+			} else {
+				booksc_ = booksc.clone();
+			}
+		}
+
+		/**
+		 * @return 0 when not found (not -1, because we just want to select the first book)
+		 */
+		public int getPositionFromBookId(int pos) {
+			for (int i = 0; i < booksc_.length; i++) {
+				if (booksc_[i].bookId == pos) {
+					return i;
+				}
+			}
+			return 0;
+		}
+
+		@Override public int getCount() {
+			return booksc_.length;
+		}
+
+		@Override public Book getItem(int position) {
+			return booksc_[position];
+		}
+
+		@Override public long getItemId(int position) {
+			return position;
+		}
+
+		@Override public View getView(int position, View convertView, ViewGroup parent) {
+			TextView res = (TextView) (convertView != null ? convertView : LayoutInflater.from(parent.getContext()).inflate(R.layout.item_goto_dialer_book, parent, false));
+
+			final Book book = getItem(position);
+			res.setText(booksc_[position].shortName);
+			res.setTextColor(BookColorUtil.getForegroundOnDark(book.bookId));
+
+			return res;
+		}
+
+		@Override public View getDropDownView(int position, View convertView, ViewGroup parent) {
+			CheckedTextView res = (CheckedTextView) (convertView != null ? convertView : LayoutInflater.from(parent.getContext()).inflate(R.layout.item_goto_dialer_book_dropdown, parent, false));
+
+			final Book book = getItem(position);
+			res.setText(book.shortName);
+			res.setTextColor(BookColorUtil.getForegroundOnDark(book.bookId));
+
+			return res;
+		}
+	}
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/fr/GotoDirectFragment.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/fr/GotoDirectFragment.java
@@ -1,0 +1,320 @@
+package yuku.alkitab.base.fr;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.text.SpannableStringBuilder;
+import android.text.TextUtils;
+import android.util.SparseArray;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AutoCompleteTextView;
+import android.widget.Filter;
+import android.widget.Filterable;
+import android.widget.TextView;
+import androidx.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import yuku.afw.widget.EasyAdapter;
+import yuku.alkitab.base.S;
+import yuku.alkitab.base.fr.base.BaseGotoFragment;
+import yuku.alkitab.base.util.Jumper;
+import yuku.alkitab.base.util.Levenshtein;
+import yuku.alkitab.base.widget.MaterialDialogJavaHelper;
+import yuku.alkitab.debug.R;
+import yuku.alkitab.model.Book;
+
+public class GotoDirectFragment extends BaseGotoFragment {
+	private static final String EXTRA_verse = "verse";
+	private static final String EXTRA_chapter = "chapter";
+	private static final String EXTRA_bookId = "bookId";
+
+	TextView lDirectSample;
+	AutoCompleteTextView tDirectReference;
+	View bOk;
+
+	AutoCompleteAdapter adapter;
+
+	int bookId;
+	int chapter_1;
+	int verse_1;
+	GotoFinishListener listener;
+
+	static class Candidate {
+		String title;
+		int score;
+		boolean bookOnly;
+	}
+
+	public static Bundle createArgs(int bookId, int chapter_1, int verse_1) {
+		Bundle args = new Bundle();
+		args.putInt(EXTRA_bookId, bookId);
+		args.putInt(EXTRA_chapter, chapter_1);
+		args.putInt(EXTRA_verse, verse_1);
+		return args;
+	}
+
+	@Override
+	public void onAttach(final Context context) {
+		super.onAttach(context);
+
+		this.listener = (GotoFinishListener) context;
+	}
+
+	@Override public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		
+		Bundle args = getArguments();
+		if (args != null) {
+			bookId = args.getInt(EXTRA_bookId, -1);
+			chapter_1 = args.getInt(EXTRA_chapter);
+			verse_1 = args.getInt(EXTRA_verse);
+		}
+	}
+
+	@Override public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+		View res = inflater.inflate(R.layout.fragment_goto_direct, container, false);
+		lDirectSample = res.findViewById(R.id.lDirectSample);
+
+		tDirectReference = res.findViewById(R.id.tDirectReference);
+		tDirectReference.setAdapter(adapter = new AutoCompleteAdapter());
+		tDirectReference.setOnItemClickListener((parent, view, position, id) -> {
+			if (!adapter.getItem(position).bookOnly) {
+				bOk.performClick();
+			}
+		});
+
+		bOk = res.findViewById(R.id.bOk);
+		bOk.setOnClickListener(bOk_click);
+
+		tDirectReference.setOnEditorActionListener((v, actionId, event) -> {
+			bOk_click.onClick(bOk);
+			return true;
+		});
+		return res;
+	}
+
+	@Override public void onActivityCreated(Bundle savedInstanceState) {
+		super.onActivityCreated(savedInstanceState);
+
+		final String example = S.activeVersion().reference(bookId, chapter_1, verse_1);
+		final CharSequence text = getText(R.string.jump_to_prompt);
+		SpannableStringBuilder sb = new SpannableStringBuilder();
+		sb.append(text);
+		final CharSequence text2 = TextUtils.expandTemplate(text, example);
+		lDirectSample.setText(text2);
+	}
+	
+	View.OnClickListener bOk_click = new View.OnClickListener() {
+		public Pattern nobookPattern;
+
+		@Override public void onClick(View v) {
+			String reference = tDirectReference.getText().toString();
+			
+			if (reference.trim().length() == 0) {
+				return; // do nothing
+			}
+
+			// typing chapter or chapter:verse was broken sometime. Let us make a special case to handle this.
+			if (nobookPattern == null) {
+				nobookPattern = Pattern.compile("(\\d+)(?:[ :.]+(\\d+))?");
+			}
+
+			final Matcher m = nobookPattern.matcher(reference.trim());
+			if (m.matches()) {
+				try {
+					final String chapter_s = m.group(1);
+					final int chapter_1 = Integer.parseInt(chapter_s);
+
+					final String verse_s = m.group(2);
+					final int verse_1;
+					if (verse_s != null) {
+						verse_1 = Integer.parseInt(verse_s);
+					} else {
+						verse_1 = 0;
+					}
+
+					listener.onGotoFinished(GotoFinishListener.GOTO_TAB_direct, bookId, chapter_1, verse_1);
+					return;
+				} catch (NumberFormatException ignored) {}
+			}
+
+			final Jumper jumper = new Jumper(reference);
+			if (! jumper.getParseSucceeded()) {
+				MaterialDialogJavaHelper.showOkDialog(requireActivity(), getString(R.string.alamat_tidak_sah_alamat, reference));
+				return;
+			}
+			
+			final int bookId = jumper.getBookId(S.activeVersion().getConsecutiveBooks());
+			final int chapter = jumper.getChapter();
+			final int verse = jumper.getVerse();
+
+			listener.onGotoFinished(GotoFinishListener.GOTO_TAB_direct, bookId, chapter, verse);
+		}
+	};
+
+	class AutoCompleteAdapter extends EasyAdapter implements Filterable {
+		final List<Candidate> candidates = new ArrayList<>();
+
+		@Override
+		public View newView(final int position, final ViewGroup parent) {
+			return getActivity().getLayoutInflater().inflate(androidx.appcompat.R.layout.support_simple_spinner_dropdown_item, parent, false);
+		}
+
+		@Override
+		public void bindView(final View view, final int position, final ViewGroup parent) {
+			final TextView tv = (TextView) view;
+			final Candidate candidate = getItem(position);
+			tv.setText(candidate.title);
+		}
+
+		@Override
+		public int getCount() {
+			return candidates.size();
+		}
+
+		/**
+		 * This may not be removed, or the {@link android.widget.AutoCompleteTextView#setOnItemClickListener(android.widget.AdapterView.OnItemClickListener)} won't work!
+		 */
+		@Override
+		public Candidate getItem(final int position) {
+			return candidates.get(position);
+		}
+
+		@Override
+		public Filter getFilter() {
+			return new Filter() {
+				final Book[] books = S.activeVersion().getConsecutiveBooks();
+				final SparseArray<Book> bookIndex = new SparseArray<>();
+				{
+					for (final Book book : books) {
+						bookIndex.put(book.bookId, book);
+					}
+				}
+
+				List<Jumper.BookRef> bookRefs;
+
+				@Override
+				protected FilterResults performFiltering(@Nullable final CharSequence constraint) {
+					final FilterResults res = new FilterResults();
+
+					if (constraint == null) {
+						res.values = null;
+						res.count = 0;
+						return res;
+					}
+
+					final Jumper jumper = new Jumper(constraint.toString());
+					String bookName = jumper.getUnparsedBook();
+
+					final ArrayList<Candidate> candidates = new ArrayList<>();
+					if (bookName != null) {
+						bookName = bookName.trim().toLowerCase();
+						if (bookName.length() >= 1) {
+							final Set<Integer> addedBookIds = new HashSet<>();
+
+							for (final Book book : books) {
+								String title = null;
+								int score = 0;
+
+								final String n = book.shortName.toLowerCase();
+								if (n.startsWith(bookName)) {
+									title = book.shortName;
+									score = 20;
+								} else if (n.contains(bookName)) {
+									title = book.shortName;
+									score = 10;
+								}
+
+								if (score != 0) {
+									addCandidate(jumper, candidates, title, score, book);
+									addedBookIds.add(book.bookId);
+								}
+							}
+
+							// now try the levenstein
+							if (candidates.size() < 5) {
+								List<Jumper.BookRef> _bookRefs = this.bookRefs;
+								if (_bookRefs == null) {
+									this.bookRefs = _bookRefs = Jumper.createBookCandidates(books);
+								}
+
+								for (final Jumper.BookRef bookRef : _bookRefs) {
+									if (addedBookIds.contains(bookRef.getBookId())) continue;
+
+									final int distance = Levenshtein.distance(bookName, bookRef.getCondensed());
+									final Book book = bookIndex.get(bookRef.getBookId());
+									addCandidate(jumper, candidates, book.shortName, -distance, book);
+									addedBookIds.add(bookRef.getBookId());
+								}
+							}
+						}
+					}
+
+					Collections.sort(candidates, (lhs, rhs) -> rhs.score - lhs.score);
+
+					res.count = candidates.size();
+					res.values = candidates;
+					return res;
+				}
+
+				private void addCandidate(final Jumper jumper, final ArrayList<Candidate> values, String title, final int score, final Book book) {
+					boolean bookOnly = true;
+
+					// try to add chapter and verse
+					final int chapter_1 = jumper.getChapter();
+					if (chapter_1 != 0) {
+						bookOnly = false;
+						title += " " + chapter_1;
+						final int verse_1 = jumper.getVerse();
+						if (verse_1 != 0) {
+							title += ":" + verse_1;
+						}
+
+						// do not add if the chapter is unavailable
+						if (chapter_1 < 1 || chapter_1 > book.chapter_count) {
+							return;
+						} else {
+							if (verse_1 != 0 && (verse_1 < 1 || verse_1 > book.verse_counts[chapter_1 - 1])) {
+								return;
+							}
+						}
+					}
+
+					final Candidate c = new Candidate();
+					c.title = title;
+					c.score = score;
+					c.bookOnly = bookOnly;
+					values.add(c);
+				}
+
+				@Override
+				protected void publishResults(final CharSequence constraint, final FilterResults results) {
+					candidates.clear();
+
+					if (results.values != null) {
+						//noinspection unchecked
+						candidates.addAll((List<Candidate>) results.values);
+					}
+
+					notifyDataSetChanged();
+				}
+
+				@Override
+				public CharSequence convertResultToString(final Object resultValue) {
+					final Candidate c = (Candidate) resultValue;
+					if (c.bookOnly) {
+						return c.title + " "; // for user to start typing the chapter number
+					}
+
+					return c.title;
+				}
+			};
+		}
+	}
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/fr/GotoGridFragment.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/fr/GotoGridFragment.java
@@ -1,0 +1,384 @@
+package yuku.alkitab.base.fr;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import yuku.afw.storage.Preferences;
+import yuku.alkitab.base.S;
+import yuku.alkitab.base.fr.base.BaseGotoFragment;
+import yuku.alkitab.base.storage.Prefkey;
+import yuku.alkitab.base.storage.PrefkeyKt;
+import yuku.alkitab.base.util.AppLog;
+import yuku.alkitab.base.util.BookColorUtil;
+import yuku.alkitab.base.util.BookNameSorter;
+import yuku.alkitab.debug.R;
+import yuku.alkitab.model.Book;
+
+public class GotoGridFragment extends BaseGotoFragment {
+	static final String TAG = GotoGridFragment.class.getSimpleName();
+
+	private static final String EXTRA_verse = "verse";
+	private static final String EXTRA_chapter = "chapter";
+	private static final String EXTRA_bookId = "bookId";
+
+	private static final int ANIM_DURATION = 200;
+
+	View panelChapterVerse;
+	TextView lSelectedBook;
+	TextView lSelectedChapter;
+	RecyclerView gridBook;
+	RecyclerView gridChapter;
+	RecyclerView gridVerse;
+
+	Book[] books;
+	BookAdapter bookAdapter;
+	ChapterAdapter chapterAdapter;
+	VerseAdapter verseAdapter;
+
+	@Nullable
+	Book selectedBook;
+	int selectedChapter;
+
+	final View.OnClickListener lSelectedBook_click = v -> {
+		AppLog.d(TAG, "@@lSelectedBook_click: selectedBook = null");
+		selectedBook = null;
+		selectedChapter = 0;
+		transitionChapterToBook();
+	};
+
+	final View.OnClickListener lSelectedChapter_click = v -> {
+		selectedChapter = 0;
+		transitionVerseToChapter();
+	};
+
+	void transitionBookToChapter() {
+		AppLog.d(TAG, "@@transitionBookToChapter selectedBook=" + selectedBook);
+		if (selectedBook == null) return;
+
+		gridBook.setVisibility(View.INVISIBLE);
+		panelChapterVerse.setVisibility(View.VISIBLE);
+		gridChapter.setVisibility(View.VISIBLE);
+		gridChapter.setAdapter(chapterAdapter = new ChapterAdapter(selectedBook));
+		gridVerse.setVisibility(View.INVISIBLE);
+
+		animateFadeOutAndSlideLeft(gridBook, gridChapter);
+		lSelectedBook.jumpDrawablesToCurrentState();
+		lSelectedBook.setAlpha(0.f);
+		lSelectedBook.animate().alpha(1.f).setDuration(ANIM_DURATION);
+
+		displaySelectedBookAndChapter();
+	}
+
+	void transitionBookToVerse() {
+		AppLog.d(TAG, "@@transitionBookToVerse selectedBook=" + selectedBook);
+		if (selectedBook == null) return;
+
+		gridBook.setVisibility(View.INVISIBLE);
+		panelChapterVerse.setVisibility(View.VISIBLE);
+		gridVerse.setVisibility(View.VISIBLE);
+		gridVerse.setAdapter(verseAdapter = new VerseAdapter(selectedBook, selectedChapter));
+		gridChapter.setVisibility(View.INVISIBLE);
+
+		animateFadeOutAndSlideLeft(gridBook, gridVerse);
+		lSelectedBook.jumpDrawablesToCurrentState();
+		lSelectedBook.setAlpha(0.f);
+		lSelectedBook.animate().alpha(1.f).setDuration(ANIM_DURATION);
+
+		displaySelectedBookAndChapter();
+	}
+
+	void transitionChapterToBook() {
+		AppLog.d(TAG, "@@transitionChapterToBook");
+
+		gridBook.setVisibility(View.VISIBLE);
+		panelChapterVerse.setVisibility(View.INVISIBLE);
+
+		animateFadeOutAndSlideRight(gridChapter, gridBook);
+	}
+
+	void transitionChapterToVerse() {
+		AppLog.d(TAG, "@@transitionChapterToVerse selectedBook=" + selectedBook + " selectedChapter=" + selectedChapter);
+		if (selectedBook == null) return;
+
+		gridBook.setVisibility(View.INVISIBLE);
+		panelChapterVerse.setVisibility(View.VISIBLE);
+		gridChapter.setVisibility(View.INVISIBLE);
+		gridVerse.setVisibility(View.VISIBLE);
+		gridVerse.setAdapter(verseAdapter = new VerseAdapter(selectedBook, selectedChapter));
+
+		animateFadeOutAndSlideLeft(gridChapter, gridVerse);
+
+		displaySelectedBookAndChapter();
+	}
+
+	void transitionVerseToChapter() {
+		AppLog.d(TAG, "@@transitionVerseToChapter");
+
+		gridBook.setVisibility(View.INVISIBLE);
+		panelChapterVerse.setVisibility(View.VISIBLE);
+		gridChapter.setVisibility(View.VISIBLE);
+		gridChapter.setAdapter(chapterAdapter = new ChapterAdapter(selectedBook));
+		gridVerse.setVisibility(View.INVISIBLE);
+
+		animateFadeOutAndSlideRight(gridVerse, gridChapter);
+
+		displaySelectedBookAndChapter();
+	}
+
+	static void animateFadeOutAndSlideLeft(final View fadingOut, final View slidingLeft) {
+		fadingOut.setVisibility(View.VISIBLE);
+		fadingOut.animate().alpha(0.f).setDuration(ANIM_DURATION).setListener(new AnimatorListenerAdapter() {
+			@Override
+			public void onAnimationEnd(Animator animation) {
+				fadingOut.setAlpha(1.f);
+				fadingOut.setVisibility(View.INVISIBLE);
+			}
+		});
+		slidingLeft.setX(slidingLeft.getWidth());
+		slidingLeft.animate().translationXBy(-slidingLeft.getWidth()).setDuration(ANIM_DURATION).setListener(new AnimatorListenerAdapter() {
+			@Override
+			public void onAnimationEnd(Animator animation) {
+				slidingLeft.setVisibility(View.VISIBLE);
+			}
+		});
+	}
+
+	static void animateFadeOutAndSlideRight(final View fadingOut, final View slidingRight) {
+		fadingOut.setVisibility(View.VISIBLE);
+		fadingOut.animate().alpha(0.f).setDuration(ANIM_DURATION).setListener(new AnimatorListenerAdapter() {
+			@Override
+			public void onAnimationEnd(Animator animation) {
+				fadingOut.setAlpha(1.f);
+				fadingOut.setVisibility(View.INVISIBLE);
+			}
+		});
+		slidingRight.setX(-slidingRight.getWidth());
+		slidingRight.animate().translationXBy(slidingRight.getWidth()).setDuration(ANIM_DURATION).setListener(new AnimatorListenerAdapter() {
+			@Override
+			public void onAnimationEnd(Animator animation) {
+				slidingRight.setVisibility(View.VISIBLE);
+			}
+		});
+	}
+
+	public static Bundle createArgs(int bookId, int chapter_1, int verse_1) {
+		Bundle args = new Bundle();
+		args.putInt(EXTRA_bookId, bookId);
+		args.putInt(EXTRA_chapter, chapter_1);
+		args.putInt(EXTRA_verse, verse_1);
+		return args;
+	}
+
+	protected void displaySelectedBookAndChapter() {
+		// Prevent crash when this is suddenly null
+		if (selectedBook == null) return;
+
+		lSelectedBook.setText(selectedBook.shortName);
+		lSelectedBook.setTextColor(BookColorUtil.getForegroundOnDark(selectedBook.bookId));
+		if (selectedChapter == 0) {
+			lSelectedChapter.setVisibility(View.GONE);
+		} else {
+			lSelectedChapter.setVisibility(View.VISIBLE);
+			lSelectedChapter.jumpDrawablesToCurrentState();
+			lSelectedChapter.setText(String.valueOf(selectedChapter));
+		}
+	}
+
+	GridLayoutManager createLayoutManagerForNumbers() {
+		return new GridLayoutManager(getActivity(), getResources().getInteger(R.integer.goto_grid_numeric_num_columns));
+	}
+
+	@Override
+	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+		View res = inflater.inflate(R.layout.fragment_goto_grid, container, false);
+		panelChapterVerse = res.findViewById(R.id.panelChapterVerse);
+		lSelectedBook = res.findViewById(R.id.lSelectedBook);
+		lSelectedChapter = res.findViewById(R.id.lSelectedChapter);
+
+		gridBook = res.findViewById(R.id.gridBook);
+		gridChapter = res.findViewById(R.id.gridChapter);
+		gridVerse = res.findViewById(R.id.gridVerse);
+
+		panelChapterVerse.setVisibility(View.INVISIBLE);
+		gridBook.setVisibility(View.VISIBLE);
+		gridChapter.setVisibility(View.INVISIBLE);
+		gridVerse.setVisibility(View.INVISIBLE);
+
+		gridBook.setLayoutManager(new GridLayoutManager(getActivity(), 6));
+		gridChapter.setLayoutManager(createLayoutManagerForNumbers());
+		gridVerse.setLayoutManager(createLayoutManagerForNumbers());
+
+		lSelectedBook.setOnClickListener(lSelectedBook_click);
+		lSelectedChapter.setOnClickListener(lSelectedChapter_click);
+
+		return res;
+	}
+
+	@Override
+	public void onActivityCreated(Bundle savedInstanceState) {
+		super.onActivityCreated(savedInstanceState);
+
+		books = S.activeVersion().getConsecutiveBooks();
+		gridBook.setAdapter(bookAdapter = new BookAdapter());
+	}
+
+	public class VH extends RecyclerView.ViewHolder {
+		public VH(final View itemView) {
+			super(itemView);
+		}
+	}
+
+	abstract class GridAdapter extends RecyclerView.Adapter<VH> {
+		@NonNull
+		@Override
+		public VH onCreateViewHolder(@NonNull final ViewGroup parent, final int viewType) {
+			return new VH(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_goto_grid_cell, parent, false));
+		}
+
+		@Override
+		public void onBindViewHolder(final VH holder, final int position) {
+			final TextView lName = (TextView) holder.itemView;
+			lName.setText(textForView(position));
+			lName.setTextColor(textColorForView(position));
+		}
+
+		abstract CharSequence textForView(int position);
+
+		int textColorForView(int position) {
+			return 0xffffffff;
+		}
+	}
+
+	class BookAdapter extends GridAdapter {
+		final Book[] books_grid;
+
+		public BookAdapter() {
+			// sort or not based on pref
+			if (Preferences.getBoolean(R.string.pref_alphabeticBookSort_key, R.bool.pref_alphabeticBookSort_default)) {
+				books_grid = BookNameSorter.sortAlphabetically(books);
+			} else {
+				books_grid = books.clone();
+			}
+		}
+
+		@Override
+		public int getItemCount() {
+			return books_grid.length;
+		}
+
+		@Override
+		public void onBindViewHolder(final VH holder, final int position) {
+			super.onBindViewHolder(holder, position); // must call this
+
+			holder.itemView.setOnClickListener(v -> {
+				selectedBook = bookAdapter.getItem(position);
+				AppLog.d(TAG, "@@BookAdapter#onBindViewHolder: selectedBook=" + selectedBook);
+				if (selectedBook == null) return;
+
+				if (selectedBook.chapter_count == 1) {
+					// for single-chapter books, jump directly to verse selection
+					selectedChapter = 1;
+					transitionBookToVerse();
+				} else {
+					transitionBookToChapter();
+				}
+			});
+		}
+
+		public Book getItem(int position) {
+			return books_grid[position];
+		}
+
+		@Override
+		CharSequence textForView(int position) {
+			Book book = getItem(position);
+
+			return BookNameSorter.getBookAbbr(book);
+		}
+
+		@Override
+		int textColorForView(final int position) {
+			final Book book = getItem(position);
+			return BookColorUtil.getForegroundOnDark(book.bookId);
+		}
+	}
+
+	class ChapterAdapter extends GridAdapter {
+		private final Book book;
+
+		public ChapterAdapter(Book book) {
+			this.book = book;
+		}
+
+		@Override
+		public int getItemCount() {
+			return book.chapter_count;
+		}
+
+		@Override
+		public void onBindViewHolder(final VH holder, final int position) {
+			super.onBindViewHolder(holder, position); // must call this
+
+			holder.itemView.setOnClickListener(v -> {
+				selectedChapter = position + 1;
+
+				if (Preferences.getBoolean(Prefkey.gotoAskForVerse, PrefkeyKt.GOTO_ASK_FOR_VERSE_DEFAULT)) {
+					transitionChapterToVerse();
+				} else {
+					final GotoFinishListener activity = (GotoFinishListener) getActivity();
+					if (activity != null && selectedBook != null) {
+						activity.onGotoFinished(GotoFinishListener.GOTO_TAB_grid, selectedBook.bookId, selectedChapter, 0);
+					}
+				}
+			});
+		}
+
+		@Override
+		CharSequence textForView(int position) {
+			return String.valueOf(position + 1);
+		}
+	}
+
+	class VerseAdapter extends GridAdapter {
+		@NonNull
+		private final Book book;
+		private final int chapter_1;
+
+		public VerseAdapter(@NonNull Book book, int chapter_1) {
+			this.book = book;
+			this.chapter_1 = chapter_1;
+		}
+
+		@Override
+		public int getItemCount() {
+			int chapter_0 = chapter_1 - 1;
+			return chapter_0 < 0 || chapter_0 >= book.verse_counts.length ? 0 : book.verse_counts[chapter_0];
+		}
+
+		@Override
+		public void onBindViewHolder(final VH holder, final int position) {
+			super.onBindViewHolder(holder, position);
+
+			holder.itemView.setOnClickListener(v -> {
+				final int selectedVerse = position + 1;
+				final GotoFinishListener activity = (GotoFinishListener) getActivity();
+				if (activity != null && selectedBook != null) {
+					activity.onGotoFinished(GotoFinishListener.GOTO_TAB_grid, selectedBook.bookId, selectedChapter, selectedVerse);
+				}
+			});
+		}
+
+		@Override
+		CharSequence textForView(int position) {
+			return String.valueOf(position + 1);
+		}
+	}
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/fr/base/BaseGotoFragment.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/fr/base/BaseGotoFragment.java
@@ -1,0 +1,11 @@
+package yuku.alkitab.base.fr.base;
+
+public abstract class BaseGotoFragment extends BaseFragment {
+	public interface GotoFinishListener {
+		int GOTO_TAB_dialer = 1;
+		int GOTO_TAB_direct = 2;
+		int GOTO_TAB_grid = 3;
+		
+		void onGotoFinished(int gotoTabUsed, int bookId, int chapter_1, int verse_1);
+	}
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/settings/ExperimentalFlags.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/settings/ExperimentalFlags.kt
@@ -6,4 +6,7 @@ import yuku.alkitab.debug.R
 object ExperimentalFlags {
     fun useComposeVerseItem(): Boolean =
         Preferences.getBoolean(R.string.pref_useComposeVerseItem_key, R.bool.pref_useComposeVerseItem_default)
+
+    fun useComposeGoto(): Boolean =
+        Preferences.getBoolean(R.string.pref_useComposeGoto_key, R.bool.pref_useComposeGoto_default)
 }

--- a/Alkitab/src/main/res/drawable/goto_dialer_active.xml
+++ b/Alkitab/src/main/res/drawable/goto_dialer_active.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+	android:shape="oval">
+	<stroke
+		android:width="1dp"
+		android:color="@color/accent" />
+	<solid android:color="#0000" />
+</shape>

--- a/Alkitab/src/main/res/layout-land/fragment_goto_dialer.xml
+++ b/Alkitab/src/main/res/layout-land/fragment_goto_dialer.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.percentlayout.widget.PercentFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:gravity="center_horizontal"
+	android:orientation="vertical">
+
+	<!--suppress AndroidDomInspection -->
+	<androidx.percentlayout.widget.PercentFrameLayout
+		app:layout_heightPercent="35%"
+		app:layout_marginTopPercent="0%"
+		app:layout_widthPercent="100%">
+
+		<!--suppress AndroidDomInspection -->
+		<FrameLayout
+			app:layout_heightPercent="100%"
+			app:layout_marginTopPercent="0%"
+			app:layout_widthPercent="50%">
+
+			<Spinner
+				android:id="@+id/cbBook"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"
+				android:layout_gravity="center"
+				android:layout_marginStart="16dp"
+				android:layout_marginEnd="16dp"
+				tools:listitem="@android:layout/simple_spinner_dropdown_item" />
+
+		</FrameLayout>
+
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="0dp"
+			android:layout_weight="1"
+			android:gravity="center"
+			android:orientation="horizontal"
+			app:layout_heightPercent="100%"
+			app:layout_marginStartPercent="50%"
+			app:layout_marginTopPercent="0%"
+			app:layout_widthPercent="50%">
+
+			<TextView
+				android:id="@+id/tChapterLabel"
+				android:layout_width="wrap_content"
+				android:layout_height="match_parent"
+				android:layout_marginEnd="8dp"
+				android:gravity="fill_vertical"
+				android:text="@string/pasal_sebelumangka" />
+
+			<TextView
+				android:id="@+id/tChapter"
+				android:layout_width="64dp"
+				android:layout_height="64dp"
+				android:focusable="true"
+				android:gravity="center"
+				android:textAppearance="?android:attr/textAppearanceLarge"
+				android:textSize="24sp"
+				tools:text="123" />
+
+			<TextView
+				android:id="@+id/tVerseLabel"
+				android:layout_width="wrap_content"
+				android:layout_height="match_parent"
+				android:layout_marginStart="16dp"
+				android:layout_marginEnd="8dp"
+				android:gravity="center_vertical"
+				android:text="@string/ayat_sebelumangka" />
+
+			<TextView
+				android:id="@+id/tVerse"
+				android:layout_width="64dp"
+				android:layout_height="64dp"
+				android:focusable="true"
+				android:gravity="center"
+				android:textAppearance="?android:attr/textAppearanceLarge"
+				android:textSize="24sp"
+				tools:text="123" />
+		</LinearLayout>
+
+
+		<ImageView
+			android:layout_width="match_parent"
+			android:layout_height="1dp"
+			android:layout_gravity="bottom"
+			android:layout_marginStart="32dp"
+			android:layout_marginEnd="32dp"
+			android:src="#1effffff" />
+
+	</androidx.percentlayout.widget.PercentFrameLayout>
+
+	<!--suppress AndroidDomInspection -->
+	<androidx.percentlayout.widget.PercentFrameLayout
+		android:layout_width="match_parent"
+		android:orientation="vertical"
+		app:layout_heightPercent="65%"
+		app:layout_marginTopPercent="35%"
+		tools:ignore="HardcodedText,SpUsage">
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit1"
+			style="@style/KeypadButton"
+			android:text="1"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="0%"
+			app:layout_widthPercent="16.6%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit2"
+			style="@style/KeypadButton"
+			android:text="2"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="16.6%"
+			app:layout_widthPercent="16.6%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit3"
+			style="@style/KeypadButton"
+			android:text="3"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="33.3%"
+			app:layout_widthPercent="16.6%" />
+
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit4"
+			style="@style/KeypadButton"
+			android:text="4"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="50%"
+			app:layout_widthPercent="16.6%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit5"
+			style="@style/KeypadButton"
+			android:text="5"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="66.6%"
+			app:layout_widthPercent="16.6%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit6"
+			style="@style/KeypadButton"
+			android:text="6"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="0%"
+			app:layout_marginTopPercent="50%"
+			app:layout_widthPercent="16.6%" />
+
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit7"
+			style="@style/KeypadButton"
+			android:text="7"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="16.6%"
+			app:layout_marginTopPercent="50%"
+			app:layout_widthPercent="16.6%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit8"
+			style="@style/KeypadButton"
+			android:text="8"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="33.3%"
+			app:layout_marginTopPercent="50%"
+			app:layout_widthPercent="16.6%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit9"
+			style="@style/KeypadButton"
+			android:text="9"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="50%"
+			app:layout_marginTopPercent="50%"
+			app:layout_widthPercent="16.6%" />
+
+
+		<!--suppress AndroidDomInspection -->
+		<ImageButton
+			android:id="@+id/bDigitBackspace"
+			style="@style/KeypadButton"
+			android:contentDescription="@string/desc_backspace"
+			android:src="@drawable/ic_keypad_backspace"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="83.3%"
+			app:layout_marginTopPercent="0%"
+			app:layout_widthPercent="16.6%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit0"
+			style="@style/KeypadButton"
+			android:text="0"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="66.7%"
+			app:layout_marginTopPercent="50%"
+			app:layout_widthPercent="16.6%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bOk"
+			style="?buttonBarButtonStyle"
+			android:background="?selectableItemBackgroundBorderless"
+			android:text="@string/ok"
+			android:textSize="16sp"
+			app:layout_heightPercent="50%"
+			app:layout_marginStartPercent="83.3%"
+			app:layout_marginTopPercent="50%"
+			app:layout_widthPercent="16.6%" />
+
+	</androidx.percentlayout.widget.PercentFrameLayout>
+</androidx.percentlayout.widget.PercentFrameLayout>

--- a/Alkitab/src/main/res/layout/activity_goto.xml
+++ b/Alkitab/src/main/res/layout/activity_goto.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:orientation="vertical">
+
+	<androidx.appcompat.widget.Toolbar
+		android:id="@+id/toolbar"
+		android:layout_width="match_parent"
+		android:layout_height="?actionBarSize">
+
+		<com.google.android.material.tabs.TabLayout
+			android:id="@+id/tablayout"
+			android:layout_width="match_parent"
+			android:layout_height="?actionBarSize" />
+
+	</androidx.appcompat.widget.Toolbar>
+
+	<androidx.viewpager.widget.ViewPager
+		android:id="@+id/viewPager"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent" />
+</LinearLayout>

--- a/Alkitab/src/main/res/layout/fragment_goto_dialer.xml
+++ b/Alkitab/src/main/res/layout/fragment_goto_dialer.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.percentlayout.widget.PercentFrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:gravity="center_horizontal"
+	android:orientation="vertical">
+
+	<!--suppress AndroidDomInspection -->
+	<FrameLayout
+		android:layout_width="match_parent"
+		app:layout_heightPercent="15%"
+		app:layout_marginTopPercent="0%">
+
+		<Spinner
+			android:id="@+id/cbBook"
+			android:layout_width="300dp"
+			android:layout_height="wrap_content"
+			android:layout_gravity="center_horizontal|bottom"
+			tools:listitem="@android:layout/simple_spinner_dropdown_item" />
+
+	</FrameLayout>
+
+	<!--suppress AndroidDomInspection -->
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:orientation="vertical"
+		app:layout_heightPercent="15%"
+		app:layout_marginTopPercent="15%">
+
+		<LinearLayout
+			android:layout_width="match_parent"
+			android:layout_height="0dp"
+			android:layout_weight="1"
+			android:gravity="center"
+			android:orientation="horizontal">
+
+			<TextView
+				android:id="@+id/tChapterLabel"
+				android:layout_width="wrap_content"
+				android:layout_height="match_parent"
+				android:layout_marginEnd="8dp"
+				android:gravity="fill_vertical"
+				android:text="@string/pasal_sebelumangka" />
+
+			<TextView
+				android:id="@+id/tChapter"
+				android:layout_width="64dp"
+				android:layout_height="64dp"
+				android:focusable="true"
+				android:gravity="center"
+				android:textAppearance="?android:attr/textAppearanceLarge"
+				android:textSize="24sp"
+				tools:text="123" />
+
+			<TextView
+				android:id="@+id/tVerseLabel"
+				android:layout_width="wrap_content"
+				android:layout_height="match_parent"
+				android:layout_marginEnd="8dp"
+				android:layout_marginStart="16dp"
+				android:gravity="center_vertical"
+				android:text="@string/ayat_sebelumangka" />
+
+			<TextView
+				android:id="@+id/tVerse"
+				android:layout_width="64dp"
+				android:layout_height="64dp"
+				android:focusable="true"
+				android:gravity="center"
+				android:textAppearance="?android:attr/textAppearanceLarge"
+				android:textSize="24sp"
+				tools:text="123" />
+		</LinearLayout>
+
+		<ImageView
+			android:layout_width="match_parent"
+			android:layout_height="1dp"
+			android:layout_marginStart="32dp"
+			android:layout_marginEnd="32dp"
+			android:contentDescription="@null"
+			android:src="#1effffff" />
+	</LinearLayout>
+
+	<!--suppress AndroidDomInspection -->
+	<androidx.percentlayout.widget.PercentFrameLayout
+		android:layout_width="match_parent"
+		android:orientation="vertical"
+		app:layout_heightPercent="70%"
+		app:layout_marginTopPercent="30%"
+		tools:ignore="HardcodedText,SpUsage">
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit1"
+			style="@style/KeypadButton"
+			android:text="1"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="0%"
+			app:layout_widthPercent="33.3%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit2"
+			style="@style/KeypadButton"
+			android:text="2"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="33.3%"
+			app:layout_widthPercent="33.3%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit3"
+			style="@style/KeypadButton"
+			android:text="3"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="66.7%"
+			app:layout_widthPercent="33.3%" />
+
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit4"
+			style="@style/KeypadButton"
+			android:text="4"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="0%"
+			app:layout_marginTopPercent="25%"
+			app:layout_widthPercent="33.3%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit5"
+			style="@style/KeypadButton"
+			android:text="5"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="33.3%"
+			app:layout_marginTopPercent="25%"
+			app:layout_widthPercent="33.3%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit6"
+			style="@style/KeypadButton"
+			android:text="6"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="66.7%"
+			app:layout_marginTopPercent="25%"
+			app:layout_widthPercent="33.3%" />
+
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit7"
+			style="@style/KeypadButton"
+			android:text="7"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="0%"
+			app:layout_marginTopPercent="50%"
+			app:layout_widthPercent="33.3%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit8"
+			style="@style/KeypadButton"
+			android:text="8"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="33.3%"
+			app:layout_marginTopPercent="50%"
+			app:layout_widthPercent="33.3%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit9"
+			style="@style/KeypadButton"
+			android:text="9"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="66.7%"
+			app:layout_marginTopPercent="50%"
+			app:layout_widthPercent="33.3%" />
+
+
+		<!--suppress AndroidDomInspection -->
+		<ImageButton
+			android:id="@+id/bDigitBackspace"
+			style="@style/KeypadButton"
+			android:src="@drawable/ic_keypad_backspace"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="0%"
+			app:layout_marginTopPercent="75%"
+			app:layout_widthPercent="33.3%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bDigit0"
+			style="@style/KeypadButton"
+			android:text="0"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="33.3%"
+			app:layout_marginTopPercent="75%"
+			app:layout_widthPercent="33.3%" />
+
+		<!--suppress AndroidDomInspection -->
+		<Button
+			android:id="@+id/bOk"
+			style="?buttonBarButtonStyle"
+			android:background="?selectableItemBackgroundBorderless"
+			android:text="@string/ok"
+			android:textSize="16sp"
+			app:layout_heightPercent="25%"
+			app:layout_marginStartPercent="66.7%"
+			app:layout_marginTopPercent="75%"
+			app:layout_widthPercent="33.3%" />
+
+	</androidx.percentlayout.widget.PercentFrameLayout>
+</androidx.percentlayout.widget.PercentFrameLayout>

--- a/Alkitab/src/main/res/layout/fragment_goto_direct.xml
+++ b/Alkitab/src/main/res/layout/fragment_goto_direct.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:orientation="vertical"
+	android:paddingTop="16dp">
+
+	<TextView
+		android:id="@+id/lDirectSample"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_marginStart="16dp"
+		android:labelFor="@+id/tDirectReference"
+		android:text="@string/jump_to_prompt" />
+
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:layout_marginTop="16dp"
+		android:orientation="horizontal">
+
+		<AutoCompleteTextView
+			android:id="@+id/tDirectReference"
+			android:layout_width="0dp"
+			android:layout_height="wrap_content"
+			android:layout_marginStart="16dp"
+			android:layout_weight="1"
+			android:completionThreshold="1" />
+
+		<Button
+			android:id="@+id/bOk"
+			style="?buttonBarButtonStyle"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_marginEnd="16dp"
+			android:layout_weight="0"
+			android:text="@string/ok" />
+	</LinearLayout>
+
+</LinearLayout>

--- a/Alkitab/src/main/res/layout/fragment_goto_grid.xml
+++ b/Alkitab/src/main/res/layout/fragment_goto_grid.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content">
+
+	<androidx.recyclerview.widget.RecyclerView
+		android:id="@+id/gridBook"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content" />
+
+	<LinearLayout
+		android:id="@+id/panelChapterVerse"
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content"
+		android:orientation="vertical">
+
+		<LinearLayout
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content">
+
+			<TextView
+				android:id="@+id/lSelectedBook"
+				style="?actionButtonStyle"
+				android:layout_width="wrap_content"
+				android:layout_height="48dp"
+				android:drawablePadding="4dp"
+				android:drawableEnd="@drawable/ic_delete_x"
+				android:gravity="center"
+				android:textAppearance="?android:attr/textAppearanceMedium"
+				tools:text="Selected book" />
+
+			<TextView
+				android:id="@+id/lSelectedChapter"
+				style="?actionButtonStyle"
+				android:layout_width="wrap_content"
+				android:layout_height="48dp"
+				android:drawablePadding="4dp"
+				android:drawableEnd="@drawable/ic_delete_x"
+				android:gravity="center"
+				android:textAppearance="?android:attr/textAppearanceMedium"
+				tools:text="chap" />
+		</LinearLayout>
+
+		<FrameLayout
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content">
+
+			<androidx.recyclerview.widget.RecyclerView
+				android:id="@+id/gridChapter"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content" />
+
+			<androidx.recyclerview.widget.RecyclerView
+				android:id="@+id/gridVerse"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content" />
+		</FrameLayout>
+	</LinearLayout>
+
+</FrameLayout>

--- a/Alkitab/src/main/res/layout/item_goto_dialer_book.xml
+++ b/Alkitab/src/main/res/layout/item_goto_dialer_book.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@android:id/text1"
+	style="?android:spinnerItemStyle"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:fontFamily="sans-serif-medium"
+	android:gravity="center_vertical"
+	android:minHeight="48dp"
+	android:singleLine="true"
+	android:textSize="18sp" />

--- a/Alkitab/src/main/res/layout/item_goto_dialer_book_dropdown.xml
+++ b/Alkitab/src/main/res/layout/item_goto_dialer_book_dropdown.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CheckedTextView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@android:id/text1"
+	style="?spinnerDropDownItemStyle"
+	android:layout_width="match_parent"
+	android:layout_height="wrap_content"
+	android:fontFamily="sans-serif-medium"
+	android:gravity="center_vertical"
+	android:minHeight="48dp"
+	android:singleLine="true"
+	android:textSize="18sp" />

--- a/Alkitab/src/main/res/layout/item_goto_grid_cell.xml
+++ b/Alkitab/src/main/res/layout/item_goto_grid_cell.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="@dimen/goto_grid_cell_height"
+	android:background="?selectableItemBackgroundBorderless"
+	android:fontFamily="sans-serif-medium"
+	android:gravity="center"
+	android:textSize="18sp" />

--- a/Alkitab/src/main/res/menu/activity_goto.xml
+++ b/Alkitab/src/main/res/menu/activity_goto.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto">
+
+	<item
+		android:id="@+id/menuAskForVerse"
+		android:checkable="true"
+		android:title="@string/menuAskForVerse"
+		app:showAsAction="never" />
+</menu>

--- a/Alkitab/src/main/res/values-in/pref_labels.xml
+++ b/Alkitab/src/main/res/values-in/pref_labels.xml
@@ -26,4 +26,11 @@
     <string name="pref_showHiddenVersion_title">Versi yang mungkin terbatas</string>
     <string name="pref_selectedVerseBgColor_title">Warna latar ayat terpilih</string>
     <string name="pref_forceFontScale_title">Ukuran teks UI</string>
+
+    <string name="pref_experimental">Fitur eksperimental</string>
+    <string name="pref_experimental_warning">Pilihan-pilihan ini bisa jadi belum stabil. Matikan jika Anda menemui masalah.</string>
+    <string name="pref_useComposeVerseItem_title">Gunakan Compose untuk tampilan ayat</string>
+    <string name="pref_useComposeVerseItem_summary">Tampilkan tiap ayat dengan implementasi Jetpack Compose yang baru, bukan tampilan lama. Buka sebuah pasal untuk melihat perubahannya.</string>
+    <string name="pref_useComposeGoto_title">Gunakan Compose untuk layar Navigasi</string>
+    <string name="pref_useComposeGoto_summary">Tampilkan layar Navigasi versi Jetpack Compose yang baru, bukan implementasi lama dengan tab.</string>
 </resources>

--- a/Alkitab/src/main/res/values-in/pref_labels.xml
+++ b/Alkitab/src/main/res/values-in/pref_labels.xml
@@ -28,9 +28,9 @@
     <string name="pref_forceFontScale_title">Ukuran teks UI</string>
 
     <string name="pref_experimental">Fitur eksperimental</string>
-    <string name="pref_experimental_warning">Pilihan-pilihan ini bisa jadi belum stabil. Matikan jika Anda menemui masalah.</string>
-    <string name="pref_useComposeVerseItem_title">Gunakan Compose untuk tampilan ayat</string>
+    <string name="pref_experimental_warning">Mungkin belum stabil. Matikan jika bermasalah.</string>
+    <string name="pref_useComposeVerseItem_title">Tampilan ayat (Compose)</string>
     <string name="pref_useComposeVerseItem_summary">Tampilkan tiap ayat dengan implementasi Jetpack Compose yang baru, bukan tampilan lama. Buka sebuah pasal untuk melihat perubahannya.</string>
-    <string name="pref_useComposeGoto_title">Gunakan Compose untuk layar Navigasi</string>
+    <string name="pref_useComposeGoto_title">Navigasi (Compose)</string>
     <string name="pref_useComposeGoto_summary">Tampilkan layar Navigasi versi Jetpack Compose yang baru, bukan implementasi lama dengan tab.</string>
 </resources>

--- a/Alkitab/src/main/res/values/colors.xml
+++ b/Alkitab/src/main/res/values/colors.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<color name="keypad_text_color">#fff</color>
 	<!-- Color for something interesting -->
 	<color name="escape">#4db6ac</color>
 </resources>

--- a/Alkitab/src/main/res/values/pref_labels.xml
+++ b/Alkitab/src/main/res/values/pref_labels.xml
@@ -34,4 +34,6 @@
     <string name="pref_experimental_warning">These options may be unstable. Toggle off if you see issues.</string>
     <string name="pref_useComposeVerseItem_title">Use Compose for verse items</string>
     <string name="pref_useComposeVerseItem_summary">Render each verse with the new Jetpack Compose implementation instead of the legacy custom view. Open a chapter to see the change.</string>
+    <string name="pref_useComposeGoto_title">Use Compose for the Navigation screen</string>
+    <string name="pref_useComposeGoto_summary">Show the new Jetpack Compose Navigation screen instead of the legacy tab-based implementation.</string>
 </resources>

--- a/Alkitab/src/main/res/values/pref_labels.xml
+++ b/Alkitab/src/main/res/values/pref_labels.xml
@@ -31,9 +31,9 @@
     <string name="pref_data_transfer_import_title">Import data</string>
 
     <string name="pref_experimental">Experimental features</string>
-    <string name="pref_experimental_warning">These options may be unstable. Toggle off if you see issues.</string>
-    <string name="pref_useComposeVerseItem_title">Use Compose for verse items</string>
+    <string name="pref_experimental_warning">May be unstable. Disable if you hit issues.</string>
+    <string name="pref_useComposeVerseItem_title">Verse items (Compose)</string>
     <string name="pref_useComposeVerseItem_summary">Render each verse with the new Jetpack Compose implementation instead of the legacy custom view. Open a chapter to see the change.</string>
-    <string name="pref_useComposeGoto_title">Use Compose for the Navigation screen</string>
+    <string name="pref_useComposeGoto_title">Navigation (Compose)</string>
     <string name="pref_useComposeGoto_summary">Show the new Jetpack Compose Navigation screen instead of the legacy tab-based implementation.</string>
 </resources>

--- a/Alkitab/src/main/res/values/prefkey.xml
+++ b/Alkitab/src/main/res/values/prefkey.xml
@@ -40,4 +40,7 @@
 
 	<string name="pref_useComposeVerseItem_key" translatable="false">useComposeVerseItem</string>
 	<bool name="pref_useComposeVerseItem_default">false</bool>
+
+	<string name="pref_useComposeGoto_key" translatable="false">useComposeGoto</string>
+	<bool name="pref_useComposeGoto_default">false</bool>
 </resources>

--- a/Alkitab/src/main/res/values/styles.xml
+++ b/Alkitab/src/main/res/values/styles.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+	<style name="KeypadButton">
+		<item name="android:background">?selectableItemBackgroundBorderless</item>
+		<item name="android:fontFamily">sans-serif-regular</item>
+		<item name="android:textColor">@color/keypad_text_color</item>
+		<item name="android:textSize">28sp</item>
+	</style>
+
 	<!-- Applied to non-Spinner to give an appearance of drop-down control -->
 	<style name="FakeSpinner">
 		<item name="android:background">@drawable/abc_spinner_mtrl_am_alpha</item>

--- a/Alkitab/src/main/res/xml/settings_experimental.xml
+++ b/Alkitab/src/main/res/xml/settings_experimental.xml
@@ -10,5 +10,11 @@
 			android:summary="@string/pref_useComposeVerseItem_summary"
 			android:title="@string/pref_useComposeVerseItem_title" />
 
+		<CheckBoxPreference
+			android:defaultValue="false"
+			android:key="@string/pref_useComposeGoto_key"
+			android:summary="@string/pref_useComposeGoto_summary"
+			android:title="@string/pref_useComposeGoto_title" />
+
 	</PreferenceCategory>
 </PreferenceScreen>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ androidxFragment = "1.8.9"
 androidxLifecycle = "2.9.0"
 androidxMedia3 = "1.9.2"
 androidxMultidex = "2.0.1"
+androidxPercentlayout = "1.0.0"
 androidxPreference = "1.2.1"
 androidxRecyclerview = "1.4.0"
 androidxSwiperefreshlayout = "1.1.0"
@@ -71,6 +72,7 @@ androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplaye
 androidx-media3-datasource-okhttp = { group = "androidx.media3", name = "media3-datasource-okhttp", version.ref = "androidxMedia3" }
 androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "androidxMedia3" }
 androidx-multidex = { group = "androidx.multidex", name = "multidex", version.ref = "androidxMultidex" }
+androidx-percentlayout = { group = "androidx.percentlayout", name = "percentlayout", version.ref = "androidxPercentlayout" }
 androidx-preference = { group = "androidx.preference", name = "preference", version.ref = "androidxPreference" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidxPreference" }
 androidx-recyclerview = { group = "androidx.recyclerview", name = "recyclerview", version.ref = "androidxRecyclerview" }


### PR DESCRIPTION
## Summary

The Compose Navigation screen (REM-22, #160) was not ready for production. This PR restores the legacy fragment-based GotoActivity as the default and gates the Compose port behind a new toggle in the Experimental settings.

- `GotoActivity` now branches in `onCreate`: when `ExperimentalFlags.useComposeGoto()` is true it renders the Compose `GotoScreen`, otherwise it inflates the legacy layout and wires up the dialer/direct/grid fragments. The public Java API (`createIntent` / `obtainResult` / `Result`) is unchanged, so callers don't need to know which implementation is active.
- Restored from #160's parent commit: `GotoDialerFragment`, `GotoDirectFragment`, `GotoGridFragment`, `BaseGotoFragment`, `activity_goto` + fragment layouts (portrait + landscape), the item layouts, the menu, and the `goto_dialer_active` drawable.
- Restored the `KeypadButton` style, the `keypad_text_color` color, and the `androidx.percentlayout` dependency that the legacy dialer layout needs (originally removed in #162 after #160 deleted the last consumer).
- `GotoDirectFragment` was tweaked to use `Jumper.BookRef` getters because `Jumper` was ported to Kotlin (REM-16) after #160 was merged, which made the previously-public Java fields invisible.

## Strings / localization

- New strings `pref_useComposeGoto_title` / `_summary` in English and Indonesian.
- Filled in the previously missing Indonesian translations for `pref_experimental`, `pref_experimental_warning`, and `pref_useComposeVerseItem_title` / `_summary`.
- Indonesian uses **"Navigasi"** (matching https://alkitab.app/guide/navigation) — not "Pergi ke". English uses **"Navigation screen"**.

## Test plan

- [x] `./gradlew assemblePlainDebug` — passes
- [x] `./gradlew testPlainDebugUnitTest` — passes
- [ ] Manually verify the legacy Goto screen (default): tabs swap correctly, dialer keypad responds, "Ask for verse number" menu item toggles, direct typing + autocomplete still jumps, grid book → chapter → verse flow works in both portrait and landscape.
- [ ] Manually verify Settings → Experimental → "Use Compose for the Navigation screen" toggle: when on, the Compose Goto screen is shown; when off, the legacy screen is shown.
- [ ] Verify Indonesian translations render correctly when device language is set to Indonesian.

https://claude.ai/code/session_01FdanaG6Xns2KT5uJNTX51h

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdanaG6Xns2KT5uJNTX51h)_