### PR TITLE
Stack audio bar below the content instead of overlaying it

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -16,7 +16,6 @@ import android.text.style.URLSpan
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.Menu
-import android.util.TypedValue
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
@@ -499,7 +498,11 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         // If layout is changed, updateToolbarLocation must be updated as well. This will be called in DEBUG to make sure
         // updateToolbarLocation is also updated when layout is updated.
         if (BuildConfig.DEBUG) {
-            if (root.childCount != 2 || root.getChildAt(0).id != R.id.toolbar || root.getChildAt(1).id != R.id.nontoolbar) {
+            if (root.childCount != 3 ||
+                root.getChildAt(0).id != R.id.toolbar ||
+                root.getChildAt(1).id != R.id.nontoolbar ||
+                root.getChildAt(2).id != R.id.audio_bar
+            ) {
                 throw RuntimeException("Layout changed and this is no longer compatible with updateToolbarLocation")
             }
         }
@@ -694,35 +697,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
         val audioBarView: ComposeView = findViewById(R.id.audio_bar)
         audioBinder.attach(audioBarHost, audioBarView)
-        // When the verse-nav toolbar is anchored to the bottom of the screen
-        // (Settings → Display → "Navigasi ayat di bawah"), the audio bar —
-        // which is overlaid via FrameLayout `gravity=bottom` on the outer
-        // overlayContainer — would otherwise sit on top of the toolbar's
-        // slot and hide its goto / version / search buttons. Push the bar
-        // up by exactly one actionBarSize so the two surfaces stack
-        // instead of overlapping. Toggling the setting forces an activity
-        // restart (see DisplayFragment), so a one-shot computation here is
-        // enough; we deliberately don't react to fullscreen toggles, which
-        // hide the action bar but never resize the slot.
-        if (Preferences.getBoolean(R.string.pref_bottomToolbarOnText_key, R.bool.pref_bottomToolbarOnText_default)) {
-            val tv = TypedValue()
-            if (theme.resolveAttribute(android.R.attr.actionBarSize, tv, true)) {
-                val actionBarHeight = TypedValue.complexToDimensionPixelSize(tv.data, resources.displayMetrics)
-                val params = audioBarView.layoutParams as FrameLayout.LayoutParams
-                params.bottomMargin = actionBarHeight
-                audioBarView.layoutParams = params
-            }
-        }
-        // Push the verse list up by the bar's height so the last verses are
-        // reachable instead of being hidden behind the bar. lsSplit0 / lsSplit1
-        // already set `clipToPadding="false"` so the verses still scroll
-        // through the padding region under the bar (matches the
-        // YouTube-Music-style "content fades out behind the player" feel).
-        audioBarView.addOnLayoutChangeListener { _, _, top, _, bottom, _, oldTop, _, oldBottom ->
-            if (bottom - top != oldBottom - oldTop) {
-                applyAudioBarBottomInset(bottom - top)
-            }
-        }
         lifecycleScope.launch {
             // 100 ms tick rate while playing — avoid invalidateOptionsMenu() here;
             // menu refreshes flow through `audioBarVisibilityChanged` instead.
@@ -756,18 +730,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             )
         }
         controller.setAudioHighlight(verse_1, audioHighlightColorCached)
-    }
-
-    /**
-     * Reserve [pxBottom] pixels at the bottom of each verse RecyclerView so the
-     * last verses aren't hidden behind the audio bar. Called whenever the bar's
-     * Compose host re-lays-out (slide-in, slide-out, height change). Both
-     * splits get the inset uniformly so the secondary list is also scrollable
-     * to its last verse.
-     */
-    private fun applyAudioBarBottomInset(pxBottom: Int) {
-        lsSplit0.setAudioBarBottomInset(pxBottom)
-        lsSplit1.setAudioBarBottomInset(pxBottom)
     }
 
     /**
@@ -1392,19 +1354,25 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         // - not fullscreen, toolbar at bottom
         // - not fullscreen, toolbar at top
 
-        // root contains exactly 2 children: toolbar and nontoolbar.
-        // Need to move toolbar and nontoolbar in order to accomplish this.
+        // root contains 3 children: toolbar, nontoolbar, and the audio bar.
+        // The audio bar always sits directly below the content (above the
+        // bottom-anchored verse-nav toolbar when that mode is enabled), so
+        // the order varies with the toolbar-location preference.
 
         if (!fullScreen) {
+            val audioBar = root.findViewById<View>(R.id.audio_bar)
             root.removeView(toolbar)
             root.removeView(nontoolbar)
+            root.removeView(audioBar)
 
             if (Preferences.getBoolean(R.string.pref_bottomToolbarOnText_key, R.bool.pref_bottomToolbarOnText_default)) {
                 root.addView(nontoolbar)
+                root.addView(audioBar)
                 root.addView(toolbar)
             } else {
                 root.addView(toolbar)
                 root.addView(nontoolbar)
+                root.addView(audioBar)
             }
         }
     }

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -1360,7 +1360,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         // the order varies with the toolbar-location preference.
 
         if (!fullScreen) {
-            val audioBar = root.findViewById<View>(R.id.audio_bar)
+            val audioBar = root.requireViewById<View>(R.id.audio_bar)
             root.removeView(toolbar)
             root.removeView(nontoolbar)
             root.removeView(audioBar)

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
@@ -132,16 +132,4 @@ interface VersesController {
      * without snapping the page each time the verse changes.
      */
     fun setAudioHighlight(verse_1: Int, color: Int)
