### PR TITLE
Center audio bar transport controls

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -204,50 +204,9 @@ private fun AudioBarTopRow(
     // the close button to wrap. The chapter label is also redundant: the
     // toolbar already shows the user's current chapter, and skipping
     // prev/next is a universally-understood control.
-    Row(
+    Box(
         modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
     ) {
-        ChapterNavButton(
-            available = state.prevChapterLabel != null,
-            descriptionRes = R.string.audio_bar_prev_chapter,
-            iconRes = R.drawable.ic_audio_skip_previous,
-            onClick = { onCommand(AudioBarCommand.PrevChapter) },
-        )
-
-        IconButton(
-            onClick = { onCommand(AudioBarCommand.PrevVerse) },
-            enabled = state.timingAvailable,
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_audio_keyboard_arrow_left),
-                contentDescription = stringResource(R.string.audio_bar_prev_verse),
-            )
-        }
-
-        Spacer(Modifier.width(4.dp))
-        PlayPauseButton(state = state, onCommand = onCommand)
-        Spacer(Modifier.width(4.dp))
-
-        IconButton(
-            onClick = { onCommand(AudioBarCommand.NextVerse) },
-            enabled = state.timingAvailable,
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_audio_keyboard_arrow_right),
-                contentDescription = stringResource(R.string.audio_bar_next_verse),
-            )
-        }
-
-        ChapterNavButton(
-            available = state.nextChapterLabel != null,
-            descriptionRes = R.string.audio_bar_next_chapter,
-            iconRes = R.drawable.ic_audio_skip_next,
-            onClick = { onCommand(AudioBarCommand.NextChapter) },
-        )
-
-        Spacer(Modifier.weight(1f))
-
         // Speed chip — tapping opens the [SpeedBottomSheet]. `softWrap = false`
         // keeps locales that render with a comma decimal (e.g. "1,0×" in
         // Indonesian) from wrapping into a stacked "1," / "0×" when the row
