### PR TITLE
feat(audio): start playback from the selected verse

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -168,6 +168,8 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     // --- VerseActionModeActions overrides ---
     override fun uncheckAllVersesSplit0() { lsSplit0.uncheckAllVerses(true) }
     override fun onActionModeDestroyed() { actionMode = null }
+    override fun isAudioAvailableForVerseAction(): Boolean = audioBinder.isAvailable
+    override fun playAudioFromVerse(verse_1: Int) { audioBinder.showFromVerse(verse_1) }
 
     // --- ReaderGestureActions overrides (state is read via ReaderGestureHost below) ---
     override fun onFloaterAriSelected(ari: Int) = jumpToAri(ari)

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeActions.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeActions.kt
@@ -23,6 +23,12 @@ interface VerseActionModeActions {
     /** Returns whether the current version(s) are eligible for Ribka reporting. */
     fun checkRibkaEligibility(): RibkaEligibility
 
+    /** Whether the "play audio from this verse" item should be offered. */
+    fun isAudioAvailableForVerseAction(): Boolean
+
+    /** Opens the audio bar and starts playback at the given 1-based verse. */
+    fun playAudioFromVerse(verse_1: Int)
+
     /** Called from `onDestroyActionMode` so the Activity can clear its `actionMode` field. */
     fun onActionModeDestroyed()
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
@@ -162,6 +162,9 @@ class VerseActionModeController(
         val menuRibkaReport = menu.findItem(R.id.menuRibkaReport)
         menuRibkaReport.isVisible = single && actions.checkRibkaEligibility() != RibkaEligibility.None
 
+        val menuPlayAudioFromVerse = menu.findItem(R.id.menuPlayAudioFromVerse)
+        menuPlayAudioFromVerse.isVisible = single && actions.isAudioAvailableForVerseAction()
+
         // extensions
         extensions.clear()
         extensions.addAll(ExtensionManager.getExtensions())
@@ -298,6 +301,12 @@ class VerseActionModeController(
                         }
                     }
                 )
+                true
+            }
+
+            R.id.menuPlayAudioFromVerse -> {
+                actions.playAudioFromVerse(selected.get(0))
+                mode.finish()
                 true
             }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