-
-    /**
-     * Reserves [pxBottom] extra pixels at the bottom of the underlying
-     * verse list view so the last verses are reachable while the audio bar
-     * overlays the screen. Combined with `clipToPadding="false"` on the
-     * RecyclerView, the padding region remains scrollable so verses pass
-     * under the bar (YouTube-Music-style mini-player feel) instead of being
-     * cut off behind it.
-     *
-     * Pass `0` to clear the inset when the bar slides out.
-     */
-    fun setAudioBarBottomInset(pxBottom: Int)
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -55,15 +55,7 @@ class VersesControllerImpl(
     private val attention = Attention()
     private val audioHighlight = AudioHighlight()
 
-    /**
-     * Base padding requested via [setViewPadding] (i.e. the padding the theme/
-     * preferences want, ignoring overlays). [setAudioBarBottomInset] can add
-     * extra bottom padding to keep the last verses visible above the audio
-     * bar; we keep the two values separate so neither setter clobbers the
-     * other when, e.g., the user changes font size while the bar is showing.
-     */
     private val basePadding = Rect()
-    private var audioBarBottomInsetPx: Int = 0
 
     private val dataVersionNumber = AtomicInteger()
 
@@ -446,7 +438,7 @@ class VersesControllerImpl(
 
     override fun setViewPadding(padding: Rect) {
         basePadding.set(padding)
-        applyPadding()
+        rv.setPadding(basePadding.left, basePadding.top, basePadding.right, basePadding.bottom)
     }
 
     override fun setViewScrollbarThumb(thumb: Drawable) {
@@ -522,27 +514,6 @@ class VersesControllerImpl(
     override fun setEmptyMessage(message: CharSequence?, textColor: Int) {
         rv.emptyMessage = message
         rv.emptyMessagePaint.color = textColor
-    }
-
-    override fun setAudioBarBottomInset(pxBottom: Int) {
-        if (audioBarBottomInsetPx == pxBottom) return
-        audioBarBottomInsetPx = pxBottom
-        applyPadding()
-    }
-
-    /**
-     * Apply [basePadding] + [audioBarBottomInsetPx] to the underlying
-     * RecyclerView. Either setter can be invoked at any time (font-size
-     * change while the bar is visible, or vice versa); combining the two
-     * values here means neither stomps on the other.
-     */
-    private fun applyPadding() {
-        rv.setPadding(
-            basePadding.left,
-            basePadding.top,
-            basePadding.right,
-            basePadding.bottom + audioBarBottomInsetPx,
-        )
     }
 
     fun render() {

--- a/Alkitab/src/main/res/layout/activity_isi_content.xml
+++ b/Alkitab/src/main/res/layout/activity_isi_content.xml
@@ -157,6 +157,11 @@
 
 		</FrameLayout>
 
+		<androidx.compose.ui.platform.ComposeView
+			android:id="@+id/audio_bar"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content" />
+
 	</LinearLayout>
 
 	<yuku.alkitab.base.widget.Floater
@@ -165,11 +170,5 @@
 		android:layout_height="match_parent"
 		android:padding="8dp"
 		android:visibility="gone" />
-
-	<androidx.compose.ui.platform.ComposeView
-		android:id="@+id/audio_bar"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:layout_gravity="bottom" />
 
 </FrameLayout>


### PR DESCRIPTION
## Summary

The Compose audio bar used to sit in the outer `FrameLayout` of `activity_isi_content.xml` with `gravity=bottom`, which meant the verses RecyclerView, the split handle, and the back-forward FAB all had to compensate for it: extra bottom padding for the verses (so the last verses weren't hidden behind the bar), and an extra `bottomMargin` push-up when the verse-nav toolbar was anchored to the bottom of the screen.

This PR moves the bar into the root `LinearLayout` as a sibling below `nontoolbar`, so it takes its own space in the layout. `nontoolbar` keeps `weight=1` and shrinks naturally when the bar slides in.

### Behavior

- Audio bar sits **below** the verses content instead of on top of it.
- Split handle stays fully visible.
- No bottom-padding adjustment on either RecyclerView.
- Back-forward floating button keeps its bottom-end anchor inside `nontoolbar`, so it stays visible while the audio bar is showing.
- When the verse-nav toolbar is anchored to the bottom (Settings → Display → "Navigasi ayat di bawah"), the audio bar slots between `nontoolbar` and `toolbar` — same effective layering as the old `bottomMargin = actionBarSize` workaround.

### Removed

- `VersesController.setAudioBarBottomInset` (interface) and its impl, plus the `audioBarBottomInsetPx` bookkeeping in `VersesControllerImpl`.
- The bottom-margin push-up dance for the bottom verse-nav toolbar in `IsiActivity.onCreate`.
- The audio-bar `addOnLayoutChangeListener` that fed the inset.

### Updated

- `updateToolbarLocation` now reorders three children instead of two; the DEBUG layout-shape assertion checks for `toolbar`, `nontoolbar`, `audio_bar`.

## Test plan

- [x] `./gradlew assemblePlainDebug` (built clean, 6m 24s cold)
- [x] `./gradlew testPlainDebugUnitTest` (passes)
- [x] Manual: open `IsiActivity`, start audio playback — bar appears below verses without resizing the RV padding.
- [x] Manual: scroll to the last verse of a chapter while playing — last verse is fully visible above the bar (no padding hack needed because the bar no longer overlays).
- [x] Manual: enable Settings → Display → "Navigasi ayat di bawah", confirm audio bar sits between content and the bottom verse-nav toolbar.
- [x] Manual: open split view, confirm the split handle is fully visible while the bar is showing.
- [x] Manual: confirm the back/forward floating button stays visible above the bar.
- [x] Manual: toggle fullscreen, confirm bar still renders below content and slides cleanly when shown/hidden.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JkS4u4u4rANe2pVUAHydvT)_