### PR TITLE
fix(audio-bible): restore audio bar + toolbar indicator on activity reattach and return-from-background

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -1142,6 +1142,11 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         // Re-resolve the audio overlay color in case the user changed the
         // reading theme via the textAppearancePanel while we were stopped.
         audioHighlightColorCached = 0
+
+        // Restore the audio bar + toolbar indicator if the service kept playing
+        // across recreation (rotation) or while we were backgrounded. Covers
+        // both a freshly recreated activity and a return on the same instance.
+        audioBinder.reshowIfSessionActive()
     }
 
     override fun onDestroy() {

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
@@ -110,6 +110,15 @@ class AudioBarController(
     /** Tracks whether the user has *requested* the bar visible (via [toggle]). */
     private var requestedVisible = false
     /**
+     * Set by [reshowIfSessionActive] while we are binding to an
+     * already-running service purely to restore the bar after activity
+     * recreation / return-from-background. The first projected
+     * [PlaybackState] that reports [PlaybackState.isActive] flips the bar back
+     * on, then clears this flag. Cleared without showing if the session has
+     * ended by the time we connect (no flicker).
+     */
+    private var reshowPending = false
+    /**
      * Set while the user has the slider thumb under their finger. Drives a
      * special-case in [projectToUi]: live playback continues to push a
      * `verse_1` derived from the player's current position every 100 ms, but
@@ -201,6 +210,23 @@ class AudioBarController(
     fun attach(host: Host, composeView: ComposeView) {
         this.host = host
         this.composeView = composeView
+    }
+
+    /**
+     * Restores the audio bar when the activity becomes visible again (rotation,
+     * process/activity recreation, or return-from-background) while the service
+     * is still mid-session. Call from `IsiActivity.onStart` — it covers both a
+     * fresh activity (after [attach]) and a returning one on the same instance.
+     *
+     * Binds only when [BibleAudioService.hasActiveSession] is already true, so
+     * we never spin the service up for users who haven't started audio. The
+     * actual reshow happens in [projectToUi] once the first [PlaybackState]
+     * arrives, avoiding a show-then-hide flicker if the session just ended.
+     */
+    fun reshowIfSessionActive() {
+        if (!shouldBindForReshow(requestedVisible, BibleAudioService.hasActiveSession)) return
+        reshowPending = true
+        ensureBound()
     }
 
     private var composeContentInstalled = false
@@ -328,6 +354,7 @@ class AudioBarController(
 
     fun hide() {
         requestedVisible = false
+        reshowPending = false
         dragging = false
         selectedSource = null
         lastServiceBookId = -1
@@ -360,6 +387,7 @@ class AudioBarController(
      * may continue playing when the activity is recreated (M4 lock-screen).
      */
     fun detach() {
+        reshowPending = false
         if (bound) {
             try {
                 context.unbindService(serviceConnection)
@@ -490,6 +518,26 @@ class AudioBarController(
 
     private fun projectToUi(state: PlaybackState) {
         val host = this.host
+
+        // Auto-reshow after activity recreation / return-from-background: the
+        // service is still mid-session but the bar was reset to hidden. Flip it
+        // back on once the first active state lands, reconstructing the session
+        // source from the service's loaded versionId. Done before the
+        // _uiState.update below so `visible` picks it up in the same emission.
+        if (shouldReshowNow(reshowPending, state)) {
+            reshowPending = false
+            requestedVisible = true
+            ensureComposeContent()
+            host?.audioAvailableSources()
+                ?.firstOrNull { it.versionId == state.versionId }
+                ?.let { selectedSource = it }
+            host?.audioBarVisibilityChanged(true)
+        } else if (reshowPending && !state.isActive) {
+            // Session ended before we connected — drop the pending reshow so we
+            // don't show the bar against an idle service.
+            reshowPending = false
+        }
+
         // Snapshot before we drain — if a load was queued before the service
         // connected, the first incoming state is usually `IDLE`, which would
         // briefly clear the spinner before our loadChapter call sets it back
@@ -564,5 +612,20 @@ class AudioBarController(
 
     companion object {
         private const val TAG = "AudioBarController"
+
+        /**
+         * Whether [reshowIfSessionActive] should bind to the service: only when
+         * the bar isn't already managed by this controller ([requestedVisible])
+         * and the service reports an active session. Pure for unit testing.
+         */
+        internal fun shouldBindForReshow(requestedVisible: Boolean, hasActiveSession: Boolean): Boolean =
+            !requestedVisible && hasActiveSession
+
+        /**
+         * Whether a pending reshow should fire for [state]: only once the first
+         * active state arrives. Pure for unit testing.
+         */
+        internal fun shouldReshowNow(reshowPending: Boolean, state: PlaybackState): Boolean =
+            reshowPending && state.isActive
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
@@ -524,18 +524,21 @@ class AudioBarController(
         // back on once the first active state lands, reconstructing the session
         // source from the service's loaded versionId. Done before the
         // _uiState.update below so `visible` picks it up in the same emission.
-        if (shouldReshowNow(reshowPending, state)) {
+        if (reshowPending) {
+            val reshow = shouldReshowNow(reshowPending, state)
+            // One-shot: consume the flag on the first state after binding,
+            // whether or not we actually reshow. If the session ended before we
+            // connected (!state.isActive) we just drop it — no show-then-hide
+            // flicker against an idle service.
             reshowPending = false
-            requestedVisible = true
-            ensureComposeContent()
-            host?.audioAvailableSources()
-                ?.firstOrNull { it.versionId == state.versionId }
-                ?.let { selectedSource = it }
-            host?.audioBarVisibilityChanged(true)
-        } else if (reshowPending && !state.isActive) {
-            // Session ended before we connected — drop the pending reshow so we
-            // don't show the bar against an idle service.
-            reshowPending = false
+            if (reshow) {
+                requestedVisible = true
+                ensureComposeContent()
+                host?.audioAvailableSources()
+                    ?.firstOrNull { it.versionId == state.versionId }
+                    ?.let { selectedSource = it }
+                host?.audioBarVisibilityChanged(true)
+            }
         }
 
         // Snapshot before we drain — if a load was queued before the service

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
@@ -90,6 +90,18 @@ class BibleAudioService : MediaSessionService() {
         private const val DEFAULT_PLAYBACK_SPEED = 1.0f
 
         private const val TAG = "BibleAudioService"
+
+        /**
+         * Process-wide flag (the service is local and single-instance) that lets
+         * [AudioBarController] decide whether to re-show the audio bar after the
+         * activity is recreated or returns from the background — *without*
+         * binding (which would spin the service up via `BIND_AUTO_CREATE` for
+         * users who never started audio). Set true while a chapter is loaded,
+         * cleared on stop / destroy.
+         */
+        @Volatile
+        var hasActiveSession: Boolean = false
+            private set
     }
 
     /** Parameters for [loadChapter]. The display fields drive the lock-screen metadata. */
@@ -285,6 +297,7 @@ class BibleAudioService : MediaSessionService() {
     }
 
     override fun onDestroy() {
+        hasActiveSession = false
         positionJob?.cancel()
         loadJob?.cancel()
         timingJob?.cancel()
@@ -307,6 +320,7 @@ class BibleAudioService : MediaSessionService() {
         loadJob?.cancel()
         timingJob?.cancel()
         currentRequest = request
+        hasActiveSession = true
         // New chapter — reset highlight from any previous chapter and clear errors.
         highlightTracker.setTiming(emptyList())
         _playbackState.update {
@@ -432,6 +446,7 @@ class BibleAudioService : MediaSessionService() {
         timingJob?.cancel()
         positionJob?.cancel()
         currentRequest = null
+        hasActiveSession = false
         player.pause()
         _playbackState.value = PlaybackState.IDLE
         stopSelf()

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/PlaybackState.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/PlaybackState.kt
@@ -39,6 +39,16 @@ data class PlaybackState(
     val speed: Float,
     val error: String?,
 ) {
+    /**
+     * True while a chapter is loaded into the service (playing, paused, or
+     * buffering) — i.e. not [IDLE]/stopped. Drives the auto-reshow decision in
+     * [AudioBarController] when the activity is recreated or returns from the
+     * background. Mirrors the `bookId >= 0` invariant that `loadChapter` sets
+     * and `stop()` clears.
+     */
+    val isActive: Boolean
+        get() = bookId >= 0
+
     companion object {
         val IDLE = PlaybackState(
             isPlaying = false,

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioBarControllerReshowTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioBarControllerReshowTest.kt
@@ -1,0 +1,53 @@
+package yuku.alkitab.base.audio
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-logic tests for the audio-bar auto-reshow decision used after the
+ * activity is recreated (rotation) or returns from the background while the
+ * [BibleAudioService] keeps playing. See [AudioBarController.reshowIfSessionActive].
+ */
+class AudioBarControllerReshowTest {
+
+    private fun state(bookId: Int): PlaybackState =
+        PlaybackState.IDLE.copy(bookId = bookId, chapter_1 = 1, versionId = "preset/in-tb")
+
+    @Test
+    fun `reshow binds when the service is mid-session and the bar is not already managed`() {
+        assertTrue(AudioBarController.shouldBindForReshow(requestedVisible = false, hasActiveSession = true))
+    }
+
+    @Test
+    fun `reshow does not bind when the service is idle`() {
+        assertFalse(AudioBarController.shouldBindForReshow(requestedVisible = false, hasActiveSession = false))
+    }
+
+    @Test
+    fun `reshow does not bind when the bar is already shown by this controller`() {
+        assertFalse(AudioBarController.shouldBindForReshow(requestedVisible = true, hasActiveSession = true))
+    }
+
+    @Test
+    fun `pending reshow fires once an active state arrives`() {
+        assertTrue(AudioBarController.shouldReshowNow(reshowPending = true, state = state(bookId = 5)))
+    }
+
+    @Test
+    fun `pending reshow stays hidden against an idle state to avoid show-then-hide flicker`() {
+        assertFalse(AudioBarController.shouldReshowNow(reshowPending = true, state = state(bookId = -1)))
+    }
+
+    @Test
+    fun `no reshow when none is pending even if the state is active`() {
+        assertFalse(AudioBarController.shouldReshowNow(reshowPending = false, state = state(bookId = 5)))
+    }
+
+    @Test
+    fun `PlaybackState reports active once a chapter is loaded and idle otherwise`() {
+        assertFalse(PlaybackState.IDLE.isActive)
+        assertTrue(state(bookId = 0).isActive)
+        assertTrue(state(bookId = 41).isActive)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two state-restoration issues with the same root cause — the `BibleAudioService` survives activity recreation and backgrounding (intentional), but the audio bar reset to hidden on the recreated/returning activity, so a playing session lost its UI surface:

- **Issue 5:** rotating while playing hid the audio bar (re-tapping restarted from the beginning).
- **Issue 6:** leaving the app kept audio playing, but on return the player UI + verse marker were gone (audio still playing).

## What changed

- `IsiActivity.onStart()` now calls `AudioBarController.reshowIfSessionActive()`. `onStart` covers **both** entry paths: full recreation (rotation / process-recreate, via `onCreate`→`onStart` after `attach`) and return-from-background on the same instance (`onStart` without `onCreate`).
- `AudioBarController.reshowIfSessionActive()` binds to the service **only** when it reports an active session, then re-shows the bar once the first active `PlaybackState` arrives — re-synced via the existing `StateFlow` collection (position, play/pause, verse highlight, speed). No flicker (no show-then-hide): the gate avoids binding when idle, and the projection only flips visible on an active state.
- `BibleAudioService.hasActiveSession` — process-wide gate (local single-instance service) so the controller can decide whether to auto-reshow **without** binding, which would otherwise spin the service up via `BIND_AUTO_CREATE` for users who never started audio. Set on `loadChapter`, cleared on `stop`/`onDestroy`.
- `PlaybackState.isActive` (`bookId >= 0`) distinguishes an active session from idle/stopped.
- Toolbar `menuAudio` active icon follows the restored bar visibility (existing `ic_audio_active` mechanism via `invalidateOptionsMenu()`); normal icon when idle.

The service remains the single source of truth — **no** `onSaveInstanceState` for audio state, and the persistence design (service runs across recreation/background) is unchanged. Binding is still released in `detach()`.

## Test plan

- [x] `./gradlew assemblePlainDebug` — green
- [x] `./gradlew testPlainDebugUnitTest --tests "yuku.alkitab.base.audio.AudioBarControllerReshowTest"` — pure-logic tests for the reshow decision (active vs idle service, already-shown, flicker-avoidance) + `PlaybackState.isActive`
- [ ] Manual on-device (UI cannot be verified headless):
  - [ ] (a) rotate while playing → bar reappears re-synced, audio uninterrupted
  - [ ] (b) Home then reopen while playing → bar + verse marker restored
  - [ ] (c) open another screen (e.g. devotion) then return while playing → bar + marker restored
  - [ ] (d) idle (no session) → no bar, normal audio icon