@@ -136,6 +136,14 @@ class AudioBarController(
     /** The audio source picked for the current session. Cleared on [hide]. */
     private var selectedSource: AudioSourceOption? = null
 
+    /**
+     * 1-based verse the next [buildRequest] should seek to, or `0` for the
+     * chapter start. Set by [showFromVerse] and consumed (reset to `0`) the
+     * moment [buildRequest] reads it, so neighbor/auto-advance loads always
+     * start at the beginning.
+     */
+    private var startVerse1 = 0
+
     private val _uiState = MutableStateFlow(AudioBarUiState.HIDDEN)
     val uiState: StateFlow<AudioBarUiState> = _uiState.asStateFlow()
 
@@ -270,6 +278,7 @@ class AudioBarController(
             chapter_1 = availableChapter,
             displayTitle = "${sourceBook.shortName} $availableChapter",
             displaySubtitle = source.shortName,
+            startVerse_1 = 0,
         )
         service?.loadChapter(request) ?: run { pendingLoad = host }
         recomputeChapterLabels(host)
@@ -286,6 +295,26 @@ class AudioBarController(
         } else {
             show()
         }
+    }
+
+    /**
+     * Opens the bar and starts playback seeked to [verse_1] (1-based). If the
+     * bar is already showing the same chapter, just seeks rather than reloading
+     * the MP3. Falls back to a normal start-at-0 load when the selected version
+     * has no timing for that verse (handled service-side).
+     */
+    fun showFromVerse(verse_1: Int) {
+        val host = this.host ?: return
+        val svc = service
+        if (requestedVisible && svc != null &&
+            host.audioCurrentBook().bookId == lastServiceBookId &&
+            host.audioCurrentChapter1() == lastServiceChapter1
+        ) {
+            svc.seekToVerse(verse_1)
+            return
+        }
+        startVerse1 = verse_1
+        show()
     }
 
     fun show() {
@@ -330,6 +359,7 @@ class AudioBarController(
         requestedVisible = false
         dragging = false
         selectedSource = null
+        startVerse1 = 0
         lastServiceBookId = -1
         lastServiceChapter1 = 0
         service?.stop()
@@ -424,12 +454,15 @@ class AudioBarController(
         val sourceBook = host.audioBookInVersion(source.versionId, readerBook.bookId)
             ?: return null
         val availableChapter = chapter1.coerceIn(1, sourceBook.chapter_count)
+        val sv = startVerse1
+        startVerse1 = 0
         return BibleAudioService.AudioRequest(
             versionId = source.versionId,
             bookId = sourceBook.bookId,
             chapter_1 = availableChapter,
             displayTitle = "${sourceBook.shortName} $availableChapter",
             displaySubtitle = source.shortName,
+            startVerse_1 = sv,
         )
     }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
@@ -415,12 +415,14 @@ class BibleAudioService : MediaSessionService() {
 
     /**
      * Seeks playback to the start of verse [verse_1] using the loaded timing.
-     * No-op when timing isn't loaded or has no entry for that verse. Used when
-     * the user picks a verse while this chapter is already playing.
+     * Routes through the same deferred-seek gate as [AudioRequest.startVerse_1]
+     * so a pick made while the chapter is still preparing (player not READY or
+     * timing not yet fetched) lands once both are ready, instead of being lost.
+     * Used when the user picks a verse while this chapter is already playing.
      */
     fun seekToVerse(verse_1: Int) {
-        val target = highlightTracker.getVerseStartMs(verse_1) ?: return
-        seekTo(target)
+        pendingStartVerse1 = verse_1
+        tryInitialSeek()
     }
 
     fun play() {

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
@@ -99,6 +99,12 @@ class BibleAudioService : MediaSessionService() {
         val chapter_1: Int,
         val displayTitle: String,
         val displaySubtitle: String,
+        /**
+         * 1-based verse to start playback at, or `0` to start at the beginning of
+         * the chapter. Honored only once timing is loaded; falls back to position
+         * 0 when the chapter has no timing or no entry for this verse.
+         */
+        val startVerse_1: Int,
     )
 
     /**
@@ -142,6 +148,17 @@ class BibleAudioService : MediaSessionService() {
     private var currentRequest: AudioRequest? = null
 
     /**
+     * Deferred initial-seek state for [AudioRequest.startVerse_1]. The seek can
+     * only run once BOTH the player is READY ([playerReadyForSeek]) and timing
+     * has resolved ([timingLoaded]) — the two arrive asynchronously and in
+     * either order. [tryInitialSeek] is called from both completion points and
+     * fires (or gives up, falling back to position 0) when both are ready.
+     */
+    private var pendingStartVerse1 = 0
+    private var playerReadyForSeek = false
+    private var timingLoaded = false
+
+    /**
      * Lazily-decoded app-icon bytes used as the lock-screen / notification
      * artwork. Decoded from the per-flavor `R.mipmap.ic_launcher` (which can be
      * an adaptive XML on API 26+, hence going through [ResourcesCompat] +
@@ -168,6 +185,8 @@ class BibleAudioService : MediaSessionService() {
 
         override fun onReady() {
             startPositionPolling()
+            playerReadyForSeek = true
+            tryInitialSeek()
             _playbackState.update {
                 it.copy(
                     preparing = false,
@@ -307,6 +326,9 @@ class BibleAudioService : MediaSessionService() {
         loadJob?.cancel()
         timingJob?.cancel()
         currentRequest = request
+        pendingStartVerse1 = request.startVerse_1
+        playerReadyForSeek = false
+        timingLoaded = false
         // New chapter — reset highlight from any previous chapter and clear errors.
         highlightTracker.setTiming(emptyList())
         _playbackState.update {
@@ -367,7 +389,38 @@ class BibleAudioService : MediaSessionService() {
                 request.chapter_1,
             )
             highlightTracker.setTiming(timing?.verses ?: emptyList())
+            timingLoaded = true
+            tryInitialSeek()
         }
+    }
+
+    /**
+     * Performs the deferred start-verse seek requested via
+     * [AudioRequest.startVerse_1]. No-op until the player is READY and timing
+     * has resolved. Once both are ready: seeks to the verse's start if timing
+     * has an entry for it, otherwise clears the pending seek (graceful fallback
+     * to position 0). Clearing on every resolved-timing outcome stops a stale
+     * verse from seeking a later chapter that happens to lack timing.
+     */
+    private fun tryInitialSeek() {
+        if (pendingStartVerse1 <= 0 || !playerReadyForSeek) return
+        val startMs = highlightTracker.getVerseStartMs(pendingStartVerse1)
+        if (startMs != null) {
+            pendingStartVerse1 = 0
+            seekTo(startMs)
+        } else if (timingLoaded) {
+            pendingStartVerse1 = 0
+        }
+    }
+
+    /**
+     * Seeks playback to the start of verse [verse_1] using the loaded timing.
+     * No-op when timing isn't loaded or has no entry for that verse. Used when
+     * the user picks a verse while this chapter is already playing.
+     */
+    fun seekToVerse(verse_1: Int) {
+        val target = highlightTracker.getVerseStartMs(verse_1) ?: return
+        seekTo(target)
     }
 
     fun play() {
@@ -475,6 +528,7 @@ class BibleAudioService : MediaSessionService() {
                 chapter_1 = chapter1,
                 displayTitle = "${book.shortName} $chapter1",
                 displaySubtitle = versionShortName,
+                startVerse_1 = 0,
             )
         )
     }

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/HighlightTracker.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/HighlightTracker.kt
@@ -149,6 +149,13 @@ class HighlightTracker {
     }
 
     /**
+     * Returns the `startMs` of the verse numbered [verse_1], or `null` when no
+     * timing is loaded or the chapter has no timing for that verse. Used to seek
+     * playback to a verse the user picked in the reader.
+     */
+    fun getVerseStartMs(verse_1: Int): Long? = verses.firstOrNull { it.verse_1 == verse_1 }?.startMs
+
+    /**
      * Returns the `startMs` of the verse that comes after [positionMs], or
      * `null` if no later verse exists or no timing is loaded.
      *

--- a/Alkitab/src/main/res/menu/context_isi.xml
+++ b/Alkitab/src/main/res/menu/context_isi.xml
@@ -58,6 +58,12 @@
 		app:showAsAction="always" />
 
 	<item
+		android:id="@+id/menuPlayAudioFromVerse"
+		android:icon="@drawable/ic_audio"
+		android:title="@string/audio_play_from_verse"
+		app:showAsAction="never" />
+
+	<item
 		android:id="@+id/menuAddSomething"
 		android:icon="@drawable/ic_menu_add_light"
 		android:title="@string/menuAddSomething"

--- a/Alkitab/src/main/res/values-in/strings.xml
+++ b/Alkitab/src/main/res/values-in/strings.xml
@@ -544,4 +544,5 @@
     <string name="audio_bar_error_no_audio">Tidak ada audio untuk versi ini.</string>
     <string name="audio_bar_pick_source_title">Putar audio dari</string>
     <string name="audio_bar_speed_sheet_title">Kecepatan putar</string>
+    <string name="audio_play_from_verse">Putar audio dari ayat ini</string>
 </resources>

--- a/Alkitab/src/main/res/values/strings.xml
+++ b/Alkitab/src/main/res/values/strings.xml
@@ -598,5 +598,6 @@
 	<string name="audio_bar_error_no_audio">No audio for this version.</string>
 	<string name="audio_bar_pick_source_title">Play audio from</string>
 	<string name="audio_bar_speed_sheet_title">Playback speed</string>
+	<string name="audio_play_from_verse">Play audio from this verse</string>
 
 </resources>

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/HighlightTrackerTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/HighlightTrackerTest.kt
@@ -200,6 +200,43 @@ class HighlightTrackerTest {
         assertEquals(0, t.peekVerseAt(500L))
     }
 
+    // -- getVerseStartMs -------------------------------------------------------
+
+    @Test
+    fun `getVerseStartMs returns the startMs of the matching verse`() {
+        val t = HighlightTracker()
+        t.setTiming(contiguous)
+        assertEquals(0L, t.getVerseStartMs(1))
+        assertEquals(1000L, t.getVerseStartMs(2))
+        assertEquals(2000L, t.getVerseStartMs(3))
+    }
+
+    @Test
+    fun `getVerseStartMs returns null when the verse has no timing entry`() {
+        val t = HighlightTracker()
+        t.setTiming(contiguous)
+        assertEquals(null, t.getVerseStartMs(14))
+        assertEquals(null, t.getVerseStartMs(0))
+    }
+
+    @Test
+    fun `getVerseStartMs returns null when no timing is loaded`() {
+        val t = HighlightTracker()
+        assertEquals(null, t.getVerseStartMs(1))
+    }
+
+    @Test
+    fun `getVerseStartMs honors a non-contiguous verse start offset`() {
+        val t = HighlightTracker()
+        t.setTiming(
+            listOf(
+                VerseTiming(verse_1 = 13, startMs = 0L, endMs = 1000L),
+                VerseTiming(verse_1 = 14, startMs = 1500L, endMs = 2500L),
+            )
+        )
+        assertEquals(1500L, t.getVerseStartMs(14))
+    }
+
     // -- getNextVerseStartMs ---------------------------------------------------
 
     @Test


### PR DESCRIPTION
## Summary
Addresses user feedback: *"Pick verse 14, audio still starts from verse 1 — should start from verse 14."*

- Adds a **"Play audio from this verse"** item to the verse action mode, shown **only when exactly one verse is selected** and audio is available for the current version. Reuses the toolbar audio icon (`ic_audio`) and adds English + Indonesian strings (`audio_play_from_verse`).
- Tapping it opens the audio bar (same path as the toolbar audio button) and **seeks playback to the selected verse's start time** from the chapter timing data.
- Plumbs an optional `startVerse_1` through `AudioRequest` → `BibleAudioService.loadChapter()`. The initial seek is **deferred until both the player is READY and timing has resolved** (they arrive asynchronously, in either order) — never blocks.
- **Graceful fallback to position 0** when the version has no timing / the verse has no timing entry.
- If the **same chapter is already playing**, seeks in place instead of reloading the MP3.

## Implementation notes
- `HighlightTracker.getVerseStartMs(verse_1)` — resolves a verse number to its start ms.
- `BibleAudioService` — `pendingStartVerse1` / `playerReadyForSeek` / `timingLoaded` gate `tryInitialSeek()`; new `seekToVerse()` for the already-playing case.
- `AudioBarController.showFromVerse(verse_1)` — entry point from the action mode; seek-in-place vs. start-session decision.
- All `AudioRequest(...)` call sites pass `startVerse_1` explicitly (no Kotlin default params, per project style).

## Test plan
- [x] `./gradlew assemblePlainDebug` — BUILD SUCCESSFUL
- [x] `./gradlew testPlainDebugUnitTest --tests "yuku.alkitab.base.audio.HighlightTrackerTest"` — added 4 tests for `getVerseStartMs` (match, missing verse, no timing, non-contiguous offset)
- [ ] **UI behavior cannot be verified headless**: menu item visibility for single vs. multi-select, and the actual seek-to-verse on tap, were not exercised on a device/emulator.