### PR TITLE
feat(audio-bible): single-row audio bar in landscape

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -32,7 +32,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -177,11 +177,18 @@ fun AudioBar(
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
             modifier = modifier.fillMaxWidth(),
         ) {
+            // Hoisted above the orientation branch so an in-progress seek
+            // drag carries across a portrait↔landscape rotation (and process
+            // death via rememberSaveable) instead of resetting to the playback
+            // position.
+            var dragValue by rememberSaveable { mutableStateOf<Float?>(null) }
             val landscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
             if (landscape) {
                 AudioBarLandscapeRow(
                     state = state,
                     onCommand = onCommand,
+                    dragValue = dragValue,
+                    onDragValueChange = { dragValue = it },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(
@@ -204,7 +211,12 @@ fun AudioBar(
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
                     AudioBarTopRow(state = state, onCommand = onCommand)
-                    AudioBarSliderRow(state = state, onCommand = onCommand)
+                    AudioBarSliderRow(
+                        state = state,
+                        onCommand = onCommand,
+                        dragValue = dragValue,
+                        onDragValueChange = { dragValue = it },
+                    )
                 }
             }
         }
@@ -394,9 +406,9 @@ private fun PlayPauseButton(
 private fun AudioBarSliderRow(
     state: AudioBarUiState,
     onCommand: (AudioBarCommand) -> Unit,
+    dragValue: Float?,
+    onDragValueChange: (Float?) -> Unit,
 ) {
-    var dragValue by remember { mutableStateOf<Float?>(null) }
-
     val effectivePosition = dragValue?.roundToLong() ?: state.positionMs
 
     Row(
@@ -415,7 +427,7 @@ private fun AudioBarSliderRow(
             state = state,
             onCommand = onCommand,
             dragValue = dragValue,
-            onDragValueChange = { dragValue = it },
+            onDragValueChange = onDragValueChange,
             modifier = Modifier.weight(1f),
         )
 
@@ -472,10 +484,10 @@ private fun AudioBarSlider(
 private fun AudioBarLandscapeRow(
     state: AudioBarUiState,
     onCommand: (AudioBarCommand) -> Unit,
+    dragValue: Float?,
+    onDragValueChange: (Float?) -> Unit,
     modifier: Modifier,
 ) {
-    var dragValue by remember { mutableStateOf<Float?>(null) }
-
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
@@ -484,7 +496,7 @@ private fun AudioBarLandscapeRow(
             state = state,
             onCommand = onCommand,
             dragValue = dragValue,
-            onDragValueChange = { dragValue = it },
+            onDragValueChange = onDragValueChange,
             modifier = Modifier.weight(2f),
         )
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -1,5 +1,6 @@
 package yuku.alkitab.base.audio.ui
 
+import android.content.res.Configuration
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -37,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -175,19 +177,35 @@ fun AudioBar(
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
             modifier = modifier.fillMaxWidth(),
         ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        start = 8.dp,
-                        end = 8.dp,
-                        top = 4.dp,
-                        bottom = 4.dp + bottomInset,
-                    ),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                AudioBarTopRow(state = state, onCommand = onCommand)
-                AudioBarSliderRow(state = state, onCommand = onCommand)
+            val landscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+            if (landscape) {
+                AudioBarLandscapeRow(
+                    state = state,
+                    onCommand = onCommand,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            start = 8.dp,
+                            end = 8.dp,
+                            top = 4.dp,
+                            bottom = 4.dp + bottomInset,
+                        ),
+                )
+            } else {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            start = 8.dp,
+                            end = 8.dp,
+                            top = 4.dp,
+                            bottom = 4.dp + bottomInset,
+                        ),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    AudioBarTopRow(state = state, onCommand = onCommand)
+                    AudioBarSliderRow(state = state, onCommand = onCommand)
+                }
             }
         }
     }
@@ -215,29 +233,13 @@ private fun AudioBarTopRow(
             onClick = { onCommand(AudioBarCommand.PrevChapter) },
         )
 
-        IconButton(
-            onClick = { onCommand(AudioBarCommand.PrevVerse) },
-            enabled = state.timingAvailable,
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_audio_keyboard_arrow_left),
-                contentDescription = stringResource(R.string.audio_bar_prev_verse),
-            )
-        }
+        PrevVerseButton(state = state, onCommand = onCommand)
 
         Spacer(Modifier.width(4.dp))
         PlayPauseButton(state = state, onCommand = onCommand)
         Spacer(Modifier.width(4.dp))
 
