### PR TITLE
Sync split-pane scrolling through multi-pericope blocks

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
@@ -31,6 +31,25 @@ interface VersesController {
     }
 
     abstract class VerseScrollListener {
+        /**
+         * Emitted while the user scrolls. [isPericope] indicates whether
+         * the sender's anchor was a pericope header (above [verse_1]) or
+         * [verse_1] itself.
+         *
+         * [prop] is in `[0, 1]` and represents the fraction of the sender's
+         * anchor extent already scrolled past `paddingTop`:
+         *  - When [isPericope] is `false`: fraction of the verse's height.
+         *  - When [isPericope] is `true`: fraction of the COMBINED height
+         *    of the contiguous pericope-header block above [verse_1] (one
+         *    or more headers treated as a single anchor unit, so verse
+         *    panes with differing pericope counts/heights stay aligned).
+         *
+         * The receiver multiplies [prop] by its OWN matching item or block
+         * height, so heights may differ freely between panes. A pane that
+         * lacks a pericope block above [verse_1] treats it as zero-height
+         * and simply pins the verse top to `paddingTop` while the sender
+         * scrolls through its block.
+         */
         open fun onVerseScroll(isPericope: Boolean, verse_1: Int, prop: Float) {}
 
         open fun onScrollToTop() {}
@@ -75,22 +94,21 @@ interface VersesController {
      */
     fun scrollToVerse(verse_1: Int)
     /**
-     * This is different from the other [scrollToVerse] in that if the requested
-     * verse has a pericope header, this will scroll to the verse, ignoring the pericope header.
+     * Scrolls so that this pane's [verse_1] has had `prop * (this pane's
+     * verse height)` pixels scrolled past the view's `paddingTop`. Used by
+     * the split view when the source pane's first visible item is the verse
+     * itself.
      */
     fun scrollToVerse(verse_1: Int, prop: Float)
 
     /**
-     * Scrolls to the pericope header above [verse_1] (if any), positioning it
-     * so that [prop] of its height has been scrolled past the top edge.
-     *
-     * If this version has no pericope above [verse_1], the verse itself is
-     * snapped to the top (the source's within-pericope [prop] is intentionally
-     * dropped in that case — applying it to a verse would scroll past content
-     * the source was still showing as a header).
-     *
-     * Used by the split view to mirror the source pane when its top visible
-     * item is a pericope header.
+     * Scrolls to the contiguous block of pericope headers above [verse_1]
+     * (one or more, treated as a single anchor unit), positioning it so
+     * that [prop] of THIS pane's combined block height has been scrolled
+     * past `paddingTop`. If this pane has no pericope above [verse_1] the
+     * verse itself is snapped to `paddingTop` (equivalent to a zero-height
+     * block), so the receiver waits at the verse top while the source
+     * scrolls through its own block.
      */
     fun scrollToPericope(verse_1: Int, prop: Float)
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -133,14 +133,10 @@ class VersesControllerImpl(
                 if (verseOrPericope > 0) {
                     versesListeners.verseScrollListener.onVerseScroll(false, verseOrPericope, prop)
                 } else {
-                    // Treat the entire contiguous pericope-header block above
-                    // the next verse as a single anchor unit so panes with
-                    // different pericope counts/heights still progress
-                    // smoothly across the block. Walk the block boundaries
-                    // from the current position via the cheap O(1)
-                    // getItemViewType lookups rather than the data model's
-                    // O(N) verse-search helpers, since this runs on every
-                    // scroll frame.
+                    // Contiguous pericope headers above a verse are reported
+                    // as a single anchor unit so panes whose versions have
+                    // different pericope counts/heights stay aligned across
+                    // the whole block instead of bumping at each header.
                     var blockStartPos = position
                     while (blockStartPos > 0 &&
                         versesDataModel.getItemViewType(blockStartPos - 1) == ItemType.pericope
@@ -166,12 +162,6 @@ class VersesControllerImpl(
                             combinedHeight += layoutManager.findViewByPosition(p)?.height ?: getMeasuredItemHeight(p)
                         }
 
-                        // `prop * anchorHeight` works for both the >=0 and <0
-                        // remaining branches above; the older
-                        // `anchorHeight - remaining` form was only correct in
-                        // the >=0 branch and produced > anchorHeight in the
-                        // other branch (when the previous item's bottom is
-                        // already off-screen).
                         val scrolledOfAnchorPx = prop * anchorHeight
                         val combinedScrolledPx = heightsBefore + scrolledOfAnchorPx
                         val propCombined = if (combinedHeight > 0) combinedScrolledPx / combinedHeight else 0f
@@ -317,9 +307,9 @@ class VersesControllerImpl(
         }
         val versePos = versesDataModel.getPositionIgnoringPericopeFromVerse(verse_1)
         if (blockStartPos == versePos) {
-            // No pericope above the verse on this pane → treat the block as
-            // zero-height; snap the verse to view top while the source pane
-            // scrolls through its own block.
+            // No pericope above the verse on this pane — treat as a
+            // zero-height block: pin the verse top while the sender's
+            // pericope scrolls.
             scrollToPositionWithProp(versePos, 0f)
             return
         }

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -133,15 +133,30 @@ class VersesControllerImpl(
                 if (verseOrPericope > 0) {
                     versesListeners.verseScrollListener.onVerseScroll(false, verseOrPericope, prop)
                 } else {
-                    val nextVerse_1 = versesDataModel.getVerse_1FromPosition(position)
+                    // Treat the entire contiguous pericope-header block above
+                    // the next verse as a single anchor unit so panes with
+                    // different pericope counts/heights still progress
+                    // smoothly across the block. Walk the block boundaries
+                    // from the current position via the cheap O(1)
+                    // getItemViewType lookups rather than the data model's
+                    // O(N) verse-search helpers, since this runs on every
+                    // scroll frame.
+                    var blockStartPos = position
+                    while (blockStartPos > 0 &&
+                        versesDataModel.getItemViewType(blockStartPos - 1) == ItemType.pericope
+                    ) {
+                        blockStartPos--
+                    }
+                    val itemCount = versesDataModel.itemCount
+                    var versePos = position + 1
+                    while (versePos < itemCount &&
+                        versesDataModel.getItemViewType(versePos) == ItemType.pericope
+                    ) {
+                        versePos++
+                    }
+                    if (versePos >= itemCount) return
+                    val nextVerse_1 = versesDataModel.getVerse_1FromPosition(versePos)
                     if (nextVerse_1 > 0) {
-                        // Treat the entire contiguous pericope-header block
-                        // above nextVerse_1 as a single anchor unit so panes
-                        // with different pericope counts/heights still
-                        // progress smoothly across the block.
-                        val blockStartPos = versesDataModel.getPositionOfPericopeBeginningFromVerse(nextVerse_1)
-                        val versePos = versesDataModel.getPositionIgnoringPericopeFromVerse(nextVerse_1)
-
                         var heightsBefore = 0
                         for (p in blockStartPos until position) {
                             heightsBefore += layoutManager.findViewByPosition(p)?.height ?: getMeasuredItemHeight(p)
@@ -151,9 +166,15 @@ class VersesControllerImpl(
                             combinedHeight += layoutManager.findViewByPosition(p)?.height ?: getMeasuredItemHeight(p)
                         }
 
-                        val scrolledOfAnchor = anchorHeight - remaining
-                        val combinedScrolled = heightsBefore + scrolledOfAnchor
-                        val propCombined = if (combinedHeight > 0) combinedScrolled.toFloat() / combinedHeight else 0f
+                        // `prop * anchorHeight` works for both the >=0 and <0
+                        // remaining branches above; the older
+                        // `anchorHeight - remaining` form was only correct in
+                        // the >=0 branch and produced > anchorHeight in the
+                        // other branch (when the previous item's bottom is
+                        // already off-screen).
+                        val scrolledOfAnchorPx = prop * anchorHeight
+                        val combinedScrolledPx = heightsBefore + scrolledOfAnchorPx
+                        val propCombined = if (combinedHeight > 0) combinedScrolledPx / combinedHeight else 0f
 
                         versesListeners.verseScrollListener.onVerseScroll(true, nextVerse_1, propCombined)
                     }

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -33,7 +33,6 @@ import yuku.alkitab.base.widget.ParallelSpan
 import yuku.alkitab.base.widget.PericopeHeaderItem
 import yuku.alkitab.base.widget.ReferenceParallelClickData
 import yuku.alkitab.base.widget.ScrollbarSetter.setVerticalThumb
-import yuku.alkitab.base.widget.VerseInlineLinkSpan
 import yuku.alkitab.base.widget.VerseRenderer
 import yuku.alkitab.base.widget.VerseRendererCompose
 import yuku.alkitab.debug.R
@@ -103,40 +102,65 @@ class VersesControllerImpl(
             override fun onScrolled(view: RecyclerView, dx: Int, dy: Int) {
                 super.onScrolled(view, dx, dy)
 
-                val firstVisibleItemPosition = layoutManager.findFirstVisibleItemPosition()
+                if (scrollState == RecyclerView.SCROLL_STATE_IDLE) return
+
+                val firstVisibleItemPosition = layoutManager.getChildAt(0)
+                    ?.let { layoutManager.getPosition(it) }
+                    ?: layoutManager.findFirstVisibleItemPosition()
+                if (firstVisibleItemPosition == RecyclerView.NO_POSITION) return
                 val firstChild = layoutManager.findViewByPosition(firstVisibleItemPosition) ?: return
 
                 var prop = 0f
                 var position = -1
+                var anchorHeight = 0
 
                 val remaining = firstChild.bottom // padding top is ignored
                 if (remaining >= 0) { // bottom of first child is lower than top padding
                     position = firstVisibleItemPosition
-                    prop = 1f - remaining.toFloat() / firstChild.height
-                } else { // we should have a second child
+                    anchorHeight = firstChild.height
+                    prop = if (anchorHeight > 0) 1f - remaining.toFloat() / anchorHeight else 0f
+                } else {
                     layoutManager.findViewByPosition(firstVisibleItemPosition + 1)?.let { secondChild ->
                         position = firstVisibleItemPosition + 1
-                        prop = (-remaining).toFloat() / secondChild.height
+                        anchorHeight = secondChild.height
+                        prop = if (anchorHeight > 0) (-remaining).toFloat() / anchorHeight else 0f
                     }
                 }
 
-                val verse_1 = versesDataModel.getVerseOrPericopeFromPosition(position)
+                if (position < 0) return
 
-                if (scrollState != RecyclerView.SCROLL_STATE_IDLE) {
-                    if (verse_1 > 0) {
-                        versesListeners.verseScrollListener.onVerseScroll(false, verse_1, prop)
-                    } else {
-                        // first visible item is a pericope; pass the following verse for best-effort sync
-                        val nextVerse_1 = versesDataModel.getVerse_1FromPosition(position)
-                        if (nextVerse_1 > 0) {
-                            versesListeners.verseScrollListener.onVerseScroll(true, nextVerse_1, prop)
+                val verseOrPericope = versesDataModel.getVerseOrPericopeFromPosition(position)
+                if (verseOrPericope > 0) {
+                    versesListeners.verseScrollListener.onVerseScroll(false, verseOrPericope, prop)
+                } else {
+                    val nextVerse_1 = versesDataModel.getVerse_1FromPosition(position)
+                    if (nextVerse_1 > 0) {
+                        // Treat the entire contiguous pericope-header block
+                        // above nextVerse_1 as a single anchor unit so panes
+                        // with different pericope counts/heights still
+                        // progress smoothly across the block.
+                        val blockStartPos = versesDataModel.getPositionOfPericopeBeginningFromVerse(nextVerse_1)
+                        val versePos = versesDataModel.getPositionIgnoringPericopeFromVerse(nextVerse_1)
+
+                        var heightsBefore = 0
+                        for (p in blockStartPos until position) {
+                            heightsBefore += layoutManager.findViewByPosition(p)?.height ?: getMeasuredItemHeight(p)
                         }
-                    }
+                        var combinedHeight = heightsBefore + anchorHeight
+                        for (p in position + 1 until versePos) {
+                            combinedHeight += layoutManager.findViewByPosition(p)?.height ?: getMeasuredItemHeight(p)
+                        }
 
-                    if (position == 0 && firstChild.top == view.paddingTop) {
-                        // we are really at the top
-                        versesListeners.verseScrollListener.onScrollToTop()
+                        val scrolledOfAnchor = anchorHeight - remaining
+                        val combinedScrolled = heightsBefore + scrolledOfAnchor
+                        val propCombined = if (combinedHeight > 0) combinedScrolled.toFloat() / combinedHeight else 0f
+
+                        versesListeners.verseScrollListener.onVerseScroll(true, nextVerse_1, propCombined)
                     }
+                }
+
+                if (firstVisibleItemPosition == 0 && firstChild.top == view.paddingTop) {
+                    versesListeners.verseScrollListener.onScrollToTop()
                 }
             }
         }
@@ -256,7 +280,6 @@ class VersesControllerImpl(
 
     override fun scrollToVerse(verse_1: Int, prop: Float) {
         val position = versesDataModel.getPositionIgnoringPericopeFromVerse(verse_1)
-
         if (position == -1) {
             AppLog.d(TAG, "could not find verse_1: $verse_1")
             return
@@ -266,40 +289,55 @@ class VersesControllerImpl(
     }
 
     override fun scrollToPericope(verse_1: Int, prop: Float) {
-        val pericopePos = versesDataModel.getPositionOfPericopeBeginningFromVerse(verse_1)
-        if (pericopePos == -1) {
-            AppLog.d(TAG, "could not find verse_1 for pericope: $verse_1")
+        val blockStartPos = versesDataModel.getPositionOfPericopeBeginningFromVerse(verse_1)
+        if (blockStartPos == -1) {
+            AppLog.d(TAG, "could not find pericope above verse_1: $verse_1")
             return
         }
         val versePos = versesDataModel.getPositionIgnoringPericopeFromVerse(verse_1)
-        // If this version has no pericope above the verse, applying the source's
-        // within-pericope prop to the verse would scroll past it. Snap to the
-        // verse start instead.
-        val effectiveProp = if (pericopePos == versePos) 0f else prop
-        scrollToPositionWithProp(pericopePos, effectiveProp)
+        if (blockStartPos == versePos) {
+            // No pericope above the verse on this pane → treat the block as
+            // zero-height; snap the verse to view top while the source pane
+            // scrolls through its own block.
+            scrollToPositionWithProp(versePos, 0f)
+            return
+        }
+
+        val vn = dataVersionNumber.get()
+        rv.post(fun() {
+            if (vn != dataVersionNumber.get()) return
+            if (versePos >= versesDataModel.itemCount) return
+
+            var combinedHeight = 0
+            for (p in blockStartPos until versePos) {
+                combinedHeight += layoutManager.findViewByPosition(p)?.height ?: getMeasuredItemHeight(p)
+            }
+
+            rv.stopScroll()
+            val paddingNegator = if (blockStartPos == 0) 0 else -rv.paddingTop
+            val offset = -(prop * combinedHeight).toInt() + paddingNegator
+            layoutManager.scrollToPositionWithOffset(blockStartPos, offset)
+        })
     }
 
     private fun scrollToPositionWithProp(position: Int, prop: Float) {
         val vn = dataVersionNumber.get()
         rv.post(fun() {
-            // this may happen async from above, so check data version first,
-            // then verify the position is still in bounds
             if (vn != dataVersionNumber.get()) return
             if (position >= versesDataModel.itemCount) return
-
-            // negate padding offset, unless this is the first item
-            val paddingNegator = if (position == 0) 0 else -rv.paddingTop
 
             val firstPos = layoutManager.findFirstVisibleItemPosition()
             val lastPos = layoutManager.findLastVisibleItemPosition()
             val height = if (position in firstPos..lastPos) {
-                // we have the child on screen, no need to measure
                 layoutManager.findViewByPosition(position)?.height ?: return
             } else {
                 getMeasuredItemHeight(position)
             }
+
             rv.stopScroll()
-            layoutManager.scrollToPositionWithOffset(position, -(prop * height).toInt() + paddingNegator)
+            val paddingNegator = -rv.paddingTop
+            val offset = -(prop * height).toInt() + paddingNegator
+            layoutManager.scrollToPositionWithOffset(position, offset)
         })
     }
 


### PR DESCRIPTION
## Summary

- Treat a contiguous block of pericope headers above a verse as a single anchor unit on both sender and receiver, so panes whose versions have different numbers (or heights) of pericope headers stay aligned while scrolling.
- Sender (`VersesControllerImpl.onScrolled`): when the first visible item is a pericope, sum the heights of every pericope in the block (`findViewByPosition` when on-screen, `getMeasuredItemHeight` otherwise) and emit `prop = combinedScrolled / combinedHeight` against that block instead of just the visible header.
- Receiver (`VersesControllerImpl.scrollToPericope`): finds its own block above the same verse, sums the local combined height, and applies a single `scrollToPositionWithOffset` on the block start. Falls through to the existing zero-height-block fallback (snap the verse to `paddingTop`) when this pane has no pericope above the verse.
- Updates the `VerseScrollListener.onVerseScroll` and `scrollToVerse(_, prop)` / `scrollToPericope(_, prop)` KDoc to describe the per-pane semantics. Folds the zero-anchor-height guard into the prop computation so an unmeasured first child can't divide by zero.

## Test plan

- [x] `./gradlew :Alkitab:compilePlainDebugKotlin :Alkitab:testPlainDebugUnitTest`
- [ ] On device, scroll a chapter that has multiple pericopes above the same verse in one version but a single pericope above it in the other; confirm both panes track smoothly across the entire block and re-converge at the verse boundary.
- [ ] Same chapter, opposite direction (drive the scroll from the other pane).
- [ ] Scroll a chapter with no pericopes at all to confirm the verse-anchor path is unchanged.