### PR TITLE
fix(reader): balance 2-line wrap of toolbar title so chapter number isn't clipped

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -1554,7 +1554,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
         // set goto button text
         val reference = activeSplit0.book.reference(available_chapter_1)
-        bGoto.text = reference.replace(' ', '\u00a0')
+        bGoto.text = reference
 
         if (fullScreen) {
             fullscreenReferenceToast?.cancel()

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/GotoButton.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/GotoButton.java
@@ -1,6 +1,7 @@
 package yuku.alkitab.base.widget;
 
 import android.content.Context;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import androidx.appcompat.widget.AppCompatButton;
@@ -15,22 +16,112 @@ public class GotoButton extends AppCompatButton {
 		void onFloaterDragComplete(float screenX, float screenY);
 	}
 
+	public interface WidthMeasurer {
+		float measure(String s);
+	}
+
 	int[] screenLocation = {0, 0};
 	boolean inFloaterDrag;
 	boolean inLongClicked;
 	int untouchableSideWidth = Integer.MIN_VALUE;
 	FloaterDragListener floaterDragListener;
 
+	// rawText is the logical label; the superclass renders a possibly line-broken display copy of it
+	CharSequence rawText = "";
+	int lastWrapWidth = -1;
+	CharSequence lastWrapSource = null;
+	boolean applyingWrap;
+
 	public GotoButton(final Context context) {
 		super(context);
+		init();
 	}
 
 	public GotoButton(final Context context, final AttributeSet attrs) {
 		super(context, attrs);
+		init();
 	}
 
 	public GotoButton(final Context context, final AttributeSet attrs, final int defStyle) {
 		super(context, attrs, defStyle);
+		init();
+	}
+
+	private void init() {
+		setMaxLines(2);
+		setEllipsize(TextUtils.TruncateAt.END);
+	}
+
+	@Override
+	public void setText(final CharSequence text, final BufferType type) {
+		if (!applyingWrap) {
+			rawText = text == null ? "" : text;
+			lastWrapSource = null;
+		}
+		super.setText(text, type);
+	}
+
+	@Override
+	protected void onMeasure(final int widthMeasureSpec, final int heightMeasureSpec) {
+		final int availWidth = MeasureSpec.getSize(widthMeasureSpec) - getPaddingLeft() - getPaddingRight();
+		if (availWidth > 0 && (availWidth != lastWrapWidth || rawText != lastWrapSource)) {
+			lastWrapWidth = availWidth;
+			lastWrapSource = rawText;
+
+			final String display = balanceWrap(rawText.toString(), availWidth, getPaint()::measureText);
+			applyingWrap = true;
+			super.setText(display, BufferType.NORMAL);
+			applyingWrap = false;
+		}
+		super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+	}
+
+	public static String balanceWrap(final String text, final float availWidth, final WidthMeasurer measurer) {
+		if (text.isEmpty() || measurer.measure(text) <= availWidth) {
+			return text;
+		}
+
+		final int n = text.length();
+		int bestSplit = -1;
+		float bestMax = Float.MAX_VALUE;
+		boolean foundFit = false;
+
+		for (int i = 1; i < n; i++) {
+			final String l1 = rtrim(text.substring(0, i));
+			final String l2 = ltrim(text.substring(i));
+			if (l1.isEmpty() || l2.isEmpty()) continue;
+
+			final float w1 = measurer.measure(l1);
+			final float w2 = measurer.measure(l2);
+			final float mx = Math.max(w1, w2);
+			final boolean fits = w1 <= availWidth && w2 <= availWidth;
+
+			if (fits && !foundFit) {
+				foundFit = true;
+				bestMax = mx;
+				bestSplit = i;
+			} else if (fits == foundFit && mx < bestMax) {
+				bestMax = mx;
+				bestSplit = i;
+			}
+		}
+
+		if (bestSplit < 0) {
+			return text;
+		}
+		return rtrim(text.substring(0, bestSplit)) + "\n" + ltrim(text.substring(bestSplit));
+	}
+
+	private static String rtrim(final String s) {
+		int end = s.length();
+		while (end > 0 && s.charAt(end - 1) == ' ') end--;
+		return s.substring(0, end);
+	}
+
+	private static String ltrim(final String s) {
+		int start = 0;
+		while (start < s.length() && s.charAt(start) == ' ') start++;
+		return s.substring(start);
 	}
 
 	@Override

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/GotoButton.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/GotoButton.java
@@ -17,7 +17,7 @@ public class GotoButton extends AppCompatButton {
 	}
 
 	public interface WidthMeasurer {
-		float measure(String s);
+		float measure(CharSequence s, int start, int end);
 	}
 
 	int[] screenLocation = {0, 0};
@@ -68,7 +68,7 @@ public class GotoButton extends AppCompatButton {
 			lastWrapWidth = availWidth;
 			lastWrapSource = rawText;
 
-			final String display = balanceWrap(rawText.toString(), availWidth, getPaint()::measureText);
+			final String display = balanceWrap(rawText, availWidth, getPaint()::measureText);
 			applyingWrap = true;
 			super.setText(display, BufferType.NORMAL);
 			applyingWrap = false;
@@ -76,23 +76,25 @@ public class GotoButton extends AppCompatButton {
 		super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 	}
 
-	public static String balanceWrap(final String text, final float availWidth, final WidthMeasurer measurer) {
-		if (text.isEmpty() || measurer.measure(text) <= availWidth) {
-			return text;
+	public static String balanceWrap(final CharSequence text, final float availWidth, final WidthMeasurer measurer) {
+		final int n = text.length();
+		if (n == 0 || measurer.measure(text, 0, n) <= availWidth) {
+			return text.toString();
 		}
 
-		final int n = text.length();
 		int bestSplit = -1;
 		float bestMax = Float.MAX_VALUE;
 		boolean foundFit = false;
 
 		for (int i = 1; i < n; i++) {
-			final String l1 = rtrim(text.substring(0, i));
-			final String l2 = ltrim(text.substring(i));
-			if (l1.isEmpty() || l2.isEmpty()) continue;
+			int end1 = i;
+			while (end1 > 0 && text.charAt(end1 - 1) == ' ') end1--;
+			int start2 = i;
+			while (start2 < n && text.charAt(start2) == ' ') start2++;
+			if (end1 == 0 || start2 == n) continue;
 
-			final float w1 = measurer.measure(l1);
-			final float w2 = measurer.measure(l2);
+			final float w1 = measurer.measure(text, 0, end1);
+			final float w2 = measurer.measure(text, start2, n);
 			final float mx = Math.max(w1, w2);
 			final boolean fits = w1 <= availWidth && w2 <= availWidth;
 
@@ -107,21 +109,14 @@ public class GotoButton extends AppCompatButton {
 		}
 
 		if (bestSplit < 0) {
-			return text;
+			return text.toString();
 		}
-		return rtrim(text.substring(0, bestSplit)) + "\n" + ltrim(text.substring(bestSplit));
-	}
 
-	private static String rtrim(final String s) {
-		int end = s.length();
-		while (end > 0 && s.charAt(end - 1) == ' ') end--;
-		return s.substring(0, end);
-	}
-
-	private static String ltrim(final String s) {
-		int start = 0;
-		while (start < s.length() && s.charAt(start) == ' ') start++;
-		return s.substring(start);
+		int end1 = bestSplit;
+		while (end1 > 0 && text.charAt(end1 - 1) == ' ') end1--;
+		int start2 = bestSplit;
+		while (start2 < n && text.charAt(start2) == ' ') start2++;
+		return text.subSequence(0, end1).toString() + "\n" + text.subSequence(start2, n).toString();
 	}
 
 	@Override

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonBalanceWrapTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonBalanceWrapTest.kt
@@ -5,7 +5,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GotoButtonBalanceWrapTest {
-	private val byLength = GotoButton.WidthMeasurer { it.length.toFloat() }
+	private val byLength = GotoButton.WidthMeasurer { _, start, end -> (end - start).toFloat() }
 
 	@Test
 	fun `text that fits the available width is returned unchanged on a single line`() {

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonBalanceWrapTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonBalanceWrapTest.kt
@@ -1,0 +1,43 @@
+package yuku.alkitab.base.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GotoButtonBalanceWrapTest {
+	private val byLength = GotoButton.WidthMeasurer { it.length.toFloat() }
+
+	@Test
+	fun `text that fits the available width is returned unchanged on a single line`() {
+		assertEquals("Kej 1", GotoButton.balanceWrap("Kej 1", 10f, byLength))
+	}
+
+	@Test
+	fun `a three token reference that does not fit is split into two balanced lines keeping the chapter number`() {
+		val out = GotoButton.balanceWrap("1 Tesalonika 2", 8f, byLength)
+		assertEquals("1 Tesal\nonika 2", out)
+		val lines = out.split("\n")
+		assertEquals(2, lines.size)
+		assertTrue(lines.all { it.length <= 8 })
+		assertTrue(out.replace("\n", " ").endsWith("2"))
+	}
+
+	@Test
+	fun `the split breaks mid word rather than only at whitespace when that balances better`() {
+		val out = GotoButton.balanceWrap("Wahyu 22", 5f, byLength)
+		val lines = out.split("\n")
+		assertEquals(2, lines.size)
+		assertTrue(lines.all { it.length <= 5 })
+	}
+
+	@Test
+	fun `a leading space on the second line is trimmed when the split lands on whitespace`() {
+		val out = GotoButton.balanceWrap("abc 123", 4f, byLength)
+		assertEquals("abc\n123", out)
+	}
+
+	@Test
+	fun `empty text is returned unchanged`() {
+		assertEquals("", GotoButton.balanceWrap("", 5f, byLength))
+	}
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonSideBySideSnapshotTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonSideBySideSnapshotTest.kt
@@ -149,7 +149,7 @@ class GotoButtonSideBySideSnapshotTest {
             "Kidung Agung 8",
             "Pengkhotbah 12",
         )
-        val widths = listOf(120, 160, 200, 240, 320)
+        val widths = listOf(40, 60, 80, 100, 120, 160)
         val cases = mutableListOf<Case>()
         var i = 1
         for (ref in references) {

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonSideBySideSnapshotTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonSideBySideSnapshotTest.kt
@@ -1,0 +1,246 @@
+package yuku.alkitab.base.widget
+
+import android.app.Activity
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color as AndroidColor
+import android.graphics.Typeface
+import android.os.Looper
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.AppCompatButton
+import androidx.test.core.app.ApplicationProvider
+import java.io.File
+import java.io.FileOutputStream
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import yuku.afw.App as AfwApp
+import yuku.alkitab.debug.R
+
+/**
+ * Visual side-by-side snapshot test for the reader toolbar title button.
+ *
+ * The left column is the OLD behaviour: the title was set as
+ * `reference.replace(' ', ' ')` on a plain 2-line button, so the whole
+ * reference was one unbreakable token — when it didn't fit, the default
+ * TextView line-breaking could only ellipsize, clipping the chapter number.
+ *
+ * The right column is the NEW [GotoButton], which wraps an overflowing title
+ * into two character-balanced lines (mid-word allowed) so both lines fit and
+ * the chapter number stays visible.
+ *
+ * Each (reference, width) case is rendered through both paths, the bitmaps are
+ * saved as PNGs under `Alkitab/build/snapshots/goto-button/`, and an
+ * `index.html` is generated with a two-column comparison table for eyeballing.
+ *
+ * Not a strict pixel-diff: PNGs are written, not compared. Robolectric's text
+ * metrics are uniform and narrower than a real device, so on-device overflow
+ * widths don't match here and the dramatic chapter-number clip is hard to
+ * reproduce headless; the report is for eyeballing relative behaviour, not
+ * pixel-accurate device fidelity.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = AfwApp::class, sdk = [34], qualifiers = "w360dp-h640dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class GotoButtonSideBySideSnapshotTest {
+
+    private val TEXT_SIZE_SP = 16f
+    private val BUTTON_HEIGHT_PX = 56
+    private val TEXT_COLOR = AndroidColor.WHITE
+    private val BUTTON_BG = 0xff3367d6.toInt()
+
+    @Before
+    fun setUp() {
+        AfwApp.initWithAppContext(ApplicationProvider.getApplicationContext())
+    }
+
+    @Test
+    fun `produce side-by-side snapshots of the toolbar title for many references and widths`() {
+        val cases = buildCases()
+        val outputDir = resolveSnapshotDir()
+        outputDir.mkdirs()
+
+        val rows = StringBuilder()
+
+        for (case in cases) {
+            val oldBitmap = renderOld(case)
+            val newBitmap = renderNew(case)
+
+            val oldFile = File(outputDir, "${case.name}-old.png")
+            val newFile = File(outputDir, "${case.name}-new.png")
+            FileOutputStream(oldFile).use { oldBitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+            FileOutputStream(newFile).use { newBitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+
+            rows.append(
+                "<tr>" +
+                    "<td class=\"label\"><div class=\"name\">${escapeHtml(case.name)}</div><pre>${escapeHtml(case.describe())}</pre></td>" +
+                    "<td><img src=\"${oldFile.name}\"/></td>" +
+                    "<td><img src=\"${newFile.name}\"/></td>" +
+                    "</tr>\n"
+            )
+        }
+
+        val html = """
+            <!doctype html>
+            <html><head><meta charset="utf-8"/><title>GotoButton title wrap: old vs new</title>
+            <style>
+            body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 24px; }
+            table { border-collapse: collapse; }
+            td, th { vertical-align: top; padding: 8px 12px; border-bottom: 1px solid #ddd; }
+            th { text-align: left; background: #f4f4f4; position: sticky; top: 0; }
+            td.label { width: 320px; }
+            td.label .name { font-weight: 600; }
+            td.label pre { margin: 4px 0 0; white-space: pre-wrap; word-break: break-word; color: #444; font-size: 12px; }
+            img { display: block; image-rendering: pixelated; border: 1px solid #eee; }
+            </style></head>
+            <body>
+            <h1>Reader toolbar title: old vs new wrapping</h1>
+            <p>${cases.size} cases. Left = old (non-breaking-space token, ellipsized when overflowing — chapter number clipped). Right = new GotoButton balanced 2-line wrap (chapter number preserved). Blue box edges show the available button width.</p>
+            <table>
+              <thead><tr><th>Case</th><th>Old (nbsp, default wrap)</th><th>New (balanced wrap)</th></tr></thead>
+              <tbody>
+            ${rows}
+              </tbody>
+            </table>
+            </body></html>
+        """.trimIndent()
+
+        val indexFile = File(outputDir, "index.html")
+        indexFile.writeText(html)
+
+        println("Snapshot report written to: ${indexFile.absolutePath}")
+        assertTrue("index.html should exist", indexFile.exists())
+    }
+
+    private fun resolveSnapshotDir(): File {
+        val override = System.getenv("GOTO_BUTTON_SNAPSHOT_DIR")
+        if (!override.isNullOrBlank()) return File(override)
+        val moduleDir = File(System.getProperty("user.dir") ?: ".")
+        return File(moduleDir, "build/snapshots/goto-button")
+    }
+
+    // ---- Test data ------------------------------------------------------------------------------
+
+    private data class Case(
+        val name: String,
+        val text: String,
+        val widthPx: Int,
+    ) {
+        fun describe(): String = "text=\"$text\"\nwidth=${widthPx}px"
+    }
+
+    private fun buildCases(): List<Case> {
+        val references = listOf(
+            "Kej 1",
+            "Wahyu 22",
+            "1 Korintus 16",
+            "1 Tesalonika 2",
+            "Kidung Agung 8",
+            "Pengkhotbah 12",
+        )
+        val widths = listOf(70, 90, 120, 160, 200, 280)
+        val cases = mutableListOf<Case>()
+        var i = 1
+        for (ref in references) {
+            for (w in widths) {
+                val slug = ref.lowercase().replace(Regex("[^a-z0-9]+"), "-").trim('-')
+                cases += Case("%02d-%s-w%d".format(i, slug, w), ref, w)
+                i++
+            }
+        }
+        return cases
+    }
+
+    // ---- Rendering helpers ----------------------------------------------------------------------
+
+    private fun renderOld(case: Case): Bitmap {
+        val activity = buildActivity()
+        val button = AppCompatButton(activity).apply {
+            applyCommonStyle()
+            text = case.text.replace(' ', ' ')
+        }
+        attachAndDoFirstLayout(activity, button)
+        return measureAndDraw(button, case.widthPx)
+    }
+
+    private fun renderNew(case: Case): Bitmap {
+        val activity = buildActivity()
+        val button = GotoButton(activity).apply {
+            applyCommonStyle()
+            text = case.text
+        }
+        attachAndDoFirstLayout(activity, button)
+        return measureAndDraw(button, case.widthPx)
+    }
+
+    private fun AppCompatButton.applyCommonStyle() {
+        maxLines = 2
+        ellipsize = android.text.TextUtils.TruncateAt.END
+        gravity = Gravity.CENTER
+        includeFontPadding = false
+        setPadding(0, 0, 0, 0)
+        setTextColor(TEXT_COLOR)
+        setBackgroundColor(BUTTON_BG)
+        typeface = Typeface.create("sans-serif-medium", Typeface.NORMAL)
+        setTextSize(TypedValue.COMPLEX_UNIT_SP, TEXT_SIZE_SP)
+    }
+
+    private fun buildActivity(): AppCompatActivity {
+        val activity = Robolectric.buildActivity(AppCompatActivity::class.java).setup().get()
+        activity.setTheme(androidx.appcompat.R.style.Theme_AppCompat)
+        return activity
+    }
+
+    private fun attachAndDoFirstLayout(activity: Activity, view: View) {
+        val frame = FrameLayout(activity).apply {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            )
+            addView(
+                view,
+                ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                ),
+            )
+            setBackgroundColor(AndroidColor.WHITE)
+        }
+        activity.setContentView(frame)
+        idleLoopers()
+    }
+
+    private fun measureAndDraw(view: View, widthPx: Int): Bitmap {
+        val widthSpec = View.MeasureSpec.makeMeasureSpec(widthPx, View.MeasureSpec.EXACTLY)
+        val heightSpec = View.MeasureSpec.makeMeasureSpec(BUTTON_HEIGHT_PX, View.MeasureSpec.EXACTLY)
+        view.measure(widthSpec, heightSpec)
+        view.layout(0, 0, view.measuredWidth, view.measuredHeight)
+        idleLoopers()
+
+        val w = view.measuredWidth.coerceAtLeast(1)
+        val h = view.measuredHeight.coerceAtLeast(1)
+        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(AndroidColor.WHITE)
+        view.draw(canvas)
+        return bitmap
+    }
+
+    private fun idleLoopers() {
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun escapeHtml(s: String): String =
+        s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonSideBySideSnapshotTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonSideBySideSnapshotTest.kt
@@ -1,16 +1,12 @@
 package yuku.alkitab.base.widget
 
-import android.app.Activity
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color as AndroidColor
 import android.graphics.Typeface
-import android.os.Looper
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.View
-import android.view.ViewGroup
-import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatButton
 import androidx.test.core.app.ApplicationProvider
@@ -22,7 +18,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
 import yuku.afw.App as AfwApp
@@ -165,22 +160,18 @@ class GotoButtonSideBySideSnapshotTest {
     // ---- Rendering helpers ----------------------------------------------------------------------
 
     private fun renderOld(case: Case): Bitmap {
-        val activity = buildActivity()
-        val button = AppCompatButton(activity).apply {
+        val button = AppCompatButton(buildActivity()).apply {
             applyCommonStyle()
             text = case.text.replace(' ', ' ')
         }
-        attachAndDoFirstLayout(activity, button)
         return measureAndDraw(button, case.widthPx)
     }
 
     private fun renderNew(case: Case): Bitmap {
-        val activity = buildActivity()
-        val button = GotoButton(activity).apply {
+        val button = GotoButton(buildActivity()).apply {
             applyCommonStyle()
             text = case.text
         }
-        attachAndDoFirstLayout(activity, button)
         return measureAndDraw(button, case.widthPx)
     }
 
@@ -203,31 +194,15 @@ class GotoButtonSideBySideSnapshotTest {
         return activity
     }
 
-    private fun attachAndDoFirstLayout(activity: Activity, view: View) {
-        val frame = FrameLayout(activity).apply {
-            layoutParams = ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-            )
-            addView(
-                view,
-                ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT,
-                ),
-            )
-            setBackgroundColor(AndroidColor.WHITE)
-        }
-        activity.setContentView(frame)
-        idleLoopers()
-    }
-
     private fun measureAndDraw(view: View, widthPx: Int): Bitmap {
+        // Measure/layout the detached button at exactly widthPx and draw straight
+        // away. GotoButton wraps inside onMeasure via setText(), which schedules a
+        // requestLayout; idling the looper here would flush that traversal and
+        // re-measure the button at a different width, discarding the wrap.
         val widthSpec = View.MeasureSpec.makeMeasureSpec(widthPx, View.MeasureSpec.EXACTLY)
         val heightSpec = View.MeasureSpec.makeMeasureSpec(BUTTON_HEIGHT_PX, View.MeasureSpec.EXACTLY)
         view.measure(widthSpec, heightSpec)
-        view.layout(0, 0, view.measuredWidth, view.measuredHeight)
-        idleLoopers()
+        view.layout(0, 0, widthPx, BUTTON_HEIGHT_PX)
 
         // Pin the bitmap to the requested width/height so every old/new pair is
         // the same size and the button's edges (and any overflow clip) are visible.
@@ -236,10 +211,6 @@ class GotoButtonSideBySideSnapshotTest {
         canvas.drawColor(AndroidColor.WHITE)
         view.draw(canvas)
         return bitmap
-    }
-
-    private fun idleLoopers() {
-        Shadows.shadowOf(Looper.getMainLooper()).idle()
     }
 
     private fun escapeHtml(s: String): String =

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonSideBySideSnapshotTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/GotoButtonSideBySideSnapshotTest.kt
@@ -149,7 +149,7 @@ class GotoButtonSideBySideSnapshotTest {
             "Kidung Agung 8",
             "Pengkhotbah 12",
         )
-        val widths = listOf(70, 90, 120, 160, 200, 280)
+        val widths = listOf(120, 160, 200, 240, 320)
         val cases = mutableListOf<Case>()
         var i = 1
         for (ref in references) {
@@ -188,6 +188,7 @@ class GotoButtonSideBySideSnapshotTest {
         maxLines = 2
         ellipsize = android.text.TextUtils.TruncateAt.END
         gravity = Gravity.CENTER
+        isAllCaps = false
         includeFontPadding = false
         setPadding(0, 0, 0, 0)
         setTextColor(TEXT_COLOR)
@@ -228,9 +229,9 @@ class GotoButtonSideBySideSnapshotTest {
         view.layout(0, 0, view.measuredWidth, view.measuredHeight)
         idleLoopers()
 
-        val w = view.measuredWidth.coerceAtLeast(1)
-        val h = view.measuredHeight.coerceAtLeast(1)
-        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        // Pin the bitmap to the requested width/height so every old/new pair is
+        // the same size and the button's edges (and any overflow clip) are visible.
+        val bitmap = Bitmap.createBitmap(widthPx, BUTTON_HEIGHT_PX, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
         canvas.drawColor(AndroidColor.WHITE)
         view.draw(canvas)


### PR DESCRIPTION
## Summary
- Reader toolbar title (`GotoButton`) showed `Book.reference` (e.g. "1 Tesalonika 2") with spaces replaced by non-breaking spaces — one unbreakable token. When it overflowed one line, default `TextView` breaking only split at whitespace, wrapping as "1" / "Tesalonika" and **clipping the trailing chapter number**.
- `GotoButton` now wraps overflowing titles into two character-balanced lines, breaking mid-word when that balances better, so both lines fit the available width and the chapter number stays visible.
- Titles that fit one line render unchanged. No marquee, no font autosizing, `maxLines` stays 2. The raw label is preserved; only the rendered copy carries the inserted break.

Reported via reader feedback (issue 9).

## Implementation
- `GotoButton.balanceWrap(text, availWidth, measurer)` — pure split-point logic: returns the string unchanged if it fits, else inserts `\n` at the split minimizing `max(line1Width, line2Width)` with both lines fitting, allowing mid-word breaks and trimming the space at the split.
- `onMeasure` computes available width (button width minus paddings) and re-wraps only when width or raw text changes; `setText` captures the raw label and a guard flag prevents re-layout loops.
- `IsiActivity` now feeds the raw reference (dropped the ` ` hack).

## Test plan
- [x] `./gradlew :Alkitab:testPlainDebugUnitTest --tests "yuku.alkitab.base.widget.GotoButtonBalanceWrapTest"` — pure split logic (fit-unchanged, balanced 3-token split keeping chapter number, mid-word break, whitespace-split trim, empty).
- [x] `./gradlew assemblePlainDebug` — green.
- [ ] Visual rendering cannot be verified headless. Manual on-device: "1 Tesalonika 2" (portrait → two balanced lines, "2" visible); a long single book that fits one line (stays one line); "Kej 1" (one line, unchanged).