-        IconButton(
-            onClick = { onCommand(AudioBarCommand.NextVerse) },
-            enabled = state.timingAvailable,
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_audio_keyboard_arrow_right),
-                contentDescription = stringResource(R.string.audio_bar_next_verse),
-            )
-        }
+        NextVerseButton(state = state, onCommand = onCommand)
 
         ChapterNavButton(
             available = state.nextChapterLabel != null,
@@ -248,29 +250,76 @@ private fun AudioBarTopRow(
 
         Spacer(Modifier.weight(1f))
 
-        // Speed chip — tapping opens the [SpeedBottomSheet]. `softWrap = false`
-        // keeps locales that render with a comma decimal (e.g. "1,0×" in
-        // Indonesian) from wrapping into a stacked "1," / "0×" when the row
-        // is tight.
-        val locale = appLocale()
-        TextButton(
-            onClick = { onCommand(AudioBarCommand.Speed) },
-            modifier = Modifier.padding(horizontal = 4.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.audio_bar_speed_format, formatSpeedNumber(state.speed, locale)),
-                style = MaterialTheme.typography.labelLarge,
-                maxLines = 1,
-                softWrap = false,
-            )
-        }
+        SpeedButton(state = state, onCommand = onCommand)
 
-        IconButton(onClick = { onCommand(AudioBarCommand.Close) }) {
-            Icon(
-                painter = painterResource(R.drawable.ic_audio_close),
-                contentDescription = stringResource(R.string.audio_bar_close),
-            )
-        }
+        CloseButton(onCommand = onCommand)
+    }
+}
+
+@Composable
+private fun PrevVerseButton(
+    state: AudioBarUiState,
+    onCommand: (AudioBarCommand) -> Unit,
+) {
+    IconButton(
+        onClick = { onCommand(AudioBarCommand.PrevVerse) },
+        enabled = state.timingAvailable,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_audio_keyboard_arrow_left),
+            contentDescription = stringResource(R.string.audio_bar_prev_verse),
+        )
+    }
+}
+
+@Composable
+private fun NextVerseButton(
+    state: AudioBarUiState,
+    onCommand: (AudioBarCommand) -> Unit,
+) {
+    IconButton(
+        onClick = { onCommand(AudioBarCommand.NextVerse) },
+        enabled = state.timingAvailable,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_audio_keyboard_arrow_right),
+            contentDescription = stringResource(R.string.audio_bar_next_verse),
+        )
+    }
+}
+
+// Speed chip — tapping opens the [SpeedBottomSheet]. `softWrap = false`
+// keeps locales that render with a comma decimal (e.g. "1,0×" in
+// Indonesian) from wrapping into a stacked "1," / "0×" when the row
+// is tight.
+@Composable
+private fun SpeedButton(
+    state: AudioBarUiState,
+    onCommand: (AudioBarCommand) -> Unit,
+) {
+    val locale = appLocale()
+    TextButton(
+        onClick = { onCommand(AudioBarCommand.Speed) },
+        modifier = Modifier.padding(horizontal = 4.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.audio_bar_speed_format, formatSpeedNumber(state.speed, locale)),
+            style = MaterialTheme.typography.labelLarge,
+            maxLines = 1,
+            softWrap = false,
+        )
+    }
+}
+
+@Composable
+private fun CloseButton(
+    onCommand: (AudioBarCommand) -> Unit,
+) {
+    IconButton(onClick = { onCommand(AudioBarCommand.Close) }) {
+        Icon(
+            painter = painterResource(R.drawable.ic_audio_close),
+            contentDescription = stringResource(R.string.audio_bar_close),
+        )
     }
 }
 
@@ -362,19 +411,11 @@ private fun AudioBarSliderRow(
             modifier = Modifier.width(40.dp),
         )
 
