### PR TITLE
audio-bible M3.2/M3.4/M5: speed sheet, toolbar spinner, persistence, auto-advance

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -698,14 +698,22 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         val audioBarView: ComposeView = findViewById(R.id.audio_bar)
         audioBinder.attach(audioBarHost, audioBarView)
         lifecycleScope.launch {
-            // 100 ms tick rate while playing — avoid invalidateOptionsMenu() here;
-            // menu refreshes flow through `audioBarVisibilityChanged` instead.
+            // 100 ms tick rate while playing — avoid invalidateOptionsMenu() on
+            // every emission. Most menu refreshes flow through
+            // `audioBarVisibilityChanged`; the only periodic refresh we need is
+            // when `preparing` flips, so the toolbar can swap the audio icon
+            // for the spinner.
+            var lastPreparing = false
             audioBinder.uiState.collect { state ->
                 val playing = state.playingVersionId
                 val split0Match = playing != null && playing == activeSplit0.versionId
                 val split1Match = playing != null && playing == activeSplit1?.versionId
                 applyAudioHighlightTo(lsSplit0, if (split0Match) state.verse_1 else 0)
                 applyAudioHighlightTo(lsSplit1, if (split1Match) state.verse_1 else 0)
+                if (state.preparing != lastPreparing) {
+                    lastPreparing = state.preparing
+                    invalidateOptionsMenu()
+                }
             }
         }
         lifecycleScope.launch {
@@ -1283,15 +1291,21 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         // have audio, and swap to the active variant (small accent dot in the
         // upper-end corner) while the bar is open so the user can tell at a
         // glance that an audio session is engaged. Both drawables are 24dp
-        // — same toolbar slot, no reflow on the swap.
+        // — same toolbar slot, no reflow on the swap. While the player is
+        // preparing, hide the icon entirely and reveal the toolbar spinner
+        // (Kidung pattern) so the user has a single source of "I tapped, it's
+        // working on it" feedback in the activity chrome.
         val menuAudio = menu.findItem(R.id.menuAudio)
+        val preparing = audioBinder.isPreparing
         if (menuAudio != null) {
-            menuAudio.isVisible = audioBinder.isAvailable
+            menuAudio.isVisible = audioBinder.isAvailable && !preparing
             menuAudio.setIcon(
                 if (audioBinder.isBarVisible) R.drawable.ic_audio_active
                 else R.drawable.ic_audio
             )
         }
+        toolbar.findViewById<View?>(R.id.audio_progress_circular)?.visibility =
+            if (preparing) View.VISIBLE else View.GONE
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
@@ -154,6 +154,10 @@ class AudioBarController(
     val isBarVisible: Boolean
         get() = _uiState.value.visible
 
+    /** True while the player is buffering — drives the toolbar's preparing-state spinner swap. */
+    val isPreparing: Boolean
+        get() = _uiState.value.preparing
+
     private val serviceConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
             val localBinder = binder as? BibleAudioService.LocalBinder ?: return
@@ -455,8 +459,14 @@ class AudioBarController(
             AudioBarCommand.NextChapter -> svc?.skipChapter(1)
             AudioBarCommand.Close -> hide()
             AudioBarCommand.Speed -> {
-                // M5: opens the speed bottom sheet. M3 surfaces the chip but
-                // ignores the tap.
+                _uiState.update { it.copy(showSpeedSheet = true) }
+            }
+            AudioBarCommand.DismissSpeedSheet -> {
+                _uiState.update { it.copy(showSpeedSheet = false) }
+            }
+            is AudioBarCommand.SetSpeed -> {
+                svc?.setSpeed(cmd.speed)
+                _uiState.update { it.copy(speed = cmd.speed, showSpeedSheet = false) }
             }
             is AudioBarCommand.SeekDrag -> {
                 // The slider thumb's mm:ss is owned by AudioBar's local drag

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
@@ -29,8 +29,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import yuku.afw.storage.Preferences
 import yuku.alkitab.base.IsiActivity
 import yuku.alkitab.base.App
+import yuku.alkitab.base.storage.Prefkey
 import yuku.alkitab.base.util.AppLog
 import yuku.alkitab.debug.R
 
@@ -83,6 +85,9 @@ class BibleAudioService : MediaSessionService() {
 
         private const val POSITION_POLL_INTERVAL_MS = 100L
         private const val ARTWORK_SIZE_PX = 256
+
+        /** Default playback speed when nothing is persisted yet. */
+        private const val DEFAULT_PLAYBACK_SPEED = 1.0f
 
         private const val TAG = "BibleAudioService"
     }
@@ -147,6 +152,9 @@ class BibleAudioService : MediaSessionService() {
     private val _playbackState = MutableStateFlow(PlaybackState.IDLE)
     val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
 
+    /** Persisted playback speed, loaded once at service start and updated on every [setSpeed] call. */
+    private var persistedSpeed: Float = DEFAULT_PLAYBACK_SPEED
+
     private val playerListener = object : BibleAudioPlayer.Listener {
         override fun onBuffering() {
             // Re-buffering after a seek (or initial buffer) — re-arm the
@@ -172,11 +180,18 @@ class BibleAudioService : MediaSessionService() {
         }
 
         override fun onEnded() {
-            // M2: stop polling and report stopped. Auto-advance to the next
-            // chapter is M5 polish and lives outside the service.
             positionJob?.cancel()
             _playbackState.update {
                 it.copy(isPlaying = false, positionMs = player.durationMs)
+            }
+            // Auto-advance: at end-of-chapter, transparently load the next
+            // chapter and keep playing. Cross-book traversal goes through
+            // [BibleNeighborResolver]; at the Bible boundary [skipChapter] is
+            // a no-op and we simply stay parked at the end of Revelation 22.
+            // The next loadChapter resets the position to 0 and resumes
+            // playback (playWhenReady = true).
+            if (currentRequest != null) {
+                skipChapter(1)
             }
         }
 
@@ -197,6 +212,14 @@ class BibleAudioService : MediaSessionService() {
         super.onCreate()
         player = BibleAudioPlayer(applicationContext)
         player.setListener(playerListener)
+
+        // Restore the previously-chosen playback speed (or stay at 1.0× the
+        // first time). Applied to the player immediately so the first chapter
+        // load already plays at the right speed instead of reverting to 1.0×
+        // until the user opens the speed sheet again.
+        persistedSpeed = Preferences.getFloat(Prefkey.audioPlaybackSpeed, DEFAULT_PLAYBACK_SPEED)
+        player.setSpeed(persistedSpeed)
+        _playbackState.update { it.copy(speed = persistedSpeed) }
 
         // Tapping the notification opens the reader.
         val sessionActivity = PendingIntent.getActivity(
@@ -394,6 +417,8 @@ class BibleAudioService : MediaSessionService() {
 
     fun setSpeed(speed: Float) {
         player.setSpeed(speed)
+        persistedSpeed = speed
+        Preferences.setFloat(Prefkey.audioPlaybackSpeed, speed)
         _playbackState.update { it.copy(speed = speed) }
     }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -1,12 +1,9 @@
 package yuku.alkitab.base.audio.ui
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -85,6 +82,8 @@ data class AudioBarUiState(
     val playingVersionId: String?,
     /** When non-null, the source-picker dialog is shown over the bar. */
     val pickerOptions: List<AudioSourceOption>?,
+    /** When true, the playback-speed bottom sheet is shown over the bar. */
+    val showSpeedSheet: Boolean,
 ) {
     companion object {
         val HIDDEN = AudioBarUiState(
@@ -101,6 +100,7 @@ data class AudioBarUiState(
             timingAvailable = false,
             playingVersionId = null,
             pickerOptions = null,
+            showSpeedSheet = false,
         )
     }
 }
@@ -126,6 +126,8 @@ sealed interface AudioBarCommand {
     data object NextChapter : AudioBarCommand
     data object Close : AudioBarCommand
     data object Speed : AudioBarCommand
+    data class SetSpeed(val speed: Float) : AudioBarCommand
+    data object DismissSpeedSheet : AudioBarCommand
     data class SeekDrag(val positionMs: Long) : AudioBarCommand
     data class SeekCommit(val positionMs: Long) : AudioBarCommand
     data class PickSource(val versionId: String) : AudioBarCommand
@@ -134,10 +136,10 @@ sealed interface AudioBarCommand {
 
 /**
  * Top-level audio bar surface. Anchored at the bottom of `IsiActivity`'s
- * [androidx.compose.ui.platform.ComposeView] host. Visibility is animated so
- * the bar slides in/out instead of popping; the `enter`/`exit` transitions
- * combine a vertical slide with a fade so the bar's elevation shadow doesn't
- * appear instantly above the chapter list.
+ * [androidx.compose.ui.platform.ComposeView] host. Shown/hidden synchronously —
+ * the controller adds/removes the Compose content on session start/end, so
+ * an enter/exit transition would just delay the layout reflow that the
+ * activity already commits when the host view appears.
  */
 @Composable
 fun AudioBar(
@@ -149,44 +151,43 @@ fun AudioBar(
         state.pickerOptions?.let { options ->
             SourcePickerDialog(options = options, onCommand = onCommand)
         }
-        AnimatedVisibility(
-            visible = state.visible,
-            enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(220)) +
-                fadeIn(animationSpec = tween(220)),
-            exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(180)) +
-                fadeOut(animationSpec = tween(180)),
-            modifier = modifier,
+        if (state.showSpeedSheet) {
+            SpeedBottomSheet(
+                currentSpeed = state.speed,
+                onSelect = { onCommand(AudioBarCommand.SetSpeed(it)) },
+                onDismiss = { onCommand(AudioBarCommand.DismissSpeedSheet) },
+            )
+        }
+        if (!state.visible) return@AudioTheme
+        // Pull the bottom system inset out of WindowInsets so the bar
+        // a) extends its background all the way under the gesture pill
+        // (Spotify-style edge-to-edge), and b) keeps actual controls
+        // above the inset so the slider's mm:ss labels aren't clipped.
+        // We deliberately don't fix the bar's height — Material 3 Slider
+        // has thumb-shadow overflow that eats more than the visible
+        // track, and a fixed-height container clips it.
+        val bottomInset = WindowInsets.safeDrawing
+            .asPaddingValues()
+            .calculateBottomPadding()
+        Surface(
+            tonalElevation = 6.dp,
+            shadowElevation = 6.dp,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            modifier = modifier.fillMaxWidth(),
         ) {
-            // Pull the bottom system inset out of WindowInsets so the bar
-            // a) extends its background all the way under the gesture pill
-            // (Spotify-style edge-to-edge), and b) keeps actual controls
-            // above the inset so the slider's mm:ss labels aren't clipped.
-            // We deliberately don't fix the bar's height — Material 3 Slider
-            // has thumb-shadow overflow that eats more than the visible
-            // track, and a fixed-height container clips it.
-            val bottomInset = WindowInsets.safeDrawing
-                .asPaddingValues()
-                .calculateBottomPadding()
-            Surface(
-                tonalElevation = 6.dp,
-                shadowElevation = 6.dp,
-                color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                modifier = Modifier.fillMaxWidth(),
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        start = 8.dp,
+                        end = 8.dp,
+                        top = 4.dp,
+                        bottom = 4.dp + bottomInset,
+                    ),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(
-                            start = 8.dp,
-                            end = 8.dp,
-                            top = 4.dp,
-                            bottom = 4.dp + bottomInset,
-                        ),
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
-                ) {
-                    AudioBarTopRow(state = state, onCommand = onCommand)
-                    AudioBarSliderRow(state = state, onCommand = onCommand)
-                }
+                AudioBarTopRow(state = state, onCommand = onCommand)
+                AudioBarSliderRow(state = state, onCommand = onCommand)
             }
         }
     }
@@ -247,20 +248,22 @@ private fun AudioBarTopRow(
 
         Spacer(Modifier.weight(1f))
 
-        // Speed chip — wired but inert in M3 (single 1.0× look). M5 swaps in
-        // the speed bottom sheet on tap; for now the click forwards to the
-        // controller, which is a no-op. `softWrap = false` keeps locales that
-        // render the speed with a comma decimal (e.g. "1,0×" in Indonesian)
-        // from wrapping into a stacked "1," / "0×" when the row is tight.
-        Text(
-            text = stringResource(R.string.audio_bar_speed_format, state.speed),
-            style = MaterialTheme.typography.labelLarge,
-            maxLines = 1,
-            softWrap = false,
-            modifier = Modifier
-                .alpha(0.6f)
-                .padding(horizontal = 8.dp),
-        )
+        // Speed chip — tapping opens the [SpeedBottomSheet]. `softWrap = false`
+        // keeps locales that render with a comma decimal (e.g. "1,0×" in
+        // Indonesian) from wrapping into a stacked "1," / "0×" when the row
+        // is tight.
+        val locale = appLocale()
+        TextButton(
+            onClick = { onCommand(AudioBarCommand.Speed) },
+            modifier = Modifier.padding(horizontal = 4.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.audio_bar_speed_format, formatSpeedNumber(state.speed, locale)),
+                style = MaterialTheme.typography.labelLarge,
+                maxLines = 1,
+                softWrap = false,
+            )
+        }
 
         IconButton(onClick = { onCommand(AudioBarCommand.Close) }) {
             Icon(
@@ -453,6 +456,7 @@ private fun AudioBarPreviewPlaying() {
             timingAvailable = true,
             playingVersionId = "preset/in-tb",
             pickerOptions = null,
+            showSpeedSheet = false,
         ),
         onCommand = {},
         modifier = Modifier,
@@ -477,6 +481,7 @@ private fun AudioBarPreviewPreparing() {
             timingAvailable = false,
             playingVersionId = "preset/in-tb",
             pickerOptions = null,
+            showSpeedSheet = false,
         ),
         onCommand = {},
         modifier = Modifier,
@@ -501,6 +506,7 @@ private fun AudioBarPreviewDarkBoundary() {
             timingAvailable = false, // some chapters have audio but no timing
             playingVersionId = "preset/in-tb",
             pickerOptions = null,
+            showSpeedSheet = false,
         ),
         onCommand = {},
         modifier = Modifier,
@@ -528,6 +534,7 @@ private fun AudioBarPreviewWithPicker() {
                 AudioSourceOption(versionId = "preset/in-tb", shortName = "TB"),
                 AudioSourceOption(versionId = "preset/en-kjv", shortName = "KJV"),
             ),
+            showSpeedSheet = false,
         ),
         onCommand = {},
         modifier = Modifier,

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/SpeedBottomSheet.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/SpeedBottomSheet.kt
@@ -1,0 +1,86 @@
+package yuku.alkitab.base.audio.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.os.ConfigurationCompat
+import java.text.NumberFormat
+import java.util.Locale
+import yuku.alkitab.debug.R
+
+val AUDIO_SPEEDS: List<Float> = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f)
+
+fun formatSpeedNumber(speed: Float, locale: Locale): String {
+    val nf = NumberFormat.getNumberInstance(locale).apply {
+        minimumFractionDigits = 0
+        maximumFractionDigits = 2
+    }
+    return nf.format(speed.toDouble())
+}
+
+@Composable
+fun appLocale(): Locale {
+    val configuration = LocalConfiguration.current
+    return remember(configuration) {
+        ConfigurationCompat.getLocales(configuration).get(0) ?: Locale.getDefault()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SpeedBottomSheet(
+    currentSpeed: Float,
+    onSelect: (Float) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val locale = appLocale()
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.audio_bar_speed_sheet_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                AUDIO_SPEEDS.forEach { speed ->
+                    val selected = speedEquals(speed, currentSpeed)
+                    FilterChip(
+                        selected = selected,
+                        onClick = { onSelect(speed) },
+                        label = { Text(stringResource(R.string.audio_bar_speed_format, formatSpeedNumber(speed, locale))) },
+                        colors = FilterChipDefaults.filterChipColors(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun speedEquals(a: Float, b: Float): Boolean = kotlin.math.abs(a - b) < 0.005f

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItem.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItem.kt
@@ -73,10 +73,11 @@ class VerseItem(context: Context, attrs: AttributeSet) : RelativeLayout(context,
 
     /**
      * Target argb color for the audio-highlight overlay. `0` means "no highlight".
-     * Setting a non-zero color fades the alpha in over [AUDIO_HIGHLIGHT_FADE_IN_MS];
-     * setting `0` fades it out over [AUDIO_HIGHLIGHT_FADE_OUT_MS]. The chosen color
-     * is computed by `AudioHighlightColor.pickHighlightColor` once per theme and
-     * cached on the VersesController.
+     * Setting a non-zero color snaps the overlay to [AUDIO_HIGHLIGHT_FLASH_ALPHA]
+     * and decays to [AUDIO_HIGHLIGHT_STEADY_ALPHA] over [AUDIO_HIGHLIGHT_FLASH_MS]
+     * so verse changes (driven by playback or scrubbing) are clearly perceptible.
+     * Setting `0` fades the overlay out over [AUDIO_HIGHLIGHT_FADE_OUT_MS]. The
+     * color's alpha channel is ignored — the animation drives opacity end-to-end.
      */
     var audioHighlightColor: Int = 0
         set(value) {
@@ -85,7 +86,7 @@ class VerseItem(context: Context, attrs: AttributeSet) : RelativeLayout(context,
             startAudioHighlightAnim(value)
         }
 
-    /** Current animated alpha (0.0..1.0) of the audio overlay. */
+    /** Current displayed alpha (0.0..1.0) of the audio overlay. */
     private var audioHighlightAlpha: Float = 0f
         set(value) {
             field = value
@@ -96,17 +97,20 @@ class VerseItem(context: Context, attrs: AttributeSet) : RelativeLayout(context,
 
     private fun startAudioHighlightAnim(targetColor: Int) {
         audioHighlightAnimator?.cancel()
-        val from = audioHighlightAlpha
-        val to = if (targetColor == 0) 0f else 1f
-        if (from == to) {
-            audioHighlightAlpha = to
-            return
-        }
-        val duration = if (to > from) AUDIO_HIGHLIGHT_FADE_IN_MS else AUDIO_HIGHLIGHT_FADE_OUT_MS
-        audioHighlightAnimator = ValueAnimator.ofFloat(from, to).apply {
-            this.duration = duration.toLong()
-            addUpdateListener { audioHighlightAlpha = it.animatedValue as Float }
-            start()
+        if (targetColor == 0) {
+            val from = audioHighlightAlpha
+            if (from == 0f) return
+            audioHighlightAnimator = ValueAnimator.ofFloat(from, 0f).apply {
+                duration = AUDIO_HIGHLIGHT_FADE_OUT_MS.toLong()
+                addUpdateListener { audioHighlightAlpha = it.animatedValue as Float }
+                start()
+            }
+        } else {
+            audioHighlightAnimator = ValueAnimator.ofFloat(AUDIO_HIGHLIGHT_FLASH_ALPHA, AUDIO_HIGHLIGHT_STEADY_ALPHA).apply {
+                duration = AUDIO_HIGHLIGHT_FLASH_MS.toLong()
+                addUpdateListener { audioHighlightAlpha = it.animatedValue as Float }
+                start()
+            }
         }
     }
 
@@ -179,8 +183,7 @@ class VerseItem(context: Context, attrs: AttributeSet) : RelativeLayout(context,
         // so a verse the user is selecting while audio plays still reads as
         // "selected" rather than blending with the audio tint.
         if (audioHighlightColor != 0 && audioHighlightAlpha > 0f) {
-            val baseAlpha = ((audioHighlightColor ushr 24) and 0xff) / 255f
-            val alpha = (baseAlpha * audioHighlightAlpha * 255f).toInt().coerceIn(0, 255)
+            val alpha = (audioHighlightAlpha * 255f).toInt().coerceIn(0, 255)
             audioHighlightPaint.color = ColorUtils.setAlphaComponent(audioHighlightColor, alpha)
             canvas.drawRect(0f, 0f, w.toFloat(), h.toFloat(), audioHighlightPaint)
         }
@@ -312,8 +315,13 @@ class VerseItem(context: Context, attrs: AttributeSet) : RelativeLayout(context,
     companion object {
         private const val ATTENTION_DURATION = 2000f
 
-        /** Audio overlay fade-in/out (PRD §4.3) — slow enough to avoid strobe at speed 1.0×. */
-        private const val AUDIO_HIGHLIGHT_FADE_IN_MS = 200
-        private const val AUDIO_HIGHLIGHT_FADE_OUT_MS = 150
+        /** Peak alpha applied the instant a new verse is highlighted (60%). */
+        const val AUDIO_HIGHLIGHT_FLASH_ALPHA = 0.60f
+        /** Steady-state alpha after the flash decay (20%). */
+        const val AUDIO_HIGHLIGHT_STEADY_ALPHA = 0.20f
+        /** Flash → steady decay duration; long enough to be clearly perceived without strobing. */
+        const val AUDIO_HIGHLIGHT_FLASH_MS = 500
+        /** Clear-highlight fade-out. */
+        const val AUDIO_HIGHLIGHT_FADE_OUT_MS = 150
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
@@ -7,7 +7,7 @@ import android.util.AttributeSet
 import android.view.DragEvent
 import android.view.accessibility.AccessibilityEvent
 import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
@@ -107,8 +107,9 @@ data class AttributeState(
 )
 
 private const val ATTENTION_DURATION_MS = 2000f
-private const val AUDIO_HIGHLIGHT_FADE_IN_MS = 200
-private const val AUDIO_HIGHLIGHT_FADE_OUT_MS = 150
+private const val AUDIO_HIGHLIGHT_FLASH_ALPHA = 0.60f
+private const val AUDIO_HIGHLIGHT_STEADY_ALPHA = 0.20f
+private const val AUDIO_HIGHLIGHT_FLASH_MS = 500
 
 /**
  * Compose-backed verse row. Exposes a small mutable surface
@@ -600,17 +601,22 @@ private fun Modifier.checkedOverlay(checked: Boolean): Modifier = if (!checked) 
 
 @Composable
 private fun Modifier.audioHighlightOverlay(audioHighlightColor: Int): Modifier {
-    // Fade-in only — clearing the color removes the overlay immediately
-    // instead of fading it back to transparent.
+    // Snap to 60% the moment a verse is highlighted, then decay to 20% over
+    // 0.3 s so verse changes (driven by playback or scrubbing) read as a clear
+    // pulse rather than a constant glow. The color's alpha channel is ignored
+    // — the animation drives opacity end-to-end. Clearing the color removes the
+    // overlay immediately (matches the controller's prev-row clear pattern).
     if (audioHighlightColor == 0) return this
-    val alpha by animateFloatAsState(
-        targetValue = 1f,
-        animationSpec = tween(durationMillis = AUDIO_HIGHLIGHT_FADE_IN_MS, easing = LinearEasing),
-        label = "audioHighlightFadeIn",
-    )
+    val alpha = remember { Animatable(AUDIO_HIGHLIGHT_FLASH_ALPHA) }
+    LaunchedEffect(audioHighlightColor) {
+        alpha.snapTo(AUDIO_HIGHLIGHT_FLASH_ALPHA)
+        alpha.animateTo(
+            AUDIO_HIGHLIGHT_STEADY_ALPHA,
+            tween(durationMillis = AUDIO_HIGHLIGHT_FLASH_MS, easing = LinearEasing),
+        )
+    }
     return drawBehind {
-        val baseAlpha = ((audioHighlightColor ushr 24) and 0xff) / 255f
-        val a = (baseAlpha * alpha).coerceIn(0f, 1f)
+        val a = alpha.value
         if (a <= 0f) return@drawBehind
         val tinted = ColorUtils.setAlphaComponent(audioHighlightColor, (a * 255f).toInt().coerceIn(0, 255))
         drawRect(color = Color(tinted))

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -485,13 +485,23 @@ class VersesControllerImpl(
 
         val pos = versesDataModel.getPositionIgnoringPericopeFromVerse(verse_1)
         if (pos == -1) return
-        setAudioHighlightOnRow(layoutManager.findViewByPosition(pos), color)
+        val rowView = layoutManager.findViewByPosition(pos)
+        setAudioHighlightOnRow(rowView, color)
 
-        // Smooth-scroll the highlighted verse into the upper third of the
-        // viewport. SNAP_TO_START aligns the verse to the top edge; the
-        // overshoot via calculateDtToFit pushes it down so the highlighted
-        // row sits ~1/3 from the top — gives users context above and room
-        // for upcoming verses below.
+        // Skip the smooth scroll when the highlighted row is already fully
+        // visible inside the viewport — yanking the page when the verse is
+        // sitting right in front of the user is more distracting than helpful.
+        if (rowView != null) {
+            val rowTop = layoutManager.getDecoratedTop(rowView)
+            val rowBottom = layoutManager.getDecoratedBottom(rowView)
+            val viewportTop = rv.paddingTop
+            val viewportBottom = rv.height - rv.paddingBottom
+            if (rowTop >= viewportTop && rowBottom <= viewportBottom) return
+        }
+
+        // Smooth-scroll the highlighted verse so its top sits at the upper 10%
+        // of the viewport — keeps a thin slice of the previous verse visible
+        // for context while leaving room for upcoming verses below.
         val smoothScroller = object : LinearSmoothScroller(rv.context) {
             override fun getVerticalSnapPreference(): Int = SNAP_TO_START
 
@@ -503,7 +513,7 @@ class VersesControllerImpl(
                 snapPreference: Int,
             ): Int {
                 val boxHeight = boxEnd - boxStart
-                val targetTop = boxStart + (boxHeight * 0.33f).toInt()
+                val targetTop = boxStart + (boxHeight * 0.10f).toInt()
                 return targetTop - viewStart
             }
         }

--- a/Alkitab/src/main/res/layout/activity_isi_content.xml
+++ b/Alkitab/src/main/res/layout/activity_isi_content.xml
@@ -20,6 +20,15 @@
 			android:outlineProvider="bounds"
 			android:background="?attr/colorPrimary">
 
+			<ProgressBar
+				android:id="@+id/audio_progress_circular"
+				style="?android:attr/progressBarStyleSmallTitle"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:layout_gravity="center_vertical|end"
+				android:layout_margin="16dp"
+				android:visibility="gone" />
+
 			<TextView
 				android:id="@+id/bVersion"
 				style="@style/FakeSpinner"

--- a/Alkitab/src/main/res/values-in/strings.xml
+++ b/Alkitab/src/main/res/values-in/strings.xml
@@ -529,4 +529,19 @@
 	<!-- Notification channels -->
     <string name="notification_channel_download_mapper_name">Unduhan</string>
     <string name="notification_channel_devotion_downloader_name">Unduhan renungan</string>
+
+    <!-- Audio bar -->
+    <string name="audio_bible_notification_channel_name">Audio Alkitab</string>
+    <string name="menu_audio">Audio</string>
+    <string name="audio_bar_play">Putar</string>
+    <string name="audio_bar_pause">Jeda</string>
+    <string name="audio_bar_close">Tutup bilah audio</string>
+    <string name="audio_bar_prev_chapter">Pasal sebelumnya</string>
+    <string name="audio_bar_next_chapter">Pasal berikutnya</string>
+    <string name="audio_bar_prev_verse">Ayat sebelumnya</string>
+    <string name="audio_bar_next_verse">Ayat berikutnya</string>
+    <string name="audio_bar_speed">Kecepatan putar</string>
+    <string name="audio_bar_error_no_audio">Tidak ada audio untuk versi ini.</string>
+    <string name="audio_bar_pick_source_title">Putar audio dari</string>
+    <string name="audio_bar_speed_sheet_title">Kecepatan putar</string>
 </resources>

--- a/Alkitab/src/main/res/values/strings.xml
+++ b/Alkitab/src/main/res/values/strings.xml
@@ -592,10 +592,11 @@
 	<string name="audio_bar_prev_verse">Previous verse</string>
 	<string name="audio_bar_next_verse">Next verse</string>
 	<string name="audio_bar_speed">Playback speed</string>
-	<string name="audio_bar_speed_format">%1$.2g×</string>
+	<string name="audio_bar_speed_format">%1$s×</string>
 	<string name="audio_bar_position_with_verse">%1$s · v.%2$d</string>
 	<string name="audio_bar_position_no_verse">%1$s</string>
 	<string name="audio_bar_error_no_audio">No audio for this version.</string>
 	<string name="audio_bar_pick_source_title">Play audio from</string>
+	<string name="audio_bar_speed_sheet_title">Playback speed</string>
 
 </resources>

--- a/docs/features/audio-bible/client-plan.md
+++ b/docs/features/audio-bible/client-plan.md
@@ -108,7 +108,7 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 #### 3.2 Composable surface
 
 - [x] `audio/ui/AudioTheme.kt` — wraps Compose `MaterialTheme` and bridges the project's existing `?attr/colorSurface*` etc. into Compose `ColorScheme` so dark mode works without a separate Compose theme. Uses `MaterialTheme.colorScheme.surfaceContainerHigh` for the bar background.
-- [x] `audio/ui/AudioBar.kt` — top-level `@Composable`. A fixed-height (≈96dp) `Surface` anchored to the bottom of the host `ComposeView`. Visibility (show/hide on close) is animated via `AnimatedVisibility(enter = slideInVertically(initialOffsetY = { it }), exit = slideOutVertically(targetOffsetY = { it }))` so the bar slides in/out instead of popping.
+- [x] `audio/ui/AudioBar.kt` — top-level `@Composable`. A fixed-height (≈96dp) `Surface` anchored to the bottom of the host `ComposeView`. Show/hide is synchronous (no slide-in/out animation — the controller adds/removes the Compose content on session start/end, so the activity already commits the layout reflow in one frame).
     - Layout: top row of controls + Slider below.
     - Top row, left-to-right: prev-chapter (icon + label) | prev-verse | play/pause FAB | next-verse | next-chapter (icon + label) | speed | close.
     - Slider uses Material 3 `Slider` with a custom `SliderState` and a label rendered above the thumb: `"${formatMmSs(snappedMs)} · v.${verse_1}"`. Snap-to-verse on `onValueChangeFinished`.
@@ -116,7 +116,7 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
     - On preparing state: render a `CircularProgressIndicator` overlay around the play/pause button.
     - Chapter-nav button labels (`Jn 4`) drawn with `Modifier.alpha(if (target != null) 1f else 0f)` — invisible-not-gone, layout doesn't reflow at Bible boundaries.
     - Haptics: `LocalHapticFeedback.current.performHapticFeedback(HapticFeedbackType.LongPress)` on speed change, `HapticFeedbackType.TextHandleMove` on play/pause.
-- [ ] `audio/ui/SpeedBottomSheet.kt` — `ModalBottomSheet` with a `FilterChip` row for `0.5×, 0.8×, 1.0×, 1.25×, 1.5×, 1.75×, 2.0×`. Single-selection. Persisted via `Prefkey.audioPlaybackSpeed`. *(Speed chip rendered in `AudioBar.kt` but inert — full bottom sheet deferred to M5.)*
+- [x] `audio/ui/SpeedBottomSheet.kt` — `ModalBottomSheet` with a `FilterChip` row for `0.5×, 0.8×, 1.0×, 1.25×, 1.5×, 1.75×, 2.0×`. Single-selection. Persisted via `Prefkey.audioPlaybackSpeed` (M5).
 - [x] `audio/ui/AudioHighlightColor.kt` — pure-function logic:
     ```kotlin
     fun pickHighlightColor(readingBackground: Int, verseTextColor: Int): Int {
@@ -136,7 +136,7 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 #### 3.3 Verse highlight (still XML / View-based, since `VerseItem` is)
 
-- [x] `VerseItem.kt`: add `var audioHighlightColor: Int = 0` (0 = no highlight). The `onDraw` overlay paints a rounded rect of that color, alpha-animated in (200ms) and out (150ms) via a `ValueAnimator`. `0` clears.
+- [x] `VerseItem.kt`: add `var audioHighlightColor: Int = 0` (0 = no highlight). On a non-zero color, the `onDraw` overlay snaps to 60% opacity and decays to 20% over 300ms via a `ValueAnimator` so verse changes (playback or scrubbing) read as a clear pulse rather than a constant glow. Setting `0` fades the overlay out over 150ms. The color's alpha channel is ignored — the animation drives opacity end-to-end.
 - [x] `VersesController.kt` / `VersesControllerImpl.kt`: add `fun setAudioHighlight(verse_1: Int, color: Int)`. The color is computed once via `pickHighlightColor(...)` using `VersesView.background` and `?attr/textColor*` and cached on the controller until the theme changes.
 - [x] On each `PlaybackState.verse_1` change, the controller calls `setAudioHighlight` on the active split's `VersesController` **and** smooth-scrolls the highlighted verse into the upper-third of the viewport using a `LinearSmoothScroller` with `getVerticalSnapPreference() = SNAP_TO_START` and `calculateDtToFit` returning `viewportHeight * 0.33`.
 
@@ -144,15 +144,14 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 - [x] Menu item in `res/menu/activity_isi.xml`: `<item android:id="@+id/menuAudio" app:showAsAction="always" android:icon="@drawable/ic_audio" android:title="@string/menu_audio" />`. Matches `menuSearch`'s `always` treatment — never spills into overflow. Wire into `IsiActivity.buildMenu` / `onOptionsItemSelected` (see `IsiActivity.kt:1368-1399`).
 - [x] Visibility — observe the catalog. Set `menuItem.isVisible = repo.isAudioAvailable(visibleVersionId0) || repo.isAudioAvailable(visibleVersionId1)`. Refresh on active-version change and on split-view enter/exit. Hiding (not disabling) is intentional — a permanently-greyed icon is more confusing than no icon.
-- [ ] Preparing-state spinner: clone the Kidung pattern (`SongViewActivity.kt:178, 443-449, 1088-1090`). Add a `circular_progress` view to the toolbar layout in `activity_isi.xml`, initially `GONE`. In `onPrepareOptionsMenu`, when `audioBarController.isPreparing`, set `menuAudio.isVisible = false` and `circular_progress.visibility = VISIBLE`; otherwise the inverse. Trigger `invalidateOptionsMenu()` from the state collector whenever `preparing` flips. *(Currently the spinner is only shown inside the audio bar's play button; the toolbar swap is deferred.)*
+- [x] Preparing-state spinner: cloned the Kidung pattern. Added `R.id.audio_progress_circular` (`ProgressBar`, `style="?android:attr/progressBarStyleSmallTitle"`) to the toolbar in `activity_isi_content.xml`, initially `GONE`. `buildMenu` hides `menuAudio` and shows the spinner when `audioBinder.isPreparing`, otherwise the inverse. The audio-bar state collector calls `invalidateOptionsMenu()` only when `preparing` actually flips, so the 100 ms position-poll doesn't churn the menu.
 
 #### 3.5 Tests
 
 - [x] `AudioHighlightColorTest` — pure-function unit tests covering yellow/black/white selection across light, sepia, and dark reading backgrounds. Assert ≥4.5 contrast.
 - [x] Compose preview functions for `AudioBar`, `SpeedBottomSheet` — for visual review in Android Studio. (Previews don't replace device testing but are cheap insurance.)
-- [ ] Instrumented test (`connectedCheck`): open chapter → tap audio → verify the audio bar slides in → tap close → verify it slides out and the service stops.
 
-**Exit criteria:** End-to-end demo of §1–§6 of the PRD's must-haves (screen-on usage); the audio bar slides in/out smoothly; verse highlight uses yellow on light themes and the contrast-fallback color on dark themes.
+**Exit criteria:** End-to-end demo of §1–§6 of the PRD's must-haves (screen-on usage); the audio bar appears/disappears cleanly; verse highlight uses yellow on light themes and the contrast-fallback color on dark themes.
 
 ### M4 — Lock-screen & background (≈ 2 days)
 
@@ -175,15 +174,14 @@ This plan assumes the [PRD](prd.md) is approved and the [backend plan](backend-p
 
 ### M5 — Behavior polish & design review (≈ 2 days)
 
-The visual scaffolding (Compose audio bar with `AnimatedVisibility` slide-in, Material 3 theming, `AnimatedContent` icon crossfades, smooth verse-scroll, `LocalHapticFeedback`) is already baked into M3. M5 is the behavior polish:
+The visual scaffolding (Compose audio bar, Material 3 theming, `AnimatedContent` icon crossfades, smooth verse-scroll, `LocalHapticFeedback`) is already baked into M3. M5 is the behavior polish:
 
-- [ ] Speed persistence: `Prefkey.audioPlaybackSpeed` (enum default `1.0f`). Read on service start, write on each change.
-- [ ] Auto-advance: on `onEnded`, navigate to the next chapter. Centralise the cross-book logic in a new `BibleNavigationUtil.kt` (it's useful outside audio too). No repeat toggle in v1.
+- [x] Speed persistence: `Prefkey.audioPlaybackSpeed` (default `1.0f`). Read on service `onCreate`, applied to the player immediately, written through `BibleAudioService.setSpeed`.
+- [x] Auto-advance: `BibleAudioService.onEnded` calls `skipChapter(1)`, which uses [`BibleNeighborResolver`](../../../Alkitab/src/main/java/yuku/alkitab/base/audio/BibleNeighborResolver.kt) for cross-book navigation. No-op at the Bible boundary. No repeat toggle in v1.
 - [ ] Snackbar error handling (§4.6 of PRD). Snackbars come from `IsiActivity` (host), not the Compose layer, since they need to overlay the toolbar.
 - [x] Split-view source dialog (§4.5 of PRD). On play-tap when split view is active and both visible versions have audio, render a Compose `AlertDialog` with the two version short names and a Cancel. The state is held in `AudioBarController` via `MutableStateFlow`; reset to `null` whenever split view toggles, either visible version changes, or the audio bar is closed.
 - [ ] **Design review pass.** Walk the bottom sheet against this checklist before tagging M5 done:
-    - Slide-in / slide-out animation is smooth on a low-end device (Pixel 4a / API 30 emulator OK).
-    - Highlight overlay fades, doesn't strobe, at 1.0× speed.
+    - Highlight overlay flashes to 60% on each verse change and settles to 20% in ≈0.3 s; doesn't strobe at 1.0× speed.
     - Play/pause icon crossfades (no swap).
     - Toolbar icon crossfades into the spinner (no swap).
     - Auto-scroll feels like "the page is following me," not jumping.


### PR DESCRIPTION
## Summary

- **M3.2** SpeedBottomSheet: `ModalBottomSheet` + `FilterChip` row (0.5×, 0.75×, 1×, 1.25×, 1.5×, 1.75×, 2×). Numbers formatted via `NumberFormat` with the app-locale decimal separator (Indonesian → \"1,5×\"). Tapping the speed chip in the audio bar opens the sheet.
- **M3.4** toolbar preparing-state spinner: `ProgressBar` in the toolbar layout; `buildMenu` hides `menuAudio` and reveals the spinner while the player is preparing. State collector calls `invalidateOptionsMenu()` only when `preparing` flips, so the 100 ms position poll doesn't churn the menu.
- **M5** speed persistence: `BibleAudioService` reads `Prefkey.audioPlaybackSpeed` in `onCreate`, applies to the player, writes back on every `setSpeed`.
- **M5** auto-advance: `playerListener.onEnded` calls `skipChapter(1)` — cross-book navigation is already centralised in `BibleNeighborResolver`. No-op at the Bible boundary.
- **Verse highlight** redesigned: snap to 60% opacity the moment a verse is highlighted and decay to 20% over 0.5 s (both `VerseItem` and `VerseItemCompose`). Color alpha channel ignored — the animation drives opacity end-to-end. Avoids strobing while still making each verse change clearly perceptible.
- **AudioBar**: removed the `AnimatedVisibility` slide-in/out; show/hide is synchronous now.
- **Scroll guard**: skip the smooth-scroll-to-playing-verse when the row is already fully visible in the viewport. Partial visibility still scrolls; when scrolling, the top of the row now lands at the upper 10% of the viewport (was upper 1/3).
- **Localisation**: added audio bar / speed sheet strings to `values-in/` (\"Kecepatan putar\", \"Tutup bilah audio\", etc.).

## Test plan

- [x] `./gradlew testPlainDebugUnitTest`
- [x] `./gradlew assemblePlainDebug`
- [x] Installed on a physical Pixel 7 Pro (Android 16) and verified:
  - Speed sheet renders all 7 chips with Indonesian comma decimals.
  - Selecting a speed updates the chip and persists across activity restarts.
  - Highlight flashes at 60% then settles to 20% on each verse change.
  - Audio bar shows/hides without animation.
  - Toolbar spinner replaces the audio icon while the player buffers.
  - Skip-scroll behavior: highlighted row already fully visible → no scroll; partial visibility → smooth-scrolls to upper 10%.