@@ -255,7 +214,9 @@ private fun AudioBarTopRow(
         val locale = appLocale()
         TextButton(
             onClick = { onCommand(AudioBarCommand.Speed) },
-            modifier = Modifier.padding(horizontal = 4.dp),
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .padding(horizontal = 4.dp),
         ) {
             Text(
                 text = stringResource(R.string.audio_bar_speed_format, formatSpeedNumber(state.speed, locale)),
@@ -265,7 +226,53 @@ private fun AudioBarTopRow(
             )
         }
 
-        IconButton(onClick = { onCommand(AudioBarCommand.Close) }) {
+        Row(
+            modifier = Modifier.align(Alignment.Center),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ChapterNavButton(
+                available = state.prevChapterLabel != null,
+                descriptionRes = R.string.audio_bar_prev_chapter,
+                iconRes = R.drawable.ic_audio_skip_previous,
+                onClick = { onCommand(AudioBarCommand.PrevChapter) },
+            )
+
+            IconButton(
+                onClick = { onCommand(AudioBarCommand.PrevVerse) },
+                enabled = state.timingAvailable,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_audio_keyboard_arrow_left),
+                    contentDescription = stringResource(R.string.audio_bar_prev_verse),
+                )
+            }
+
+            Spacer(Modifier.width(4.dp))
+            PlayPauseButton(state = state, onCommand = onCommand)
+            Spacer(Modifier.width(4.dp))
+
+            IconButton(
+                onClick = { onCommand(AudioBarCommand.NextVerse) },
+                enabled = state.timingAvailable,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_audio_keyboard_arrow_right),
+                    contentDescription = stringResource(R.string.audio_bar_next_verse),
+                )
+            }
+
+            ChapterNavButton(
+                available = state.nextChapterLabel != null,
+                descriptionRes = R.string.audio_bar_next_chapter,
+                iconRes = R.drawable.ic_audio_skip_next,
+                onClick = { onCommand(AudioBarCommand.NextChapter) },
+            )
+        }
+
+        IconButton(
+            onClick = { onCommand(AudioBarCommand.Close) },
+            modifier = Modifier.align(Alignment.CenterEnd),
+        ) {
             Icon(
                 painter = painterResource(R.drawable.ic_audio_close),
                 contentDescription = stringResource(R.string.audio_bar_close),

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -204,79 +204,84 @@ private fun AudioBarTopRow(
     // the close button to wrap. The chapter label is also redundant: the
     // toolbar already shows the user's current chapter, and skipping
     // prev/next is a universally-understood control.
-    Box(
+    // Three-slot row: equal-weight side slots make the transport cluster
+    // geometrically centered regardless of the speed/close widths, while the
+    // Row layout (unlike a Box overlay) keeps the side controls from
+    // overlapping the cluster on narrow screens — the weighted slots shrink
+    // and the cluster keeps its intrinsic width.
+    Row(
         modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         // Speed chip — tapping opens the [SpeedBottomSheet]. `softWrap = false`
         // keeps locales that render with a comma decimal (e.g. "1,0×" in
         // Indonesian) from wrapping into a stacked "1," / "0×" when the row
         // is tight.
         val locale = appLocale()
-        TextButton(
-            onClick = { onCommand(AudioBarCommand.Speed) },
-            modifier = Modifier
-                .align(Alignment.CenterStart)
-                .padding(horizontal = 4.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.audio_bar_speed_format, formatSpeedNumber(state.speed, locale)),
-                style = MaterialTheme.typography.labelLarge,
-                maxLines = 1,
-                softWrap = false,
-            )
-        }
-
-        Row(
-            modifier = Modifier.align(Alignment.Center),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            ChapterNavButton(
-                available = state.prevChapterLabel != null,
-                descriptionRes = R.string.audio_bar_prev_chapter,
-                iconRes = R.drawable.ic_audio_skip_previous,
-                onClick = { onCommand(AudioBarCommand.PrevChapter) },
-            )
-
-            IconButton(
-                onClick = { onCommand(AudioBarCommand.PrevVerse) },
-                enabled = state.timingAvailable,
+        Box(modifier = Modifier.weight(1f)) {
+            TextButton(
+                onClick = { onCommand(AudioBarCommand.Speed) },
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(horizontal = 4.dp),
             ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_audio_keyboard_arrow_left),
-                    contentDescription = stringResource(R.string.audio_bar_prev_verse),
+                Text(
+                    text = stringResource(R.string.audio_bar_speed_format, formatSpeedNumber(state.speed, locale)),
+                    style = MaterialTheme.typography.labelLarge,
+                    maxLines = 1,
+                    softWrap = false,
                 )
             }
-
-            Spacer(Modifier.width(4.dp))
-            PlayPauseButton(state = state, onCommand = onCommand)
-            Spacer(Modifier.width(4.dp))
-
-            IconButton(
-                onClick = { onCommand(AudioBarCommand.NextVerse) },
-                enabled = state.timingAvailable,
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_audio_keyboard_arrow_right),
-                    contentDescription = stringResource(R.string.audio_bar_next_verse),
-                )
-            }
-
-            ChapterNavButton(
-                available = state.nextChapterLabel != null,
-                descriptionRes = R.string.audio_bar_next_chapter,
-                iconRes = R.drawable.ic_audio_skip_next,
-                onClick = { onCommand(AudioBarCommand.NextChapter) },
-            )
         }
+
+        ChapterNavButton(
+            available = state.prevChapterLabel != null,
+            descriptionRes = R.string.audio_bar_prev_chapter,
+            iconRes = R.drawable.ic_audio_skip_previous,
+            onClick = { onCommand(AudioBarCommand.PrevChapter) },
+        )
 
         IconButton(
-            onClick = { onCommand(AudioBarCommand.Close) },
-            modifier = Modifier.align(Alignment.CenterEnd),
+            onClick = { onCommand(AudioBarCommand.PrevVerse) },
+            enabled = state.timingAvailable,
         ) {
             Icon(
-                painter = painterResource(R.drawable.ic_audio_close),
-                contentDescription = stringResource(R.string.audio_bar_close),
+                painter = painterResource(R.drawable.ic_audio_keyboard_arrow_left),
+                contentDescription = stringResource(R.string.audio_bar_prev_verse),
             )
+        }
+
+        Spacer(Modifier.width(4.dp))
+        PlayPauseButton(state = state, onCommand = onCommand)
+        Spacer(Modifier.width(4.dp))
+
+        IconButton(
+            onClick = { onCommand(AudioBarCommand.NextVerse) },
+            enabled = state.timingAvailable,
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_audio_keyboard_arrow_right),
+                contentDescription = stringResource(R.string.audio_bar_next_verse),
+            )
+        }
+
+        ChapterNavButton(
+            available = state.nextChapterLabel != null,
+            descriptionRes = R.string.audio_bar_next_chapter,
+            iconRes = R.drawable.ic_audio_skip_next,
+            onClick = { onCommand(AudioBarCommand.NextChapter) },
+        )
+
+        Box(modifier = Modifier.weight(1f)) {
+            IconButton(
+                onClick = { onCommand(AudioBarCommand.Close) },
+                modifier = Modifier.align(Alignment.CenterEnd),
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_audio_close),
+                    contentDescription = stringResource(R.string.audio_bar_close),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Center-align the audio player transport buttons per audio-bible feedback issue 10 ("Posisi tombol player audio bisa dibuat align center").
- `AudioBarTopRow` was a left-aligned `Row`; now a `Box(fillMaxWidth)` with the 5-button transport cluster (`prev-chapter`, `prev-verse`, play/pause, `next-verse`, `next-chapter`) at `Alignment.Center`, the speed chip at `CenterStart`, and close at `CenterEnd`.
- Centering is independent of the speed/close widths, so the cluster stays put at Bible boundaries (chapter buttons render `alpha 0`, not gone) and when timing-disabled verse buttons grey out but keep their footprint.

All existing behavior preserved: boundary invisibility, `timingAvailable` enable/disable, preparing spinner overlay, 4dp inner spacers, command callbacks. Slider row untouched (issue 12 is separate).

## Test plan
- [x] `./gradlew assemblePlainDebug` — BUILD SUCCESSFUL, no new warnings.
- [ ] Compose rendering can't be verified headless. Manual checks needed:
  - [ ] Portrait: cluster centered, no overlap with speed chip / close on narrow width.
  - [ ] Landscape.
  - [ ] Genesis (prev-chapter hidden) — cluster stays centered, doesn't jump.
  - [ ] Revelation (next-chapter hidden).
  - [ ] Version without timing — verse buttons disabled but cluster centering holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)