-        Slider(
-            value = effectivePosition.toFloat(),
-            valueRange = 0f..maxOf(state.durationMs.toFloat(), 1f),
-            onValueChange = { v ->
-                dragValue = v
-                onCommand(AudioBarCommand.SeekDrag(v.roundToLong()))
-            },
-            onValueChangeFinished = {
-                val v = dragValue ?: return@Slider
-                onCommand(AudioBarCommand.SeekCommit(v.roundToLong()))
-                dragValue = null
-            },
-            enabled = state.durationMs > 0L && state.error == null,
+        AudioBarSlider(
+            state = state,
+            onCommand = onCommand,
+            dragValue = dragValue,
+            onDragValueChange = { dragValue = it },
             modifier = Modifier.weight(1f),
         )
 
@@ -390,6 +431,90 @@ private fun AudioBarSliderRow(
         // it was redundant with the verse highlight in the reader and just
         // looked like a stray code to users. The highlight in the verse list
         // is the authoritative current-verse cue.
+    }
+}
+
+@Composable
+private fun AudioBarSlider(
+    state: AudioBarUiState,
+    onCommand: (AudioBarCommand) -> Unit,
+    dragValue: Float?,
+    onDragValueChange: (Float?) -> Unit,
+    modifier: Modifier,
+) {
+    val effectivePosition = dragValue?.roundToLong() ?: state.positionMs
+    Slider(
+        value = effectivePosition.toFloat(),
+        valueRange = 0f..maxOf(state.durationMs.toFloat(), 1f),
+        onValueChange = { v ->
+            onDragValueChange(v)
+            onCommand(AudioBarCommand.SeekDrag(v.roundToLong()))
+        },
+        onValueChangeFinished = {
+            val v = dragValue ?: return@Slider
+            onCommand(AudioBarCommand.SeekCommit(v.roundToLong()))
+            onDragValueChange(null)
+        },
+        enabled = state.durationMs > 0L && state.error == null,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Landscape variant — collapses the bar into a single row to reclaim the
+ * vertical space the two-row portrait layout costs (worse with split view).
+ * Order: slider · spacer · transport cluster · speed · close. The mm:ss
+ * position/duration labels are dropped here — the slider conveys progress and
+ * keeping the labels would push the control cluster into wrapping on a single
+ * row.
+ */
+@Composable
+private fun AudioBarLandscapeRow(
+    state: AudioBarUiState,
+    onCommand: (AudioBarCommand) -> Unit,
+    modifier: Modifier,
+) {
+    var dragValue by remember { mutableStateOf<Float?>(null) }
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AudioBarSlider(
+            state = state,
+            onCommand = onCommand,
+            dragValue = dragValue,
+            onDragValueChange = { dragValue = it },
+            modifier = Modifier.weight(2f),
+        )
+
+        Spacer(Modifier.weight(1f))
+
+        ChapterNavButton(
+            available = state.prevChapterLabel != null,
+            descriptionRes = R.string.audio_bar_prev_chapter,
+            iconRes = R.drawable.ic_audio_skip_previous,
+            onClick = { onCommand(AudioBarCommand.PrevChapter) },
+        )
+
+        PrevVerseButton(state = state, onCommand = onCommand)
+
+        Spacer(Modifier.width(4.dp))
+        PlayPauseButton(state = state, onCommand = onCommand)
+        Spacer(Modifier.width(4.dp))
+
+        NextVerseButton(state = state, onCommand = onCommand)
+
+        ChapterNavButton(
+            available = state.nextChapterLabel != null,
+            descriptionRes = R.string.audio_bar_next_chapter,
+            iconRes = R.drawable.ic_audio_skip_next,
+            onClick = { onCommand(AudioBarCommand.NextChapter) },
+        )
+
+        SpeedButton(state = state, onCommand = onCommand)
+
+        CloseButton(onCommand = onCommand)
     }
 }
 


### PR DESCRIPTION
## Summary
- Audio bar collapses to a **single row** in landscape orientation, reclaiming the vertical space the two-row portrait layout costs (worse with split view on). Addresses audio-bible feedback **issue 14**.
- Landscape order, left→right: `[slider] [spacer] [prev chap] [prev verse] [play/pause] [next verse] [next chap] [speed] [close]`.
- Portrait keeps the existing two-row layout unchanged.

## Implementation
- Branch the inner content of `AudioBar` on `LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE`. Only the inner content branches — `Surface`/elevation/insets handling untouched.
- New `AudioBarLandscapeRow`: a single `Row` with the seek `Slider` weighted on the left, a `Spacer(weight=1f)`, then the transport cluster + speed chip + close grouped at the right.
- Extracted small shared composables (`PrevVerseButton`, `NextVerseButton`, `SpeedButton`, `CloseButton`, `AudioBarSlider`) so both layouts reuse the same controls/callbacks — no duplicated button internals. `ChapterNavButton`/`PlayPauseButton` were already shared.
- mm:ss position/duration labels are dropped in landscape so the spec'd order fits on one row (the slider conveys progress). Portrait keeps them.
- All behavior preserved: drag-seek with live verse preview, boundary-invisible chapter buttons (Genesis/Revelation), `timingAvailable` enable/disable of verse buttons, preparing spinner.

## Test plan
- [x] `./gradlew assemblePlainDebug` passes locally.
- [ ] **Compose rendering can't be verified headless.** Manual checks:
  - [ ] Landscape single-row: correct order, slider scrubs, verse preview works.
  - [ ] Landscape + split mode: noticeably less cramped.
  - [ ] Portrait still two-row.
  - [ ] Rotate portrait↔landscape while playing — no crash, layout swaps.
  - [ ] Genesis/Revelation boundary — chapter buttons hidden (alpha 0, no reflow).
  - [ ] Version without timing — verse buttons disabled.