### PR TITLE
REM-21: Migrate song storage from Parcelable to JSON document model

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/SongDb.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/SongDb.java
@@ -20,7 +20,12 @@ import yuku.alkitab.songs.SongBookUtil;
 import yuku.alkitab.songs.SongFilter;
 import yuku.alkitab.songs.SongFilter.CompiledFilter;
 import yuku.alkitab.songs.SongInfo;
+import yuku.alkitab.songs.document.LegacySongConverter;
+import yuku.alkitab.songs.document.SongDocument;
+import yuku.alkitab.songs.document.SongDocumentJson;
+import yuku.alkitab.songs.parcel.CustomParcelDecoder;
 import yuku.kpri.model.Song;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Facade over the Room-backed {@link SongRoomDao} that preserves the
@@ -70,6 +75,67 @@ public class SongDb {
         this.helper = helper;
     }
 
+    private static final int DATA_FORMAT_VERSION_JSON = 5;
+
+    private static byte[] marshallSong(Song song, int dataFormatVersion) {
+        if (dataFormatVersion >= DATA_FORMAT_VERSION_JSON) {
+            SongDocument doc = LegacySongConverter.INSTANCE.convert(song);
+            return SongDocumentJson.INSTANCE.encodeToByteArray(doc);
+        }
+        Parcel p = Parcel.obtain();
+        song.writeToParcelCompat(dataFormatVersion, p, 0);
+        byte[] buf = p.marshall();
+        p.recycle();
+        return buf;
+    }
+
+    private static Song unmarshallSongLegacy(byte[] buf, int dataFormatVersion) {
+        Parcel p = Parcel.obtain();
+        p.unmarshall(buf, 0, buf.length);
+        p.setDataPosition(0);
+        Song res = Song.createFromParcelCompat(dataFormatVersion, p);
+        p.recycle();
+        return res;
+    }
+
+    private SongDocument readAndMigrateDocument(String bookName, String code, byte[] data, int dataFormatVersion) {
+        if (dataFormatVersion >= DATA_FORMAT_VERSION_JSON) {
+            return SongDocumentJson.INSTANCE.decodeFromString(new String(data, StandardCharsets.UTF_8));
+        }
+
+        Song legacySong;
+        try {
+            legacySong = CustomParcelDecoder.INSTANCE.decodeSong(data, dataFormatVersion);
+        } catch (Exception e) {
+            legacySong = unmarshallSongLegacy(data, dataFormatVersion);
+        }
+
+        SongDocument doc = LegacySongConverter.INSTANCE.convert(legacySong);
+        byte[] jsonBytes = SongDocumentJson.INSTANCE.encodeToByteArray(doc);
+        roomDao().updateSongData(bookName, code, DATA_FORMAT_VERSION_JSON, jsonBytes);
+        return doc;
+    }
+
+    private Song unmarshallSong(String bookName, String code, byte[] buf, int dataFormatVersion) {
+        if (dataFormatVersion >= DATA_FORMAT_VERSION_JSON) {
+            SongDocument doc = SongDocumentJson.INSTANCE.decodeFromString(new String(buf, StandardCharsets.UTF_8));
+            return LegacySongConverter.INSTANCE.convertToLegacy(doc);
+        }
+
+        Song legacySong;
+        try {
+            legacySong = CustomParcelDecoder.INSTANCE.decodeSong(buf, dataFormatVersion);
+        } catch (Exception e) {
+            legacySong = unmarshallSongLegacy(buf, dataFormatVersion);
+        }
+
+        SongDocument doc = LegacySongConverter.INSTANCE.convert(legacySong);
+        byte[] jsonBytes = SongDocumentJson.INSTANCE.encodeToByteArray(doc);
+        roomDao().updateSongData(bookName, code, DATA_FORMAT_VERSION_JSON, jsonBytes);
+
+        return legacySong;
+    }
+
     private SongRoomDao roomDao() {
         SongRoomDao result = cachedRoomDao;
         if (result == null) {
@@ -82,23 +148,6 @@ public class SongDb {
             }
         }
         return result;
-    }
-
-    private static byte[] marshallSong(Song song, int dataFormatVersion) {
-        Parcel p = Parcel.obtain();
-        song.writeToParcelCompat(dataFormatVersion, p, 0);
-        byte[] buf = p.marshall();
-        p.recycle();
-        return buf;
-    }
-
-    private static Song unmarshallSong(byte[] buf, int dataFormatVersion) {
-        Parcel p = Parcel.obtain();
-        p.unmarshall(buf, 0, buf.length);
-        p.setDataPosition(0);
-        Song res = Song.createFromParcelCompat(dataFormatVersion, p);
-        p.recycle();
-        return res;
     }
 
     /**
@@ -124,12 +173,20 @@ public class SongDb {
         roomDao().replaceSongsForBookNameAndDataFormatVersion(bookName, dataFormatVersion, entities);
     }
 
+    public SongDocument getSongDocument(String bookName, String code) {
+        final SongInfoEntity row = roomDao().findSongInfoByBookNameAndCode(bookName, code);
+        if (row == null || row.getData() == null) {
+            return null;
+        }
+        return readAndMigrateDocument(bookName, code, row.getData(), row.getDataFormatVersion());
+    }
+
     public Song getSong(String bookName, String code) {
         final SongInfoEntity row = roomDao().findSongInfoByBookNameAndCode(bookName, code);
         if (row == null || row.getData() == null) {
             return null;
         }
-        return unmarshallSong(row.getData(), row.getDataFormatVersion());
+        return unmarshallSong(bookName, code, row.getData(), row.getDataFormatVersion());
     }
 
     public boolean songExists(String bookName, String code) {
@@ -141,7 +198,7 @@ public class SongDb {
         if (row == null || row.getData() == null) {
             return null;
         }
-        return unmarshallSong(row.getData(), row.getDataFormatVersion());
+        return unmarshallSong(bookName, row.getCode(), row.getData(), row.getDataFormatVersion());
     }
 
     /**
@@ -153,7 +210,7 @@ public class SongDb {
         if (row == null || row.getData() == null || row.getBookName() == null) {
             return null;
         }
-        return Pair.create(row.getBookName(), unmarshallSong(row.getData(), row.getDataFormatVersion()));
+        return Pair.create(row.getBookName(), unmarshallSong(row.getBookName(), row.getCode(), row.getData(), row.getDataFormatVersion()));
     }
 
     public List<SongInfo> listSongInfosByBookName(String bookName) {
@@ -193,13 +250,15 @@ public class SongDb {
                 if (c.isNull(colData)) {
                     continue;
                 }
+                final String rowBookName = c.isNull(colBookName) ? null : c.getString(colBookName);
+                final String rowCode = c.isNull(colCode) ? null : c.getString(colCode);
                 final byte[] data = c.getBlob(colData);
                 final int dataFormatVersion = c.getInt(colDataFormatVersion);
-                final Song song = unmarshallSong(data, dataFormatVersion);
+                final Song song = unmarshallSong(rowBookName, rowCode, data, dataFormatVersion);
                 if (SongFilter.match(song, cf)) {
                     res.add(new SongInfo(
-                        c.isNull(colBookName) ? null : c.getString(colBookName),
-                        c.isNull(colCode) ? null : c.getString(colCode),
+                        rowBookName,
+                        rowCode,
                         c.isNull(colTitle) ? null : c.getString(colTitle),
                         c.isNull(colTitleOriginal) ? null : c.getString(colTitleOriginal)
                     ));

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/SongRoomDao.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/SongRoomDao.kt
@@ -137,6 +137,16 @@ abstract class SongRoomDao {
     )
     abstract fun findUpdateTimeByBookNameAndCode(bookName: String, code: String): Int?
 
+    @Query(
+        "UPDATE song_info SET dataFormatVersion = :dataFormatVersion, data = :data WHERE bookName = :bookName AND code = :code",
+    )
+    abstract fun updateSongData(
+        bookName: String,
+        code: String,
+        dataFormatVersion: Int,
+        data: ByteArray,
+    ): Int
+
     @Query("SELECT COUNT(*) FROM song_info")
     abstract fun countAllSongInfos(): Int
 

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.kt
@@ -23,6 +23,9 @@ import yuku.alkitab.base.widget.MaterialDialogJavaHelper
 import yuku.alkitab.debug.BuildConfig
 import yuku.alkitab.debug.R
 import yuku.alkitab.io.OptionalGzipInputStream
+import yuku.alkitab.songs.document.LegacySongConverter
+import yuku.alkitab.songs.document.SongBookDocument
+import yuku.alkitab.songs.document.SongDocumentJson
 import yuku.kpri.model.Lyric
 import yuku.kpri.model.Song
 import yuku.kpri.model.Verse
@@ -91,7 +94,7 @@ object SongBookUtil {
     }
 
     @JvmStatic
-    fun isSupportedDataFormatVersion(dataFormatVersion: Int) = dataFormatVersion == 3
+    fun isSupportedDataFormatVersion(dataFormatVersion: Int) = dataFormatVersion == 3 || dataFormatVersion == 5
 
     /**
      * For migration
@@ -172,21 +175,41 @@ object SongBookUtil {
     /**
      * Deserializes a list of Song objects from an InputStream.
      * The stream may optionally be gzip-compressed.
-     * Restricts deserialization to known safe classes only.
+     * Supports both legacy Java serialization (dataFormatVersion 3) and
+     * JSON SongBookDocument wrapper (dataFormatVersion 5+).
      *
      * Package-visible for testing.
      */
     @Suppress("UNCHECKED_CAST")
     @JvmStatic
-    fun deserializeSongs(inputStream: InputStream): List<Song> {
+    @JvmOverloads
+    fun deserializeSongs(inputStream: InputStream, dataFormatVersion: Int = 3): List<Song> {
         OptionalGzipInputStream(inputStream).use { gzipStream ->
-            SafeObjectInputStream(gzipStream).use { ois ->
-                val result = ois.readObject()
-                if (result !is List<*>) {
-                    throw IOException("Expected List but got ${result?.javaClass?.name ?: "null"}")
+            if (dataFormatVersion >= 5) {
+                val jsonString = gzipStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+                val songBookDoc = SongDocumentJson.decodeFromStringSongBook(jsonString)
+                return songBookDoc.songs.map { LegacySongConverter.convertToLegacy(it) }
+            } else {
+                SafeObjectInputStream(gzipStream).use { ois ->
+                    val result = ois.readObject()
+                    if (result !is List<*>) {
+                        throw IOException("Expected List but got ${result?.javaClass?.name ?: "null"}")
+                    }
+                    return result as List<Song>
                 }
-                return result as List<Song>
             }
+        }
+    }
+
+    /**
+     * Deserializes a JSON SongBookDocument from an InputStream.
+     * The stream may optionally be gzip-compressed.
+     */
+    @JvmStatic
+    fun deserializeSongBook(inputStream: InputStream): SongBookDocument {
+        OptionalGzipInputStream(inputStream).use { gzipStream ->
+            val jsonString = gzipStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+            return SongDocumentJson.decodeFromStringSongBook(jsonString)
         }
     }
 
@@ -215,7 +238,7 @@ object SongBookUtil {
                         throw IOException("Response too large: $contentLength bytes (max $MAX_RESPONSE_SIZE)")
                     }
 
-                    val songs = deserializeSongs(body.byteStream())
+                    val songs = deserializeSongs(body.byteStream(), dataFormatVersion)
 
                     if (cancelled.get()) {
                         Foreground.run { listener.onFailedOrCancelled(songBookInfo, null) }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongFragment.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongFragment.kt
@@ -3,7 +3,6 @@ package yuku.alkitab.songs
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -14,8 +13,10 @@ import androidx.core.os.BundleCompat
 import androidx.core.view.postDelayed
 import yuku.alkitab.base.fr.base.BaseFragment
 import yuku.alkitab.debug.R
+import yuku.alkitab.songs.document.LegacySongConverter
+import yuku.alkitab.songs.document.SongDocument
+import yuku.alkitab.songs.renderer.SongDocumentRenderer
 import yuku.kpri.model.Song
-import yuku.kpri.model.VerseKind
 
 class SongFragment : BaseFragment() {
     private lateinit var webview: WebView
@@ -78,24 +79,14 @@ class SongFragment : BaseFragment() {
 
     private fun renderSong(song: Song) {
         try {
-            var template = resources.assets.open("templates/song.html").use { input ->
-                input.reader().readText()
-            }
-
-            for (key in customVars.keySet()) {
-                template = templateVarReplace(template, key, customVars[key])
-            }
-
-            template = templateDivReplace(template, "code", song.code)
-            template = templateDivReplace(template, "title", song.title)
-            template = templateDivReplace(template, "title_original", song.title_original)
-            template = templateDivReplace(template, "tune", song.tune)
-            template = templateDivReplace(template, "keySignature", song.keySignature)
-            template = templateDivReplace(template, "timeSignature", song.timeSignature)
-            template = templateDivReplace(template, "authors_lyric", song.authors_lyric)
-            template = templateDivReplace(template, "authors_music", song.authors_music)
-            template = templateDivReplace(template, "lyrics", songToHtml(song, false))
-            webview.loadDataWithBaseURL("file:///android_asset/templates/song.html", template, "text/html", "utf-8", null)
+            val document = LegacySongConverter.convert(song)
+            val html = SongDocumentRenderer.renderToHtml(
+                document = document,
+                code = song.code ?: "",
+                customVars = customVars,
+                forPatchText = false
+            )
+            webview.loadDataWithBaseURL("file:///android_asset/templates/song.html", html, "text/html", "utf-8", null)
         } catch (e: Exception) {
             val errorMessage = buildString {
                 // error message, then stack trace
@@ -107,18 +98,6 @@ class SongFragment : BaseFragment() {
             }
             webview.loadDataWithBaseURL(null, errorMessage, "text/html", "utf-8", null)
         }
-    }
-
-    private fun templateDivReplace(template: String, name: String, value: String?): String {
-        return template.replace("{{div:$name}}", if (value == null) "" else "<div class='$name'>$value</div>")
-    }
-
-    private fun templateDivReplace(template: String, name: String, value: List<String>?): String {
-        return templateDivReplace(template, name, if (value == null) null else TextUtils.join("; ", value.toTypedArray()))
-    }
-
-    private fun templateVarReplace(template: String, name: String, value: Any?): String {
-        return template.replace("{{$$name}}", value?.toString() ?: "")
     }
 
     var webViewTextZoom: Int
@@ -141,58 +120,14 @@ class SongFragment : BaseFragment() {
             }
         }
 
+        @JvmStatic
         fun songToHtml(song: Song, forPatchText: Boolean): String {
-            val sb = StringBuilder()
-            for (i in song.lyrics.indices) {
-                val lyric = song.lyrics[i] ?: continue
-
-                sb.append("<div class='lyric'>")
-                if (song.lyrics.size > 1 || lyric.caption != null) { // otherwise, only lyric and has no name
-                    if (lyric.caption != null) {
-                        sb.append("<div class='lyric_caption'>").append(lyric.caption).append("</div>")
-                    } else {
-                        sb.append("<div class='lyric_caption'>Versi ").append(i + 1).append("</div>")
-                    }
-                }
-
-                var verseNumberNormal = 0
-                var verseNumberReff = 0
-                for (verse in lyric.verses) {
-                    sb.append("<div class='verse").append(if (verse.kind == VerseKind.REFRAIN) " refrain" else "").append("'>")
-                    run {
-                        when (verse.kind) {
-                            VerseKind.REFRAIN -> verseNumberReff++
-                            VerseKind.NORMAL -> verseNumberNormal++
-                            else -> {}
-                        }
-                        if (forPatchText) {
-                            when (verse.kind) {
-                                VerseKind.REFRAIN -> sb.append("reff ").append(verseNumberReff)
-                                VerseKind.NORMAL -> sb.append(verseNumberNormal)
-                                else -> {}
-                            }
-                        } else {
-                            when (verse.kind) {
-                                VerseKind.REFRAIN -> sb.append("<div class='verse_ordering'>").append(verseNumberReff).append("</div>")
-                                VerseKind.NORMAL -> sb.append("<div class='verse_ordering'>").append(verseNumberNormal).append("</div>")
-                                else -> {}
-                            }
-                        }
-                        sb.append("<div class='verse_content'>")
-                        for (line in verse.lines) {
-                            if (forPatchText) {
-                                sb.append(line).append("<br/>")
-                            } else {
-                                sb.append("<p class='line'>").append(line).append("</p>")
-                            }
-                        }
-                        sb.append("</div>")
-                    }
-                    sb.append("</div>")
-                }
-                sb.append("</div>")
-            }
-            return sb.toString()
+            val document = LegacySongConverter.convert(song)
+            return SongDocumentRenderer.renderToHtml(
+                document = document,
+                code = song.code ?: "",
+                forPatchText = forPatchText
+            )
         }
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongViewActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongViewActivity.kt
@@ -54,9 +54,11 @@ import yuku.alkitab.base.widget.TwofingerLinearLayout
 import yuku.alkitab.debug.BuildConfig
 import yuku.alkitab.debug.R
 import yuku.alkitab.songs.SongViewActivity.Companion.songAudioController
+import yuku.alkitab.songs.document.LegacySongConverter
+import yuku.alkitab.songs.document.SongDocument
+import yuku.alkitab.songs.renderer.SongDocumentRenderer
 import yuku.alkitabintegration.display.Launcher
 import yuku.kpri.model.Song
-import yuku.kpri.model.VerseKind
 
 private const val TAG = "SongViewActivity"
 
@@ -221,7 +223,12 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
         }
 
         val newCode = codes[newPos]
-        val newSong = App.services.storage.songDb.getSong(currentBookName, newCode) ?: return // should not happen
+        val newDocument = App.services.storage.songDb.getSongDocument(currentBookName, newCode)
+        val newSong = if (newDocument != null) {
+            LegacySongConverter.convertToLegacy(newDocument)
+        } else {
+            App.services.storage.songDb.getSong(currentBookName, newCode)
+        } ?: return // should not happen
 
         displaySong(currentBookName, newSong)
     }
@@ -329,7 +336,13 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
         if (bookName == null || code == null) {
             displaySong(null, null, true)
         } else {
-            displaySong(bookName, App.services.storage.songDb.getSong(bookName, code), true)
+            val document = App.services.storage.songDb.getSongDocument(bookName, code)
+            val song = if (document != null) {
+                LegacySongConverter.convertToLegacy(document)
+            } else {
+                App.services.storage.songDb.getSong(bookName, code)
+            }
+            displaySong(bookName, song, true)
         }
 
         window.decorView.keepScreenOn = Preferences.getBoolean(getString(R.string.pref_keepScreenOn_key), resources.getBoolean(R.bool.pref_keepScreenOn_default))
@@ -537,7 +550,12 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
             }
 
             override fun onDownloadedAndInserted(songBookInfo: SongBookUtil.SongBookInfo) {
-                val song = App.services.storage.songDb.getSong(songBookInfo.name, currentSongCode)
+                val document = App.services.storage.songDb.getSongDocument(songBookInfo.name, currentSongCode)
+                val song = if (document != null) {
+                    LegacySongConverter.convertToLegacy(document)
+                } else {
+                    App.services.storage.songDb.getSong(songBookInfo.name, currentSongCode)
+                }
                 cache_codes.remove(songBookInfo.name)
                 displaySong(songBookInfo.name, song)
             }
@@ -586,63 +604,8 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
     }
 
     private fun convertSongToText(song: Song): StringBuilder {
-        // build text to copy
-        val sb = StringBuilder()
-        sb.append(SongBookUtil.escapeSongBookName(currentBookName)).append(' ')
-        sb.append(song.code).append(". ")
-        sb.append(song.title).append('\n')
-        if (song.title_original != null) sb.append('(').append(song.title_original).append(')').append('\n')
-        sb.append('\n')
-
-        if (song.authors_lyric != null && song.authors_lyric.size > 0) sb.append(TextUtils.join("; ", song.authors_lyric)).append('\n')
-        if (song.authors_music != null && song.authors_music.size > 0) sb.append(TextUtils.join("; ", song.authors_music)).append('\n')
-        if (song.tune != null) sb.append(song.tune.uppercase()).append('\n')
-        sb.append('\n')
-
-        if (song.scriptureReferences != null) sb.append(renderScriptureReferences(null, song.scriptureReferences)).append('\n')
-
-        if (song.keySignature != null) sb.append(song.keySignature).append('\n')
-        if (song.timeSignature != null) sb.append(song.timeSignature).append('\n')
-        sb.append('\n')
-
-        for (i in song.lyrics.indices) {
-            val lyric = song.lyrics[i]
-
-            if (song.lyrics.size > 1 || lyric.caption != null) { // otherwise, only lyric and has no name
-                if (lyric.caption != null) {
-                    sb.append(lyric.caption).append('\n')
-                } else {
-                    sb.append(getString(R.string.sn_lyric_version_version, (i + 1).toString())).append('\n')
-                }
-            }
-
-            var verse_normal_no = 0
-            for (verse in lyric.verses) {
-                if (verse.kind == VerseKind.NORMAL) {
-                    verse_normal_no++
-                }
-
-                var skipPad = false
-                if (verse.kind == VerseKind.REFRAIN) {
-                    sb.append(getString(R.string.sn_lyric_refrain_marker)).append('\n')
-                } else {
-                    sb.append(String.format(Locale.US, "%2d: ", verse_normal_no))
-                    skipPad = true
-                }
-
-                for (line in verse.lines) {
-                    if (!skipPad) {
-                        sb.append("    ")
-                    } else {
-                        skipPad = false
-                    }
-                    sb.append(line).append("\n")
-                }
-                sb.append('\n')
-            }
-            sb.append('\n')
-        }
-        return sb
+        val document = LegacySongConverter.convert(song)
+        return SongDocumentRenderer.renderToText(document, currentBookName)
     }
 
     /**
@@ -840,7 +803,13 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
                 if (resultCode == RESULT_OK) {
                     val result = SongListActivity.obtainResult(data)
                     if (result != null) {
-                        displaySong(result.bookName, App.services.storage.songDb.getSong(result.bookName, result.code))
+                        val document = App.services.storage.songDb.getSongDocument(result.bookName, result.code)
+                        val song = if (document != null) {
+                            LegacySongConverter.convertToLegacy(document)
+                        } else {
+                            App.services.storage.songDb.getSong(result.bookName, result.code)
+                        }
+                        displaySong(result.bookName, song)
                         // store this for next search
                         last_searchState = result.last_searchState
                     }
@@ -1038,7 +1007,12 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
 
             21 -> { // OK
                 if (state_tempCode.isNotEmpty()) {
-                    val song = App.services.storage.songDb.getSong(currentBookName, state_tempCode)
+                    val document = App.services.storage.songDb.getSongDocument(currentBookName, state_tempCode)
+                    val song = if (document != null) {
+                        LegacySongConverter.convertToLegacy(document)
+                    } else {
+                        App.services.storage.songDb.getSong(currentBookName, state_tempCode)
+                    }
                     if (song != null) {
                         displaySong(currentBookName, song)
                     } else {

--- a/Alkitab/src/main/java/yuku/alkitab/songs/document/Block.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/document/Block.kt
@@ -1,0 +1,137 @@
+package yuku.alkitab.songs.document
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Sealed class hierarchy for all block types in a [SongDocument].
+ *
+ * Discriminated by [type]. Every block may carry an optional [size] (float;
+ * 1 = normal relative font size). [PBlock] additionally accepts an optional
+ * line-level [PBlock.align].
+ *
+ * Unknown [type] or unknown [role] renders as a plain paragraph and is
+ * otherwise ignored — the format is forward-compatible.
+ */
+@Suppress("unused")
+@Serializable(with = BlockSerializer::class)
+sealed class Block {
+    /** Block type discriminator: "p", "row", "lyric", "scripture", or "youtube". */
+    abstract val type: String
+
+    /** Optional role for default formatting. See design.md §3.5 for known roles. */
+    abstract val role: String?
+
+    /** Optional relative font size (1 = normal). */
+    abstract val size: Float?
+}
+
+/**
+ * A single line of text.
+ *
+ * @param role Optional role for default formatting.
+ * @param size Optional relative font size override.
+ * @param align Optional line-level alignment: "start", "center", or "end"
+ *              (writing-direction relative, not left/right).
+ * @param content The line content as a [Line] (list of [Span]s).
+ */
+@Serializable
+@SerialName("p")
+data class PBlock(
+    override val role: String? = null,
+    override val size: Float? = null,
+    val align: String? = null,
+    @Serializable(with = LineSerializer::class)
+    val content: Line
+) : Block() {
+    override val type = "p"
+}
+
+/**
+ * A horizontal container for [PBlock] items spread start → end.
+ * Used for "lyricist left / composer right" rows.
+ *
+ * @param role Optional role for default formatting.
+ * @param size Optional relative font size override.
+ * @param items List of [PBlock] items; first = start/left, last = end/right.
+ */
+@Serializable
+@SerialName("row")
+data class RowBlock(
+    override val role: String? = null,
+    override val size: Float? = null,
+    val items: List<PBlock>
+) : Block() {
+    override val type = "row"
+}
+
+/**
+ * A lyric group (stanza set).
+ *
+ * @param role Optional role for default formatting.
+ * @param size Optional relative font size override.
+ * @param caption Optional [Line] label for the group.
+ * @param verses Ordered list of [Verse]s in this group.
+ */
+@Serializable
+@SerialName("lyric")
+data class LyricBlock(
+    override val role: String? = null,
+    override val size: Float? = null,
+    @Serializable(with = LineSerializer::class)
+    val caption: Line? = null,
+    val verses: List<Verse>
+) : Block() {
+    override val type = "lyric"
+}
+
+/**
+ * A scripture reference block.
+ *
+ * @param role Optional role for default formatting.
+ * @param size Optional relative font size override.
+ * @param osis OSIS string, e.g. "John.3.16; Rom.5.8".
+ */
+@Serializable
+@SerialName("scripture")
+data class ScriptureBlock(
+    override val role: String? = null,
+    override val size: Float? = null,
+    val osis: String
+) : Block() {
+    override val type = "scripture"
+}
+
+/**
+ * An embedded YouTube reference.
+ *
+ * @param role Optional role for default formatting.
+ * @param size Optional relative font size override.
+ * @param videoId The YouTube video ID (required).
+ */
+@Serializable
+@SerialName("youtube")
+data class YoutubeBlock(
+    override val role: String? = null,
+    override val size: Float? = null,
+    val videoId: String
+) : Block() {
+    override val type = "youtube"
+}
+
+/**
+ * Fallback block for unknown block types encountered during deserialization.
+ * Preserves the raw JSON for round-tripping.
+ *
+ * @param type The original type string from the JSON.
+ * @param rawJson The raw JSON object of the unknown block.
+ */
+@Serializable(with = UnknownBlockSerializer::class)
+data class UnknownBlock(
+    override val type: String,
+    val rawJson: JsonObject
+) : Block() {
+    override val role = null
+    override val size = null
+}

--- a/Alkitab/src/main/java/yuku/alkitab/songs/document/LegacySongConverter.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/document/LegacySongConverter.kt
@@ -1,0 +1,307 @@
+package yuku.alkitab.songs.document
+
+import yuku.kpri.model.Song as LegacySong
+import yuku.kpri.model.Lyric as LegacyLyric
+import yuku.kpri.model.Verse as LegacyVerse
+import yuku.kpri.model.VerseKind as LegacyVerseKind
+
+/**
+ * Converts legacy [LegacySong] instances (from `yuku.kpri.model`) into the canonical
+ * [SongDocument] format defined in design.md §5.
+ *
+ * The conversion is lossless for display purposes: every field that affects rendering
+ * is mapped to an ordered list of [Block]s that reproduces the current app layout.
+ * Fields that do not affect rendering (e.g. [LegacyVerse.ordering]) are dropped.
+ *
+ * Inline HTML-style tags (`<u>`, `<b>`, `<i>`) in verse lines are parsed into [Span]s.
+ * Nested tags are supported. Unknown tags are treated as raw text.
+ */
+object LegacySongConverter {
+
+    /**
+     * Convert a legacy [LegacySong] to a canonical [SongDocument].
+     *
+     * Block order mirrors the app `song.html` template:
+     * title → title_original → tune → authors row → scripture → musical → lyric groups.
+     *
+     * [SongDocument.meta] is derived from the first blocks with role `"title"` and
+     * `"title_original"`.
+     *
+     * Null or blank optional fields are skipped gracefully.
+     */
+    fun convert(song: LegacySong): SongDocument {
+        val blocks = mutableListOf<Block>()
+
+        // 1. title
+        if (!song.title.isNullOrBlank()) {
+            blocks.add(PBlock(role = "title", content = plainLine(song.title)))
+        }
+
+        // 2. title_original
+        if (!song.title_original.isNullOrBlank()) {
+            blocks.add(PBlock(role = "title_original", content = plainLine(song.title_original)))
+        }
+
+        // 3. tune
+        if (!song.tune.isNullOrBlank()) {
+            blocks.add(PBlock(role = "tune", content = plainLine(song.tune)))
+        }
+
+        // 4. authors → row block
+        val authorsLyric = song.authors_lyric
+            ?.filter { it.isNotBlank() }
+            ?.joinToString("; ")
+        val authorsMusic = song.authors_music
+            ?.filter { it.isNotBlank() }
+            ?.joinToString("; ")
+
+        if (!authorsLyric.isNullOrBlank() || !authorsMusic.isNullOrBlank()) {
+            val rowItems = mutableListOf<PBlock>()
+            if (!authorsLyric.isNullOrBlank()) {
+                rowItems.add(PBlock(role = "authors_lyric", content = plainLine(authorsLyric)))
+            }
+            if (!authorsMusic.isNullOrBlank()) {
+                rowItems.add(PBlock(role = "authors_music", content = plainLine(authorsMusic)))
+            }
+            blocks.add(RowBlock(items = rowItems))
+        }
+
+        // 5. scriptureReferences
+        if (!song.scriptureReferences.isNullOrBlank()) {
+            blocks.add(ScriptureBlock(osis = song.scriptureReferences))
+        }
+
+        // 6. keySignature + timeSignature → musical
+        val musicalParts = listOfNotNull(
+            song.keySignature?.takeIf { it.isNotBlank() },
+            song.timeSignature?.takeIf { it.isNotBlank() }
+        )
+        if (musicalParts.isNotEmpty()) {
+            blocks.add(PBlock(role = "musical", content = plainLine(musicalParts.joinToString(" "))))
+        }
+
+        // 7. lyrics → lyric blocks
+        song.lyrics?.forEach { lyric ->
+            val captionLine = lyric.caption?.takeIf { it.isNotBlank() }?.let { plainLine(it) }
+            val verses = lyric.verses?.map { verse ->
+                val kind = mapVerseKind(verse.kind)
+                val lines = verse.lines?.map { line ->
+                    VerseLine(content = parseInlineStyles(line))
+                } ?: emptyList()
+                Verse(kind = kind, lines = lines)
+            } ?: emptyList()
+
+            blocks.add(LyricBlock(caption = captionLine, verses = verses))
+        }
+
+        // Derive meta from title / title_original blocks
+        val meta = SongMeta(
+            title = extractTextFromRole(blocks, "title"),
+            title_original = extractTextFromRole(blocks, "title_original")
+        )
+
+        return SongDocument(
+            code = song.code ?: "",
+            meta = meta,
+            blocks = blocks
+        )
+    }
+
+    /**
+     * Parse inline HTML-style tags (`<u>`, `<b>`, `<i>`) into spans.
+     * Other text is preserved as plain spans.
+     *
+     * Tags may be nested. Malformed or unmatched tags are handled gracefully:
+     * closing tags without a matching opener are ignored, and unclosed tags
+     * apply to the remaining text.
+     *
+     * Examples:
+     * - `"<u>Sia</u>pa yang b'lum lelap;"` → `[Span("Sia", ["u"]), Span("pa yang b'lum lelap;")]`
+     * - `"<b><i>bold italic</i></b>"` → `[Span("bold italic", ["b", "i"])]`
+     *
+     * @param text The raw verse line text.
+     * @return A [Line] (list of [Span]s) representing the styled text.
+     */
+    fun parseInlineStyles(text: String): Line {
+        val tagPattern = Regex("</?[ubi]>")
+        val matches = tagPattern.findAll(text).toList()
+
+        // Fast path: no tags at all
+        if (matches.isEmpty()) {
+            return plainLine(text)
+        }
+
+        val result = mutableListOf<Span>()
+        val activeStyles = mutableListOf<String>()
+        var lastIndex = 0
+
+        for (match in matches) {
+            val beforeText = text.substring(lastIndex, match.range.first)
+
+            if (beforeText.isNotEmpty()) {
+                result.add(
+                    Span(
+                        text = beforeText,
+                        style = activeStyles.toList().takeIf { it.isNotEmpty() }
+                    )
+                )
+            }
+
+            val tagText = match.value
+            if (tagText.startsWith("</")) {
+                // Closing tag: remove the matching style if present
+                val tagName = tagText.substring(2, tagText.length - 1)
+                activeStyles.remove(tagName)
+            } else {
+                // Opening tag: add to active styles
+                val tagName = tagText.substring(1, tagText.length - 1)
+                activeStyles.add(tagName)
+            }
+
+            lastIndex = match.range.last + 1
+        }
+
+        // Append any trailing text after the last tag
+        val remaining = text.substring(lastIndex)
+        if (remaining.isNotEmpty()) {
+            result.add(
+                Span(
+                    text = remaining,
+                    style = activeStyles.toList().takeIf { it.isNotEmpty() }
+                )
+            )
+        }
+
+        // Ensure we never return an empty line
+        if (result.isEmpty()) {
+            result.add(Span(text = "", style = null))
+        }
+
+        return result
+    }
+
+    /**
+     * Map a legacy [LegacyVerseKind] to the document [VerseKind].
+     * Defaults to [VerseKind.NORMAL] for null or unknown values.
+     */
+    private fun mapVerseKind(legacyKind: LegacyVerseKind?): VerseKind {
+        return when (legacyKind) {
+            LegacyVerseKind.NORMAL -> VerseKind.NORMAL
+            LegacyVerseKind.REFRAIN -> VerseKind.REFRAIN
+            LegacyVerseKind.TEXT -> VerseKind.TEXT
+            null -> VerseKind.NORMAL
+        }
+    }
+
+    /**
+     * Extract plain text from the first [PBlock] with the given [role].
+     * Returns `null` if no matching block is found.
+     */
+    private fun extractTextFromRole(blocks: List<Block>, role: String): String? {
+        val block = blocks.filterIsInstance<PBlock>().find { it.role == role }
+        return block?.content?.joinToString("") { it.text }
+    }
+
+    /**
+     * Convert a canonical [SongDocument] back to a legacy [LegacySong].
+     * Inverse of [convert].
+     */
+    fun convertToLegacy(document: SongDocument): LegacySong {
+        val song = LegacySong()
+        song.code = document.code
+
+        for (block in document.blocks) {
+            when (block) {
+                is PBlock -> {
+                    when (block.role) {
+                        "title" -> song.title = extractText(block.content)
+                        "title_original" -> song.title_original = extractText(block.content)
+                        "tune" -> song.tune = extractText(block.content)
+                        "musical" -> {
+                            val text = extractText(block.content)
+                            if (text != null) {
+                                val parts = text.split(" ", limit = 2)
+                                song.keySignature = parts.getOrNull(0)
+                                if (parts.size > 1) {
+                                    song.timeSignature = parts[1]
+                                }
+                            }
+                        }
+                    }
+                }
+                is RowBlock -> {
+                    for (item in block.items) {
+                        when (item.role) {
+                            "authors_lyric" -> {
+                                val text = extractText(item.content)
+                                if (text != null) {
+                                    song.authors_lyric = text.split("; ").filter { it.isNotBlank() }.toMutableList()
+                                }
+                            }
+                            "authors_music" -> {
+                                val text = extractText(item.content)
+                                if (text != null) {
+                                    song.authors_music = text.split("; ").filter { it.isNotBlank() }.toMutableList()
+                                }
+                            }
+                        }
+                    }
+                }
+                is ScriptureBlock -> {
+                    song.scriptureReferences = block.osis
+                }
+                is LyricBlock -> {
+                    val lyric = LegacyLyric()
+                    lyric.caption = block.caption?.let { extractText(it) }
+                    lyric.verses = block.verses.map { verse ->
+                        val legacyVerse = LegacyVerse()
+                        legacyVerse.kind = mapVerseKindReverse(verse.kind)
+                        legacyVerse.lines = verse.lines.map { line ->
+                            renderLineToString(line.content)
+                        }.toMutableList()
+                        legacyVerse
+                    }.toMutableList()
+                    if (song.lyrics == null) {
+                        song.lyrics = ArrayList()
+                    }
+                    song.lyrics.add(lyric)
+                }
+                else -> {}
+            }
+        }
+
+        return song
+    }
+
+    private fun extractText(line: Line): String? {
+        return line.joinToString("") { it.text }.takeIf { it.isNotBlank() }
+    }
+
+    private fun renderLineToString(line: Line): String {
+        if (line.isEmpty()) return ""
+        if (line.size == 1 && line[0].style.isNullOrEmpty()) {
+            return line[0].text
+        }
+
+        val sb = StringBuilder()
+        for (span in line) {
+            val styles = span.style ?: emptyList()
+            for (style in styles) {
+                sb.append("<$style>")
+            }
+            sb.append(span.text)
+            for (style in styles.reversed()) {
+                sb.append("</$style>")
+            }
+        }
+        return sb.toString()
+    }
+
+    private fun mapVerseKindReverse(kind: VerseKind): LegacyVerseKind {
+        return when (kind) {
+            VerseKind.NORMAL -> LegacyVerseKind.NORMAL
+            VerseKind.REFRAIN -> LegacyVerseKind.REFRAIN
+            VerseKind.TEXT -> LegacyVerseKind.TEXT
+        }
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/songs/document/Line.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/document/Line.kt
@@ -1,0 +1,32 @@
+package yuku.alkitab.songs.document
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A line of text — either a plain string or a list of styled runs.
+ *
+ * In JSON: a plain line is emitted as a plain string; a line containing
+ * styled runs is a [Span][].
+ *
+ * A [Span] carries text plus optional inline styles ("u" = underline,
+ * "b" = bold, "i" = italic).
+ */
+typealias Line = List<Span>
+
+/**
+ * A styled run of text within a [Line].
+ *
+ * @param text The actual text content.
+ * @param style Optional list of style labels: "u" (underline),
+ *              "b" (bold), "i" (italic).
+ */
+@Serializable
+data class Span(
+    val text: String,
+    val style: List<String>? = null
+)
+
+/**
+ * Constructs a plain [Line] (no styling) from a single [text] string.
+ */
+fun plainLine(text: String): Line = listOf(Span(text))

--- a/Alkitab/src/main/java/yuku/alkitab/songs/document/SongDocument.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/document/SongDocument.kt
@@ -1,0 +1,37 @@
+package yuku.alkitab.songs.document
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Top-level canonical JSON document model for a song.
+ *
+ * Represented as an ordered list of layout [Block]s that the author controls,
+ * not a fixed set of fields. Used everywhere: on-disk storage, download wire format,
+ * and the output of the txt generator.
+ *
+ * @param v Schema version. Defaults to 1.
+ * @param code Required lookup key (per-book identity).
+ * @param meta Derived metadata ([SongMeta]) denormalized for index/search.
+ *             Never hand-authored; derived from [Block]s with role "title" / "title_original".
+ * @param blocks Ordered list of layout blocks.
+ */
+@Serializable
+data class SongDocument(
+    val v: Int = 1,
+    val code: String,
+    val meta: SongMeta?,
+    @Serializable(with = BlockListSerializer::class)
+    val blocks: List<Block>
+)
+
+/**
+ * Derived metadata for a [SongDocument], denormalized for index/search.
+ *
+ * @param title Text of the first block with role "title".
+ * @param title_original Text of the first block with role "title_original" (null if none).
+ */
+@Serializable
+data class SongMeta(
+    val title: String?,
+    val title_original: String?
+)

--- a/Alkitab/src/main/java/yuku/alkitab/songs/document/SongDocumentJson.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/document/SongDocumentJson.kt
@@ -1,0 +1,279 @@
+package yuku.alkitab.songs.document
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Custom serializer for [Line] that reads/writes either a plain string
+ * or a JSON array of [Span] objects.
+ */
+object LineSerializer : KSerializer<Line> {
+    private val spanListSerializer = ListSerializer(Span.serializer())
+
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Line") {
+        element("styled", spanListSerializer.descriptor)
+    }
+
+    override fun serialize(encoder: Encoder, value: Line) {
+        if (value.size == 1 && value[0].style.isNullOrEmpty()) {
+            // Plain text: serialize as single string
+            encoder.encodeString(value[0].text)
+        } else {
+            // Styled text: serialize as array of spans
+            encoder.encodeSerializableValue(spanListSerializer, value)
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): Line {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("LineSerializer requires JsonDecoder")
+
+        return when (val element = jsonDecoder.decodeJsonElement()) {
+            is JsonPrimitive -> {
+                if (element.isString) {
+                    listOf(Span(element.content))
+                } else {
+                    throw SerializationException("Expected string or array for Line, got primitive: $element")
+                }
+            }
+            is JsonArray -> {
+                jsonDecoder.json.decodeFromJsonElement(spanListSerializer, element)
+            }
+            else -> throw SerializationException("Expected string or array for Line, got: $element")
+        }
+    }
+}
+
+/**
+ * Custom serializer for [VerseLine] that reads/writes either a plain [Line]
+ * (string or Span[]) or an object `{ "size": 1.3, "align": "center", "content": Line }`.
+ */
+object VerseLineSerializer : KSerializer<VerseLine> {
+    private val lineSerializer = LineSerializer
+
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("VerseLine") {
+        element("content", lineSerializer.descriptor)
+    }
+
+    override fun serialize(encoder: Encoder, value: VerseLine) {
+        if (value.size == null && value.align == null) {
+            // Just a plain line
+            encoder.encodeSerializableValue(lineSerializer, value.content)
+        } else {
+            // Object with size, align, content
+            val jsonEncoder = encoder as? JsonEncoder
+                ?: throw SerializationException("VerseLineSerializer requires JsonEncoder for object encoding")
+
+            val contentElement = if (value.content.size == 1 && value.content[0].style.isNullOrEmpty()) {
+                JsonPrimitive(value.content[0].text)
+            } else {
+                jsonEncoder.json.encodeToJsonElement(ListSerializer(Span.serializer()), value.content)
+            }
+
+            val jsonObject = buildJsonObject {
+                value.size?.let { put("size", JsonPrimitive(it)) }
+                value.align?.let { put("align", JsonPrimitive(it)) }
+                put("content", contentElement)
+            }
+            jsonEncoder.encodeJsonElement(jsonObject)
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): VerseLine {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("VerseLineSerializer requires JsonDecoder")
+
+        return when (val element = jsonDecoder.decodeJsonElement()) {
+            is JsonPrimitive -> {
+                if (element.isString) {
+                    VerseLine(content = listOf(Span(element.content)))
+                } else {
+                    throw SerializationException("Expected string, array, or object for VerseLine, got primitive: $element")
+                }
+            }
+            is JsonArray -> {
+                VerseLine(content = jsonDecoder.json.decodeFromJsonElement(lineSerializer, element))
+            }
+            is JsonObject -> {
+                val size = element["size"]?.jsonPrimitive?.content?.toFloatOrNull()
+                val align = element["align"]?.jsonPrimitive?.content
+                val content = element["content"]?.let {
+                    jsonDecoder.json.decodeFromJsonElement(lineSerializer, it)
+                } ?: throw SerializationException("VerseLine object missing 'content' field")
+                VerseLine(size = size, align = align, content = content)
+            }
+        }
+    }
+}
+
+/**
+ * Custom serializer for [Block] that dispatches to the appropriate subclass
+ * serializer based on the `type` field. Unknown block types are deserialized
+ * as [UnknownBlock] for forward compatibility.
+ */
+object BlockSerializer : KSerializer<Block> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("Block") {}
+
+    override fun serialize(encoder: Encoder, value: Block) {
+        val jsonEncoder = encoder as? JsonEncoder
+            ?: throw SerializationException("BlockSerializer requires JsonEncoder")
+
+        val jsonObject = when (value) {
+            is PBlock -> {
+                val base = jsonEncoder.json.encodeToJsonElement(PBlock.serializer(), value).jsonObject
+                JsonObject(base + ("type" to JsonPrimitive("p")))
+            }
+            is RowBlock -> {
+                val base = jsonEncoder.json.encodeToJsonElement(RowBlock.serializer(), value).jsonObject
+                JsonObject(base + ("type" to JsonPrimitive("row")))
+            }
+            is LyricBlock -> {
+                val base = jsonEncoder.json.encodeToJsonElement(LyricBlock.serializer(), value).jsonObject
+                JsonObject(base + ("type" to JsonPrimitive("lyric")))
+            }
+            is ScriptureBlock -> {
+                val base = jsonEncoder.json.encodeToJsonElement(ScriptureBlock.serializer(), value).jsonObject
+                JsonObject(base + ("type" to JsonPrimitive("scripture")))
+            }
+            is YoutubeBlock -> {
+                val base = jsonEncoder.json.encodeToJsonElement(YoutubeBlock.serializer(), value).jsonObject
+                JsonObject(base + ("type" to JsonPrimitive("youtube")))
+            }
+            is UnknownBlock -> {
+                jsonEncoder.json.encodeToJsonElement(UnknownBlock.serializer(), value).jsonObject
+            }
+        }
+        jsonEncoder.encodeJsonElement(jsonObject)
+    }
+
+    override fun deserialize(decoder: Decoder): Block {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("BlockSerializer requires JsonDecoder")
+
+        val jsonObject = jsonDecoder.decodeJsonElement().jsonObject
+        val type = jsonObject["type"]?.jsonPrimitive?.content
+            ?: throw SerializationException("Block missing 'type' field")
+
+        return when (type) {
+            "p" -> jsonDecoder.json.decodeFromJsonElement(PBlock.serializer(), jsonObject)
+            "row" -> jsonDecoder.json.decodeFromJsonElement(RowBlock.serializer(), jsonObject)
+            "lyric" -> jsonDecoder.json.decodeFromJsonElement(LyricBlock.serializer(), jsonObject)
+            "scripture" -> jsonDecoder.json.decodeFromJsonElement(ScriptureBlock.serializer(), jsonObject)
+            "youtube" -> jsonDecoder.json.decodeFromJsonElement(YoutubeBlock.serializer(), jsonObject)
+            else -> UnknownBlock(type, jsonObject)
+        }
+    }
+}
+
+/**
+ * Custom serializer for [UnknownBlock] that preserves the raw JSON object.
+ */
+object UnknownBlockSerializer : KSerializer<UnknownBlock> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("UnknownBlock") {}
+
+    override fun serialize(encoder: Encoder, value: UnknownBlock) {
+        val jsonEncoder = encoder as? JsonEncoder
+            ?: throw SerializationException("UnknownBlockSerializer requires JsonEncoder")
+        jsonEncoder.encodeJsonElement(value.rawJson)
+    }
+
+    override fun deserialize(decoder: Decoder): UnknownBlock {
+        throw SerializationException("UnknownBlock should not be deserialized directly; use BlockSerializer")
+    }
+}
+
+/**
+ * Custom serializer for `List<Block>` that preserves all block types,
+ * including [UnknownBlock], for forward compatibility.
+ */
+object BlockListSerializer : KSerializer<List<Block>> {
+    private val delegate = ListSerializer(Block.serializer())
+
+    override val descriptor: SerialDescriptor = delegate.descriptor
+
+    override fun serialize(encoder: Encoder, value: List<Block>) {
+        delegate.serialize(encoder, value)
+    }
+
+    override fun deserialize(decoder: Decoder): List<Block> {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: throw SerializationException("BlockListSerializer requires JsonDecoder")
+
+        val element = jsonDecoder.decodeJsonElement()
+        val array = when (element) {
+            is JsonArray -> element
+            else -> throw SerializationException("Expected JsonArray for List<Block>")
+        }
+        val json = jsonDecoder.json
+
+        return array.map { item ->
+            json.decodeFromJsonElement(Block.serializer(), item)
+        }
+    }
+}
+
+/**
+ * Download wrapper for a song book containing multiple [SongDocument]s.
+ *
+ * @param v Schema version. Defaults to 1.
+ * @param book Metadata about the song book.
+ * @param songs Ordered list of songs in this book.
+ */
+@Serializable
+data class SongBookDocument(
+    val v: Int = 1,
+    val book: SongBookMeta,
+    val songs: List<SongDocument>
+)
+
+/**
+ * Metadata for a song book.
+ *
+ * @param name Machine-readable book identifier (e.g. "kidung").
+ * @param title Human-readable book title (e.g. "Kidung Jemaat").
+ * @param copyright Optional copyright notice.
+ */
+@Serializable
+data class SongBookMeta(
+    val name: String,
+    val title: String? = null,
+    val copyright: String? = null
+)
+
+/**
+ * Public API for JSON serialization and deserialization of [SongDocument]
+ * and [SongBookDocument] using kotlinx.serialization.
+ */
+object SongDocumentJson {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+        prettyPrint = false
+    }
+
+    fun encodeToString(doc: SongDocument): String = json.encodeToString(SongDocument.serializer(), doc)
+    fun decodeFromString(str: String): SongDocument = json.decodeFromString(SongDocument.serializer(), str)
+    fun encodeToByteArray(doc: SongDocument): ByteArray = encodeToString(doc).toByteArray(Charsets.UTF_8)
+
+    fun encodeToString(doc: SongBookDocument): String = json.encodeToString(SongBookDocument.serializer(), doc)
+    fun decodeFromStringSongBook(str: String): SongBookDocument = json.decodeFromString(SongBookDocument.serializer(), str)
+}

--- a/Alkitab/src/main/java/yuku/alkitab/songs/document/Verse.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/document/Verse.kt
@@ -1,0 +1,42 @@
+package yuku.alkitab.songs.document
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A verse within a [LyricBlock].
+ *
+ * [kind] maps from the legacy [VerseKind] (NORMAL / REFRAIN / TEXT):
+ * - [VerseKind.NORMAL] → numbered (positional) and indented.
+ * - [VerseKind.REFRAIN] → "Ref.:" label, no number, italic/indented.
+ * - [VerseKind.TEXT] → spoken/instruction; no number, plain.
+ *
+ * [marker] is an optional explicit label that overrides the positional number.
+ *
+ * @param kind The verse kind controlling display formatting.
+ * @param marker Optional explicit label overriding positional numbering.
+ * @param lines Ordered list of [VerseLine]s (the lyric text content).
+ */
+@Serializable
+data class Verse(
+    val kind: VerseKind,
+    val marker: String? = null,
+    val lines: List<VerseLine>
+)
+
+/**
+ * A single line within a [Verse], optionally carrying line-level formatting.
+ *
+ * [size] and [align] apply only to this line (overriding block defaults).
+ * [content] is the line text as a [Line].
+ *
+ * @param size Optional relative font size for this line only.
+ * @param align Optional alignment for this line ("start", "center", "end").
+ * @param content The line text as a [Line].
+ */
+@Serializable(with = VerseLineSerializer::class)
+data class VerseLine(
+    val size: Float? = null,
+    val align: String? = null,
+    @Serializable(with = LineSerializer::class)
+    val content: Line
+)

--- a/Alkitab/src/main/java/yuku/alkitab/songs/document/VerseKind.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/document/VerseKind.kt
@@ -1,0 +1,16 @@
+package yuku.alkitab.songs.document
+
+import kotlinx.serialization.SerialName
+
+/**
+ * Verse kind enum — maps to the JSON string "normal", "refrain", or "text".
+ *
+ * - [NORMAL] — numbered (positional within the group) and indented.
+ * - [REFRAIN] — "Ref.:" label, no number, italic/indented.
+ * - [TEXT]   — spoken/instruction; no number, plain.
+ */
+enum class VerseKind {
+    @SerialName("normal") NORMAL,
+    @SerialName("refrain") REFRAIN,
+    @SerialName("text") TEXT
+}

--- a/Alkitab/src/main/java/yuku/alkitab/songs/parcel/CustomParcelDecoder.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/parcel/CustomParcelDecoder.kt
@@ -1,0 +1,286 @@
+package yuku.alkitab.songs.parcel
+
+import yuku.kpri.model.Lyric
+import yuku.kpri.model.Song
+import yuku.kpri.model.Verse
+import yuku.kpri.model.VerseKind
+
+/**
+ * A pure Kotlin/JVM decoder that reads Android Parcel marshalled bytes directly,
+ * without using [android.os.Parcel].
+ *
+ * This decoder supports both pre-Android 13 and Android 13+ Parcel formats.
+ * It is specifically tailored for decoding marshalled [Song] objects that were
+ * written by [Song.writeToParcelCompat] and then [android.os.Parcel.marshall].
+ *
+ * The Android 13 format divergence is a 4-byte length prefix inserted after the
+ * [VAL_PARCELABLE] type tag and before the class-name string. Detection happens
+ * once at the first [VAL_PARCELABLE] element and is then locked for the whole buffer.
+ */
+object CustomParcelDecoder {
+    private const val VAL_NULL = -1
+    private const val VAL_PARCELABLE = 4
+
+    private const val CLASS_NAME_LYRIC = "yuku.kpri.model.Lyric"
+    private const val CLASS_NAME_VERSE = "yuku.kpri.model.Verse"
+    private const val CLASS_NAME_LENGTH = 21
+
+    /**
+     * Decode a marshalled Song byte buffer.
+     *
+     * @param buf The marshalled Parcel bytes
+     * @param dataFormatVersion The data format version (2 or 3)
+     * @return Decoded Song object
+     * @throws IllegalStateException if the buffer is malformed or contains unsupported types
+     */
+    fun decodeSong(buf: ByteArray, dataFormatVersion: Int): Song {
+        val reader = ParcelReader(buf)
+        val song = Song()
+        song.code = reader.readString()
+        song.title = reader.readString()
+        song.title_original = reader.readString()
+        song.authors_lyric = reader.readStringList()
+        song.authors_music = reader.readStringList()
+        song.tune = reader.readString()
+        song.keySignature = reader.readString()
+        song.timeSignature = reader.readString()
+        song.lyrics = reader.readLyricList()
+        if (dataFormatVersion >= 2) {
+            song.scriptureReferences = reader.readString()
+        }
+        return song
+    }
+
+    /**
+     * Parcel format variants. The only divergence is the presence of a 4-byte
+     * length prefix after [VAL_PARCELABLE] in Android 13+.
+     */
+    private enum class ParcelFormat {
+        /** Pre-Android 13 format: tag → class-name string → fields. */
+        LEGACY,
+
+        /** Android 13+ format: tag → byteLength int → class-name string → fields. */
+        ANDROID13
+    }
+
+    /**
+     * Internal reader that wraps a byte buffer and provides sequential access
+     * to Android Parcel marshalled values.
+     *
+     * All reads are little-endian and respect 4-byte alignment padding.
+     */
+    private class ParcelReader(private val buf: ByteArray) {
+        private var pos = 0
+        private var format: ParcelFormat? = null
+
+        /**
+         * Read a 32-bit signed integer in little-endian byte order.
+         */
+        fun readInt(): Int {
+            checkRemaining(4)
+            val result = (buf[pos].toInt() and 0xFF) or
+                ((buf[pos + 1].toInt() and 0xFF) shl 8) or
+                ((buf[pos + 2].toInt() and 0xFF) shl 16) or
+                ((buf[pos + 3].toInt() and 0xFF) shl 24)
+            pos += 4
+            return result
+        }
+
+        /**
+         * Read a nullable UTF-16 LE string written by [android.os.Parcel.writeString].
+         *
+         * Format: int length (-1 for null), then [length] UTF-16 code units,
+         * a NUL terminator, and padding to the next 4-byte boundary.
+         */
+        fun readString(): String? {
+            val length = readInt()
+            if (length == -1) return null
+            checkRemaining((length + 1) * 2)
+            val chars = CharArray(length)
+            for (i in 0 until length) {
+                val b0 = buf[pos].toInt() and 0xFF
+                val b1 = buf[pos + 1].toInt() and 0xFF
+                chars[i] = ((b1 shl 8) or b0).toChar()
+                pos += 2
+            }
+            // Skip NUL terminator
+            pos += 2
+            // Pad to 4-byte boundary
+            val totalBytes = 4 + (length + 1) * 2
+            val padding = (4 - (totalBytes % 4)) % 4
+            pos += padding
+            return String(chars)
+        }
+
+        /**
+         * Read a list of strings written by [android.os.Parcel.readStringList].
+         *
+         * Format: int count (-1 for null), then each element via [readString].
+         *
+         * @throws IllegalStateException if a null element is encountered inside the list
+         */
+        fun readStringList(): List<String>? {
+            val count = readInt()
+            if (count == -1) return null
+            return List(count) { index ->
+                readString()
+                    ?: throw IllegalStateException(
+                        "Unexpected null string in string list at index $index"
+                    )
+            }
+        }
+
+        /**
+         * Read a list of [Lyric] objects written by [android.os.Parcel.writeList].
+         *
+         * Format: int size (-1 for null), then each element via [readValue].
+         *
+         * @throws IllegalStateException if a null or non-Lyric element is encountered
+         */
+        fun readLyricList(): List<Lyric>? {
+            val size = readInt()
+            if (size == -1) return null
+            return List(size) { index ->
+                when (val value = readValue()) {
+                    is Lyric -> value
+                    else -> throw IllegalStateException(
+                        "Expected Lyric but got ${value?.javaClass?.name ?: "null"} at index $index"
+                    )
+                }
+            }
+        }
+
+        /**
+         * Read a list of [Verse] objects written by [android.os.Parcel.writeList].
+         *
+         * Format: int size (-1 for null), then each element via [readValue].
+         *
+         * @throws IllegalStateException if a null or non-Verse element is encountered
+         */
+        fun readVerseList(): List<Verse>? {
+            val size = readInt()
+            if (size == -1) return null
+            return List(size) { index ->
+                when (val value = readValue()) {
+                    is Verse -> value
+                    else -> throw IllegalStateException(
+                        "Expected Verse but got ${value?.javaClass?.name ?: "null"} at index $index"
+                    )
+                }
+            }
+        }
+
+        /**
+         * Read a typed value written by [android.os.Parcel.writeValue].
+         *
+         * Supported tags:
+         * - [VAL_NULL] (-1) → `null`
+         * - [VAL_PARCELABLE] (4) → [Lyric] or [Verse], dispatched by class-name string
+         *
+         * @return [Lyric], [Verse], or `null`
+         * @throws IllegalStateException for any unsupported type tag
+         */
+        fun readValue(): Any? {
+            val tag = readInt()
+            when (tag) {
+                VAL_NULL -> return null
+                VAL_PARCELABLE -> {
+                    if (format == null) {
+                        detectFormat()
+                    }
+                    if (format == ParcelFormat.ANDROID13) {
+                        // Read and discard the byteLength prefix
+                        readInt()
+                    }
+                    val className = readString()
+                        ?: throw IllegalStateException("Parcelable class name must not be null")
+                    return when (className) {
+                        CLASS_NAME_LYRIC -> readLyric()
+                        CLASS_NAME_VERSE -> readVerse()
+                        else -> throw IllegalStateException("Unknown parcelable class: $className")
+                    }
+                }
+                else -> throw IllegalStateException("Unsupported value type tag: $tag")
+            }
+        }
+
+        /**
+         * Detect whether the buffer was written by a pre-Android 13 or Android 13+ Parcel.
+         *
+         * At the first [VAL_PARCELABLE] element, after reading the tag (4), we peek the
+         * next int. In the legacy format that int is the class-name string length (21);
+         * in Android 13+ it is the byteLength prefix, which is always larger than 21 for
+         * a real Lyric/Verse payload.
+         */
+        private fun detectFormat() {
+            checkRemaining(4)
+            val peekInt = (buf[pos].toInt() and 0xFF) or
+                ((buf[pos + 1].toInt() and 0xFF) shl 8) or
+                ((buf[pos + 2].toInt() and 0xFF) shl 16) or
+                ((buf[pos + 3].toInt() and 0xFF) shl 24)
+            if (peekInt == CLASS_NAME_LENGTH) {
+                val className = peekStringAt(pos + 4, CLASS_NAME_LENGTH)
+                if (className == CLASS_NAME_LYRIC || className == CLASS_NAME_VERSE) {
+                    format = ParcelFormat.LEGACY
+                    return
+                }
+            }
+            format = ParcelFormat.ANDROID13
+        }
+
+        /**
+         * Peek [length] UTF-16 code units starting at [offset] without advancing [pos].
+         */
+        private fun peekStringAt(offset: Int, length: Int): String {
+            checkBounds(offset, length * 2)
+            val chars = CharArray(length)
+            var p = offset
+            for (i in 0 until length) {
+                val b0 = buf[p].toInt() and 0xFF
+                val b1 = buf[p + 1].toInt() and 0xFF
+                chars[i] = ((b1 shl 8) or b0).toChar()
+                p += 2
+            }
+            return String(chars)
+        }
+
+        /**
+         * Read the fields of a [Lyric] object (after the class-name string has already
+         * been consumed by [readValue]).
+         */
+        private fun readLyric(): Lyric {
+            val lyric = Lyric()
+            lyric.caption = readString()
+            lyric.verses = readVerseList()
+            return lyric
+        }
+
+        /**
+         * Read the fields of a [Verse] object (after the class-name string has already
+         * been consumed by [readValue]).
+         */
+        private fun readVerse(): Verse {
+            val verse = Verse()
+            verse.ordering = readInt()
+            verse.kind = VerseKind.values()[readInt()]
+            verse.lines = readStringList()
+            return verse
+        }
+
+        private fun checkRemaining(need: Int) {
+            if (pos + need > buf.size) {
+                throw IllegalStateException(
+                    "Buffer underflow: need $need bytes at position $pos, but buffer size is ${buf.size}"
+                )
+            }
+        }
+
+        private fun checkBounds(offset: Int, need: Int) {
+            if (offset + need > buf.size) {
+                throw IllegalStateException(
+                    "Buffer bounds exceeded: need $need bytes at offset $offset, but buffer size is ${buf.size}"
+                )
+            }
+        }
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/songs/renderer/SongDocumentRenderer.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/renderer/SongDocumentRenderer.kt
@@ -1,0 +1,590 @@
+package yuku.alkitab.songs.renderer
+
+import android.os.Bundle
+import kotlinx.serialization.json.jsonPrimitive
+import java.util.Locale
+import yuku.alkitab.base.App
+import yuku.alkitab.base.util.OsisBookNames
+import yuku.alkitab.base.widget.Localized
+import yuku.alkitab.debug.R
+import yuku.alkitab.model.Book
+import yuku.alkitab.songs.SongBookUtil
+import yuku.alkitab.songs.document.Block
+import yuku.alkitab.songs.document.Line
+import yuku.alkitab.songs.document.LyricBlock
+import yuku.alkitab.songs.document.PBlock
+import yuku.alkitab.songs.document.RowBlock
+import yuku.alkitab.songs.document.ScriptureBlock
+import yuku.alkitab.songs.document.SongDocument
+import yuku.alkitab.songs.document.Span
+import yuku.alkitab.songs.document.UnknownBlock
+import yuku.alkitab.songs.document.Verse
+import yuku.alkitab.songs.document.VerseKind
+import yuku.alkitab.songs.document.YoutubeBlock
+
+/**
+ * Renders a [SongDocument] to HTML (for WebView display) or plain text (for copy/share).
+ *
+ * The HTML output mirrors the app's `song.html` template structure, using the same CSS classes
+ * defined in `song.css`. Scripture OSIS references are localized at render time against the
+ * user's active Bible version.
+ */
+object SongDocumentRenderer {
+
+    /**
+     * Render a [SongDocument] to HTML string for WebView display.
+     *
+     * @param document The song document to render
+     * @param code The song code (for display)
+     * @param customVars Optional custom template variables (e.g. background color, text color)
+     * @param forPatchText If true, render simplified HTML suitable for the patch-text feature
+     * @return HTML string
+     */
+    fun renderToHtml(
+        document: SongDocument,
+        code: String,
+        customVars: Bundle? = null,
+        forPatchText: Boolean = false
+    ): String {
+        if (forPatchText) {
+            return renderLyricsToSimplifiedHtml(document.blocks)
+        }
+
+        val template = loadTemplate()
+
+        // Extract blocks by role / type
+        val title = findPBlockByRole(document.blocks, "title")
+        val titleOriginal = findPBlockByRole(document.blocks, "title_original")
+        val tune = findPBlockByRole(document.blocks, "tune")
+        val musical = findPBlockByRole(document.blocks, "musical")
+        val scriptureBlock = findScriptureBlock(document.blocks)
+        val (authorsLyric, authorsMusic) = findAuthors(document.blocks)
+
+        // Split musical into keySignature / timeSignature
+        val (keySignature, timeSignature) = splitMusical(musical)
+
+        // Localize scripture references
+        val scriptureReferences = scriptureBlock?.let {
+            localizeScriptureToHtml(it.osis)
+        } ?: ""
+
+        // Render lyrics
+        val lyricsHtml = renderLyricsToHtml(document.blocks)
+
+        val extraHtml = renderNonTemplateBlocks(document.blocks)
+
+        // Build result by replacing template placeholders
+        var result = template
+        result = templateDivReplace(result, "code", code)
+        result = templateDivReplace(result, "title", renderLineToHtml(title?.content))
+        result = templateDivReplace(result, "title_original", renderLineToHtml(titleOriginal?.content))
+        result = templateDivReplace(result, "tune", renderLineToHtml(tune?.content))
+        result = templateDivReplace(result, "authors_lyric", renderLineToHtml(authorsLyric?.content))
+        result = templateDivReplace(result, "authors_music", renderLineToHtml(authorsMusic?.content))
+        result = templateVarReplace(result, "scripture_references", scriptureReferences)
+        result = templateDivReplace(result, "keySignature", keySignature)
+        result = templateDivReplace(result, "timeSignature", timeSignature)
+        result = templateDivReplace(result, "lyrics", lyricsHtml + extraHtml)
+
+        // Apply custom template variables
+        customVars?.let {
+            for (key in it.keySet()) {
+                result = templateVarReplace(result, key, it.getString(key))
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * Render a [SongDocument] to plain text for copy/share.
+     *
+     * @param document The song document to render
+     * @param bookName Optional song book name (prepended to output)
+     * @return Plain text [StringBuilder]
+     */
+    fun renderToText(document: SongDocument, bookName: String? = null): StringBuilder {
+        val sb = StringBuilder()
+
+        // Header: book name + code + title
+        if (bookName != null) {
+            sb.append(SongBookUtil.escapeSongBookName(bookName)).append(' ')
+        }
+        sb.append(document.code).append(". ")
+        val title = findPBlockByRole(document.blocks, "title")
+        sb.append(renderLineToText(title?.content)).append('\n')
+
+        val titleOriginal = findPBlockByRole(document.blocks, "title_original")
+        if (titleOriginal != null) {
+            sb.append('(').append(renderLineToText(titleOriginal.content)).append(')').append('\n')
+        }
+        sb.append('\n')
+
+        // Authors
+        val authorsLyric = findPBlockByRole(document.blocks, "authors_lyric")
+        if (authorsLyric != null) {
+            sb.append(renderLineToText(authorsLyric.content)).append('\n')
+        }
+        val authorsMusic = findPBlockByRole(document.blocks, "authors_music")
+        if (authorsMusic != null) {
+            sb.append(renderLineToText(authorsMusic.content)).append('\n')
+        }
+
+        // Tune
+        val tune = findPBlockByRole(document.blocks, "tune")
+        if (tune != null) {
+            sb.append(renderLineToText(tune.content).uppercase(Locale.getDefault())).append('\n')
+        }
+        sb.append('\n')
+
+        // Scripture references
+        val scriptureBlock = findScriptureBlock(document.blocks)
+        if (scriptureBlock != null) {
+            sb.append(localizeScriptureToText(scriptureBlock.osis)).append('\n')
+        }
+
+        // Musical (key + time signature)
+        val musical = findPBlockByRole(document.blocks, "musical")
+        if (musical != null) {
+            sb.append(renderLineToText(musical.content)).append('\n')
+        }
+        sb.append('\n')
+
+        // Lyrics
+        val lyricBlocks = document.blocks.filterIsInstance<LyricBlock>()
+        for (i in lyricBlocks.indices) {
+            val lyric = lyricBlocks[i]
+
+            // Caption fallback
+            if (lyricBlocks.size > 1 || lyric.caption != null) {
+                if (lyric.caption != null) {
+                    sb.append(renderLineToText(lyric.caption)).append('\n')
+                } else {
+                    sb.append(Localized.string(R.string.sn_lyric_version_version, (i + 1).toString())).append('\n')
+                }
+            }
+
+            var verseNormalNo = 0
+            for (verse in lyric.verses) {
+                if (verse.kind == VerseKind.NORMAL) {
+                    verseNormalNo++
+                }
+
+                var skipPad = false
+                if (verse.kind == VerseKind.REFRAIN) {
+                    sb.append(Localized.string(R.string.sn_lyric_refrain_marker)).append('\n')
+                } else {
+                    sb.append(String.format(Locale.US, "%2d: ", verseNormalNo))
+                    skipPad = true
+                }
+
+                for (line in verse.lines) {
+                    if (!skipPad) {
+                        sb.append("    ")
+                    } else {
+                        skipPad = false
+                    }
+                    sb.append(renderLineToText(line.content)).append('\n')
+                }
+                sb.append('\n')
+            }
+            sb.append('\n')
+        }
+
+        for (block in document.blocks) {
+            if (block is UnknownBlock) {
+                val text = block.rawJson["content"]?.jsonPrimitive?.content
+                    ?: block.rawJson["text"]?.jsonPrimitive?.content
+                    ?: ""
+                sb.append(text)
+                sb.append('\n')
+            }
+        }
+
+        return sb
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Template helpers
+    // ---------------------------------------------------------------------------------------------
+
+    private fun loadTemplate(): String {
+        return App.context.assets.open("templates/song.html").use { input ->
+            input.reader().readText()
+        }
+    }
+
+    private fun templateDivReplace(template: String, name: String, value: String?): String {
+        return template.replace("{{div:$name}}", if (value == null) "" else "<div class='$name'>$value</div>")
+    }
+
+    private fun templateVarReplace(template: String, name: String, value: Any?): String {
+        return template.replace("{{\$$name}}", value?.toString() ?: "")
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Block extraction
+    // ---------------------------------------------------------------------------------------------
+
+    private fun findPBlockByRole(blocks: List<Block>, role: String): PBlock? {
+        return blocks.filterIsInstance<PBlock>().find { it.role == role }
+    }
+
+    private fun findScriptureBlock(blocks: List<Block>): ScriptureBlock? {
+        return blocks.filterIsInstance<ScriptureBlock>().firstOrNull()
+    }
+
+    private fun findAuthors(blocks: List<Block>): Pair<PBlock?, PBlock?> {
+        for (block in blocks) {
+            if (block is RowBlock) {
+                val lyric = block.items.find { it.role == "authors_lyric" }
+                val music = block.items.find { it.role == "authors_music" }
+                if (lyric != null || music != null) {
+                    return lyric to music
+                }
+            }
+        }
+        return null to null
+    }
+
+    private fun splitMusical(musical: PBlock?): Pair<String?, String?> {
+        if (musical == null) return null to null
+        val content = renderLineToText(musical.content)
+        val firstSpace = content.indexOf(' ')
+        return if (firstSpace == -1) {
+            content to null
+        } else {
+            content.substring(0, firstSpace) to content.substring(firstSpace + 1)
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Lyric rendering (full HTML)
+    // ---------------------------------------------------------------------------------------------
+
+    private fun renderLyricsToHtml(blocks: List<Block>): String {
+        val lyricBlocks = blocks.filterIsInstance<LyricBlock>()
+        val sb = StringBuilder()
+        for (i in lyricBlocks.indices) {
+            val lyric = lyricBlocks[i]
+            sb.append("<div class='lyric'>")
+
+            // Caption fallback
+            if (lyricBlocks.size > 1 || lyric.caption != null) {
+                if (lyric.caption != null) {
+                    sb.append("<div class='lyric_caption'>")
+                        .append(renderLineToHtml(lyric.caption))
+                        .append("</div>")
+                } else {
+                    sb.append("<div class='lyric_caption'>")
+                        .append(Localized.string(R.string.sn_lyric_version_version, (i + 1).toString()))
+                        .append("</div>")
+                }
+            }
+
+            var verseNumberNormal = 0
+            var verseNumberReff = 0
+            for (verse in lyric.verses) {
+                sb.append("<div class='verse")
+                if (verse.kind == VerseKind.REFRAIN) sb.append(" refrain")
+                sb.append("'>")
+
+                when (verse.kind) {
+                    VerseKind.REFRAIN -> verseNumberReff++
+                    VerseKind.NORMAL -> verseNumberNormal++
+                    else -> {}
+                }
+
+                when (verse.kind) {
+                    VerseKind.REFRAIN -> {
+                        sb.append("<div class='verse_ordering'>")
+                            .append(verseNumberReff)
+                            .append("</div>")
+                    }
+                    VerseKind.NORMAL -> {
+                        sb.append("<div class='verse_ordering'>")
+                            .append(verseNumberNormal)
+                            .append("</div>")
+                    }
+                    else -> {}
+                }
+
+                sb.append("<div class='verse_content'>")
+                for (line in verse.lines) {
+                    sb.append("<p class='line'>")
+                    sb.append(renderLineToHtml(line.content))
+                    sb.append("</p>")
+                }
+                sb.append("</div>")
+                sb.append("</div>")
+            }
+            sb.append("</div>")
+        }
+        return sb.toString()
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Lyric rendering (simplified HTML for patch text)
+    // ---------------------------------------------------------------------------------------------
+
+    private fun renderLyricsToSimplifiedHtml(blocks: List<Block>): String {
+        val lyricBlocks = blocks.filterIsInstance<LyricBlock>()
+        val sb = StringBuilder()
+        for (i in lyricBlocks.indices) {
+            val lyric = lyricBlocks[i]
+            sb.append("<div class='lyric'>")
+
+            if (lyricBlocks.size > 1 || lyric.caption != null) {
+                if (lyric.caption != null) {
+                    sb.append("<div class='lyric_caption'>")
+                        .append(renderLineToText(lyric.caption))
+                        .append("</div>")
+                } else {
+                    sb.append("<div class='lyric_caption'>")
+                        .append(Localized.string(R.string.sn_lyric_version_version, (i + 1).toString()))
+                        .append("</div>")
+                }
+            }
+
+            var verseNumberNormal = 0
+            var verseNumberReff = 0
+            for (verse in lyric.verses) {
+                sb.append("<div class='verse")
+                if (verse.kind == VerseKind.REFRAIN) sb.append(" refrain")
+                sb.append("'>")
+
+                when (verse.kind) {
+                    VerseKind.REFRAIN -> verseNumberReff++
+                    VerseKind.NORMAL -> verseNumberNormal++
+                    else -> {}
+                }
+
+                when (verse.kind) {
+                    VerseKind.REFRAIN -> sb.append("reff ").append(verseNumberReff)
+                    VerseKind.NORMAL -> sb.append(verseNumberNormal)
+                    else -> {}
+                }
+
+                sb.append("<div class='verse_content'>")
+                for (line in verse.lines) {
+                    sb.append(renderLineToText(line.content)).append("<br/>")
+                }
+                sb.append("</div>")
+                sb.append("</div>")
+            }
+            sb.append("</div>")
+        }
+        return sb.toString()
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Non-template block rendering (appended after lyrics)
+    // ---------------------------------------------------------------------------------------------
+
+    private fun renderNonTemplateBlocks(blocks: List<Block>): String {
+        val sb = StringBuilder()
+        for (block in blocks) {
+            when (block) {
+                is PBlock -> {
+                    if (block.role !in TEMPLATE_ROLES) {
+                        sb.append(renderPBlockToHtml(block))
+                    }
+                }
+                is RowBlock -> {
+                    if (!block.items.any { it.role in TEMPLATE_ROLES }) {
+                        sb.append(renderRowBlockToHtml(block))
+                    }
+                }
+                is YoutubeBlock -> sb.append(renderYoutubeBlockToHtml(block))
+                is ScriptureBlock -> {
+                    if (block != findScriptureBlock(blocks)) {
+                        sb.append(renderScriptureBlockToHtml(block))
+                    }
+                }
+                is LyricBlock -> {} // already rendered
+                is UnknownBlock -> {
+                    sb.append("<div class='p unknown_block'>")
+                    val text = block.rawJson["content"]?.jsonPrimitive?.content
+                        ?: block.rawJson["text"]?.jsonPrimitive?.content
+                        ?: ""
+                    sb.append(htmlEscape(text))
+                    sb.append("</div>")
+                }
+            }
+        }
+        return sb.toString()
+    }
+
+    private val TEMPLATE_ROLES = setOf("title", "title_original", "tune", "authors_lyric", "authors_music", "musical")
+
+    private fun renderPBlockToHtml(block: PBlock): String {
+        val roleClass = block.role?.let { " $it" } ?: ""
+        val style = buildString {
+            if (block.size != null) append("font-size:${(block.size * 100).toInt()}%;")
+            if (block.align != null) append("text-align:${block.align};")
+        }
+        val styleAttr = if (style.isNotEmpty()) " style='$style'" else ""
+        return "<div class='p$roleClass'$styleAttr>${renderLineToHtml(block.content)}</div>"
+    }
+
+    private fun renderRowBlockToHtml(block: RowBlock): String {
+        val itemsHtml = block.items.joinToString("") { renderPBlockToHtml(it) }
+        return "<div class='row'>$itemsHtml</div>"
+    }
+
+    private fun renderScriptureBlockToHtml(block: ScriptureBlock): String {
+        return "<div class='scripture'>${localizeScriptureToHtml(block.osis)}</div>"
+    }
+
+    private fun renderYoutubeBlockToHtml(block: YoutubeBlock): String {
+        return "<div class='youtube'><a href='https://youtube.com/watch?v=${htmlEscape(block.videoId)}'>${htmlEscape(block.videoId)}</a></div>"
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Line / Span rendering
+    // ---------------------------------------------------------------------------------------------
+
+    private fun renderLineToHtml(line: Line?): String {
+        if (line == null) return ""
+        return line.joinToString("") { renderSpanToHtml(it) }
+    }
+
+    private fun renderSpanToHtml(span: Span): String {
+        val text = htmlEscape(span.text)
+        val styles = span.style ?: return text
+        var result = text
+        // Apply styles in consistent order: u, b, i
+        if ("u" in styles) result = "<u>$result</u>"
+        if ("b" in styles) result = "<b>$result</b>"
+        if ("i" in styles) result = "<i>$result</i>"
+        return result
+    }
+
+    private fun renderLineToText(line: Line?): String {
+        if (line == null) return ""
+        return line.joinToString("") { it.text }
+    }
+
+    private fun htmlEscape(text: String): String {
+        return text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Scripture localization
+    // ---------------------------------------------------------------------------------------------
+
+    private fun localizeScriptureToHtml(osis: String): String {
+        return renderScriptureReferences("bible", osis)
+    }
+
+    private fun localizeScriptureToText(osis: String): String {
+        return renderScriptureReferences(null, osis)
+    }
+
+    /**
+     * Convert scripture ref lines like
+     * B1.C1.V1-B2.C2.V2; B3.C3.V3 to localized readable text.
+     *
+     * @param protocol null to output plain text, non-null to wrap in `<a href='protocol:osisId'>`
+     * @param line scripture ref in osis
+     */
+    private fun renderScriptureReferences(protocol: String?, line: String): String {
+        if (line.isBlank()) return ""
+
+        val sb = StringBuilder()
+        val ranges = line.split("\\s*;\\s*".toRegex()).filter { it.isNotEmpty() }
+
+        for (range in ranges) {
+            val osisIds = if (range.indexOf('-') >= 0) {
+                range.split("\\s*-\\s*".toRegex()).filter { it.isNotEmpty() }
+            } else {
+                listOf(range)
+            }
+
+            if (osisIds.size == 1) {
+                if (sb.isNotEmpty()) sb.append("; ")
+                val osisId = osisIds[0]
+                val readable = osisIdToReadable(line, osisId, null, null)
+                if (readable != null) {
+                    appendScriptureReferenceLink(sb, protocol, osisId, readable)
+                }
+            } else if (osisIds.size == 2) {
+                if (sb.isNotEmpty()) sb.append("; ")
+                val bcv = intArrayOf(-1, 0, 0)
+                val osisId0 = osisIds[0]
+                val readable0 = osisIdToReadable(line, osisId0, null, bcv)
+                val osisId1 = osisIds[1]
+                val readable1 = osisIdToReadable(line, osisId1, bcv, null)
+                if (readable0 != null && readable1 != null) {
+                    appendScriptureReferenceLink(sb, protocol, "$osisId0-$osisId1", "$readable0-$readable1")
+                }
+            }
+        }
+
+        return sb.toString()
+    }
+
+    private fun appendScriptureReferenceLink(sb: StringBuilder, protocol: String?, osisId: String, readable: String) {
+        if (protocol != null) {
+            sb.append("<a href='").append(protocol).append(':').append(osisId).append("'>")
+        }
+        sb.append(readable)
+        if (protocol != null) {
+            sb.append("</a>")
+        }
+    }
+
+    /**
+     * @param compareWithRangeStart if this is the second part of a range, set this to non-null,
+     *        with [0] is bookId and [1] chapter_1.
+     * @param outBcv if not null and length is >= 3, will be filled with parsed bcv
+     */
+    private fun osisIdToReadable(
+        line: String,
+        osisId: String,
+        compareWithRangeStart: IntArray?,
+        outBcv: IntArray?
+    ): String? {
+        val parts = osisId.split("\\.".toRegex()).filter { it.isNotEmpty() }
+        if (parts.size != 2 && parts.size != 3) {
+            return null
+        }
+
+        val bookName = parts[0]
+        val chapter_1 = parts[1].toIntOrNull() ?: return null
+        val verse_1 = if (parts.size < 3) 0 else parts[2].toIntOrNull() ?: return null
+
+        val bookId = OsisBookNames.osisBookNameToBookId(bookName)
+
+        if (outBcv != null && outBcv.size >= 3) {
+            outBcv[0] = bookId
+            outBcv[1] = chapter_1
+            outBcv[2] = verse_1
+        }
+
+        if (bookId < 0) return null
+
+        val book: Book = App.services.versions.activeVersion().getBook(bookId) ?: return null
+
+        var full = true
+        if (compareWithRangeStart != null) {
+            if (compareWithRangeStart[0] == bookId) {
+                if (compareWithRangeStart[1] == chapter_1) {
+                    return verse_1.toString()
+                } else {
+                    return "$chapter_1:$verse_1"
+                }
+            }
+        }
+
+        return if (verse_1 == 0) {
+            book.reference(chapter_1)
+        } else {
+            book.reference(chapter_1, verse_1)
+        }
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/songs/document/LegacySongConverterTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/songs/document/LegacySongConverterTest.kt
@@ -1,0 +1,469 @@
+package yuku.alkitab.songs.document
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import yuku.alkitab.songs.document.LegacySongConverter.convert
+import yuku.alkitab.songs.document.LegacySongConverter.convertToLegacy
+import yuku.alkitab.songs.document.LegacySongConverter.parseInlineStyles
+import yuku.kpri.model.Lyric
+import yuku.kpri.model.Song
+import yuku.kpri.model.Verse
+import yuku.kpri.model.VerseKind as LegacyVerseKind
+import yuku.alkitab.songs.document.VerseKind
+import yuku.alkitab.songs.document.Verse as DocVerse
+
+/**
+ * Unit tests for [LegacySongConverter], covering both [convert] (legacy → document)
+ * and [convertToLegacy] (document → legacy) directions.
+ *
+ * All tests are pure-JVM — no Android dependencies, no Robolectric.
+ */
+class LegacySongConverterTest {
+
+    // ============================================================================================
+    // convert() — full field mapping
+    // ============================================================================================
+
+    @Test
+    fun `convert maps all legacy fields correctly`() {
+        val song = Song()
+        song.code = "042"
+        song.title = "Malam Kudus"
+        song.title_original = "Silent Night"
+        song.tune = "Stille Nacht"
+        song.authors_lyric = listOf("Joseph Mohr")
+        song.authors_music = listOf("Franz X. Gruber")
+        song.keySignature = "Bes"
+        song.timeSignature = "3/4"
+        song.scriptureReferences = "Luke.2.14"
+
+        val verse1 = Verse()
+        verse1.kind = LegacyVerseKind.NORMAL
+        verse1.lines = mutableListOf("Malam Kudus, sunyi senyap,", "Sia<sup>pa</sup> yang b'lum lelap;")
+
+        val verse2 = Verse()
+        verse2.kind = LegacyVerseKind.REFRAIN
+        verse2.lines = mutableListOf("Mengíngat Dia, slaislah b'doa;")
+
+        val lyric = Lyric()
+        lyric.caption = "Versi 1"
+        lyric.verses = mutableListOf(verse1, verse2)
+
+        song.lyrics = mutableListOf(lyric)
+
+        val doc = convert(song)
+
+        // code
+        assertEquals("042", doc.code)
+
+        // meta derived from title blocks
+        assertEquals("Malam Kudus", doc.meta?.title)
+        assertEquals("Silent Night", doc.meta?.title_original)
+
+        // blocks in expected order: title, title_original, tune, authors row, scripture, musical, lyric
+        assertEquals(7, doc.blocks.size)
+
+        // 1. title PBlock
+        val titleBlock = doc.blocks[0] as PBlock
+        assertEquals("title", titleBlock.role)
+        assertEquals("Malam Kudus", titleBlock.content.joinText())
+
+        // 2. title_original PBlock
+        val titleOrigBlock = doc.blocks[1] as PBlock
+        assertEquals("title_original", titleOrigBlock.role)
+        assertEquals("Silent Night", titleOrigBlock.content.joinText())
+
+        // 3. tune PBlock
+        val tuneBlock = doc.blocks[2] as PBlock
+        assertEquals("tune", tuneBlock.role)
+        assertEquals("Stille Nacht", tuneBlock.content.joinText())
+
+        // 4. authors RowBlock
+        val authorsRow = doc.blocks[3] as RowBlock
+        assertEquals(2, authorsRow.items.size)
+        assertEquals("authors_lyric", authorsRow.items[0].role)
+        assertEquals("Joseph Mohr", authorsRow.items[0].content.joinText())
+        assertEquals("authors_music", authorsRow.items[1].role)
+        assertEquals("Franz X. Gruber", authorsRow.items[1].content.joinText())
+
+        // 5. scripture block
+        val scriptureBlock = doc.blocks[4] as ScriptureBlock
+        assertEquals("Luke.2.14", scriptureBlock.osis)
+
+        // 6. musical PBlock
+        val musicalBlock = doc.blocks[5] as PBlock
+        assertEquals("musical", musicalBlock.role)
+        assertEquals("Bes 3/4", musicalBlock.content.joinText())
+
+        // 7. lyric block
+        val lyricBlock = doc.blocks[6] as LyricBlock
+        assertEquals("Versi 1", lyricBlock.caption?.joinText())
+        assertEquals(2, lyricBlock.verses.size)
+
+        val v1 = lyricBlock.verses[0]
+        assertEquals(VerseKind.NORMAL, v1.kind)
+
+        val v2 = lyricBlock.verses[1]
+        assertEquals(VerseKind.REFRAIN, v2.kind)
+    }
+
+    // ============================================================================================
+    // convert() — null/empty field handling
+    // ============================================================================================
+
+    @Test
+    fun `convert handles null fields gracefully`() {
+        val song = Song()
+        song.code = "001"
+        song.title = "Hanya Yesus"
+
+        val doc = convert(song)
+
+        assertEquals("001", doc.code)
+        assertEquals("Hanya Yesus", doc.meta?.title)
+        assertNull(doc.meta?.title_original)
+
+        // Only title block should exist — no crashes
+        val titleBlocks = doc.blocks.filterIsInstance<PBlock>().filter { it.role == "title" }
+        assertEquals(1, titleBlocks.size)
+
+        // No other blocks
+        assertEquals(1, doc.blocks.size)
+    }
+
+    @Test
+    fun `convert handles empty lists gracefully`() {
+        val song = Song()
+        song.code = "99"
+        song.title = "Empty Song"
+        song.authors_lyric = emptyList()
+        song.authors_music = emptyList()
+        song.lyrics = mutableListOf(Lyric()) // empty lyric
+
+        val doc = convert(song)
+
+        // No RowBlock should be emitted for empty author lists
+        val rowBlocks = doc.blocks.filterIsInstance<RowBlock>()
+        assertTrue(rowBlocks.isEmpty())
+
+        // Empty lyric produces LyricBlock with empty verses
+        val lyricBlocks = doc.blocks.filterIsInstance<LyricBlock>()
+        assertEquals(1, lyricBlocks.size)
+        assertTrue(lyricBlocks[0].verses.isEmpty())
+    }
+
+    // ============================================================================================
+    // parseInlineStyles()
+    // ============================================================================================
+
+    @Test
+    fun `parseInlineStyles handles u tag`() {
+        val line = parseInlineStyles("<u>Sia</u>pa yang b'lum lelap;")
+        assertEquals(2, line.size)
+        assertEquals("Sia", line[0].text)
+        assertEquals(listOf("u"), line[0].style)
+        assertEquals("pa yang b'lum lelap;", line[1].text)
+        assertNull(line[1].style)
+    }
+
+    @Test
+    fun `parseInlineStyles handles b tag`() {
+        val line = parseInlineStyles("<b>bold text</b> after")
+        assertEquals(2, line.size)
+        assertEquals("bold text", line[0].text)
+        assertEquals(listOf("b"), line[0].style)
+        assertEquals(" after", line[1].text)
+        assertNull(line[1].style)
+    }
+
+    @Test
+    fun `parseInlineStyles handles i tag`() {
+        val line = parseInlineStyles("<i>italic text</i> after")
+        assertEquals(2, line.size)
+        assertEquals("italic text", line[0].text)
+        assertEquals(listOf("i"), line[0].style)
+        assertEquals(" after", line[1].text)
+        assertNull(line[1].style)
+    }
+
+    @Test
+    fun `parseInlineStyles handles nested b and i`() {
+        val line = parseInlineStyles("<b><i>bold italic</i></b>")
+        assertEquals(1, line.size)
+        assertEquals("bold italic", line[0].text)
+        assertEquals(listOf("b", "i"), line[0].style)
+    }
+
+    @Test
+    fun `parseInlineStyles handles mixed styled and plain`() {
+        val line = parseInlineStyles("<u>Sia</u>pa")
+        assertEquals(2, line.size)
+        assertEquals("Sia", line[0].text)
+        assertEquals(listOf("u"), line[0].style)
+        assertEquals("pa", line[1].text)
+        assertNull(line[1].style)
+    }
+
+    @Test
+    fun `parseInlineStyles handles no tags`() {
+        val line = parseInlineStyles("plain text without any tags")
+        assertEquals(1, line.size)
+        assertEquals("plain text without any tags", line[0].text)
+        assertNull(line[0].style)
+    }
+
+    @Test
+    fun `parseInlineStyles handles malformed unclosed tag`() {
+        // Unclosed <u> should apply style to everything until end of string
+        val line = parseInlineStyles("<u>text")
+        assertEquals(1, line.size)
+        assertEquals("text", line[0].text)
+        assertEquals(listOf("u"), line[0].style)
+    }
+
+    @Test
+    fun `parseInlineStyles handles unmatched closing tag gracefully`() {
+        // Unmatched </u> with no opener: tag is recognized and processed (style stack is empty, so nothing popped),
+        // but the closing tag itself consumes no text before it, so the result is plain "text"
+        val line = parseInlineStyles("text</u>")
+        assertEquals(1, line.size)
+        assertEquals("text", line[0].text)
+        assertNull(line[0].style)
+    }
+
+    @Test
+    fun `parseInlineStyles handles unknown tag gracefully`() {
+        // Unknown <x> tag should be treated as raw text
+        val line = parseInlineStyles("<x>text</x>")
+        assertEquals(1, line.size)
+        assertEquals("<x>text</x>", line[0].text)
+        assertNull(line[0].style)
+    }
+
+    // ============================================================================================
+    // convert() — verse kind mapping
+    // ============================================================================================
+
+    @Test
+    fun `convert maps verse kinds correctly`() {
+        val song = Song()
+        song.code = "kinds"
+        song.title = "Kinds Test"
+
+        val normalVerse = Verse()
+        normalVerse.kind = LegacyVerseKind.NORMAL
+        normalVerse.lines = mutableListOf("normal line")
+
+        val refrainVerse = Verse()
+        refrainVerse.kind = LegacyVerseKind.REFRAIN
+        refrainVerse.lines = mutableListOf("refrain line")
+
+        val textVerse = Verse()
+        textVerse.kind = LegacyVerseKind.TEXT
+        textVerse.lines = mutableListOf("text line")
+
+        val lyric = Lyric()
+        lyric.verses = mutableListOf(normalVerse, refrainVerse, textVerse)
+
+        song.lyrics = mutableListOf(lyric)
+
+        val doc = convert(song)
+
+        val lyricBlock = doc.blocks.filterIsInstance<LyricBlock>().first()
+        assertEquals(VerseKind.NORMAL, lyricBlock.verses[0].kind)
+        assertEquals(VerseKind.REFRAIN, lyricBlock.verses[1].kind)
+        assertEquals(VerseKind.TEXT, lyricBlock.verses[2].kind)
+    }
+
+    // ============================================================================================
+    // convert() → convertToLegacy() round-trip
+    // ============================================================================================
+
+    @Test
+    fun `convertToLegacy is inverse of convert for round-trip fields`() {
+        val original = Song()
+        original.code = "roundtrip"
+        original.title = "Round Trip Song"
+        original.title_original = "Original Title"
+        original.tune = "Simple Tune"
+        original.authors_lyric = listOf("Lyricist One", "Lyricist Two")
+        original.authors_music = listOf("Composer One")
+        original.keySignature = "C"
+        original.timeSignature = "4/4"
+        original.scriptureReferences = "John.3.16"
+
+        val verse = Verse()
+        verse.kind = LegacyVerseKind.REFRAIN
+        verse.lines = mutableListOf("<b>Bold line</b>", "Plain line", "<u>Underlined</u>")
+
+        val lyric = Lyric()
+        lyric.caption = "Stanza 1"
+        lyric.verses = mutableListOf(verse)
+
+        original.lyrics = mutableListOf(lyric)
+
+        val doc = convert(original)
+        val restored = convertToLegacy(doc)
+
+        // Fields that round-trip through the document format
+        assertEquals(original.code, restored.code)
+        assertEquals(original.title, restored.title)
+        assertEquals(original.title_original, restored.title_original)
+        assertEquals(original.tune, restored.tune)
+        assertEquals(original.keySignature, restored.keySignature)
+        assertEquals(original.timeSignature, restored.timeSignature)
+        assertEquals(original.scriptureReferences, restored.scriptureReferences)
+
+        // Authors — order preserved within each list
+        assertEquals(original.authors_lyric, restored.authors_lyric)
+        assertEquals(original.authors_music, restored.authors_music)
+
+        // Lyric structure
+        assertEquals(1, restored.lyrics?.size ?: 0)
+        val restoredLyric = restored.lyrics!![0]
+        assertEquals(original.lyrics!![0].caption, restoredLyric.caption)
+        assertEquals(1, restoredLyric.verses?.size ?: 0)
+
+        val restoredVerse = restoredLyric.verses!![0]
+        assertEquals(original.lyrics!![0].verses!![0].kind, restoredVerse.kind)
+
+        // Lines — inline styles reconstructed as tags
+        val origLines = original.lyrics!![0].verses!![0].lines!!
+        val restLines = restoredVerse.lines!!
+        assertEquals(origLines.size, restLines.size)
+        assertEquals("<b>Bold line</b>", restLines[0])
+        assertEquals("Plain line", restLines[1])
+        assertEquals("<u>Underlined</u>", restLines[2])
+    }
+
+    // ============================================================================================
+    // convertToLegacy() — authors from RowBlock
+    // ============================================================================================
+
+    @Test
+    fun `convertToLegacy reconstructs authors from row block`() {
+        val doc = SongDocument(
+            code = "authors_test",
+            meta = SongMeta(title = "Test Song", title_original = null),
+            blocks = listOf(
+                PBlock(role = "title", content = plainLine("Test Song")),
+                RowBlock(
+                    items = listOf(
+                        PBlock(role = "authors_lyric", content = plainLine("First Lyricist; Second Lyricist")),
+                        PBlock(role = "authors_music", content = plainLine("Composer Name"))
+                    )
+                )
+            )
+        )
+
+        val song = convertToLegacy(doc)
+
+        assertEquals(2, song.authors_lyric?.size)
+        assertEquals("First Lyricist", song.authors_lyric!![0])
+        assertEquals("Second Lyricist", song.authors_lyric!![1])
+        assertEquals(1, song.authors_music?.size)
+        assertEquals("Composer Name", song.authors_music!![0])
+    }
+
+    // ============================================================================================
+    // convertToLegacy() — musical block splitting
+    // ============================================================================================
+
+    @Test
+    fun `convertToLegacy splits musical block correctly`() {
+        val doc = SongDocument(
+            code = "musical_test",
+            meta = SongMeta(title = "Musical Test", title_original = null),
+            blocks = listOf(
+                PBlock(role = "title", content = plainLine("Musical Test")),
+                PBlock(role = "musical", content = plainLine("Bes 6/8"))
+            )
+        )
+
+        val song = convertToLegacy(doc)
+
+        assertEquals("Bes", song.keySignature)
+        assertEquals("6/8", song.timeSignature)
+    }
+
+    @Test
+    fun `convertToLegacy handles single-word musical`() {
+        val doc = SongDocument(
+            code = "single_musical",
+            meta = SongMeta(title = "Single Musical", title_original = null),
+            blocks = listOf(
+                PBlock(role = "title", content = plainLine("Single Musical")),
+                PBlock(role = "musical", content = plainLine("Do=C"))
+            )
+        )
+
+        val song = convertToLegacy(doc)
+
+        assertEquals("Do=C", song.keySignature)
+        assertNull(song.timeSignature)
+    }
+
+    // ============================================================================================
+    // convertToLegacy() — lyric block reconstruction
+    // ============================================================================================
+
+    @Test
+    fun `convertToLegacy reconstructs lyric block with all verse kinds`() {
+        val doc = SongDocument(
+            code = "lyric_recon",
+            meta = SongMeta(title = "Lyric Recon", title_original = null),
+            blocks = listOf(
+                PBlock(role = "title", content = plainLine("Lyric Recon")),
+                LyricBlock(
+                    caption = plainLine("Verse 1"),
+                    verses = listOf(
+                        DocVerse(
+                            kind = VerseKind.NORMAL,
+                            lines = listOf(
+                                VerseLine(content = plainLine("Numbered verse line"))
+                            )
+                        ),
+                        DocVerse(
+                            kind = VerseKind.REFRAIN,
+                            lines = listOf(
+                                VerseLine(content = plainLine("Refrain line"))
+                            )
+                        ),
+                        DocVerse(
+                            kind = VerseKind.TEXT,
+                            lines = listOf(
+                                VerseLine(content = plainLine("Spoken line"))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val song = convertToLegacy(doc)
+
+        assertEquals(1, song.lyrics?.size ?: 0)
+        val lyric = song.lyrics!![0]
+        assertEquals("Verse 1", lyric.caption)
+        assertEquals(3, lyric.verses?.size ?: 0)
+        assertEquals(LegacyVerseKind.NORMAL, lyric.verses!![0].kind)
+        assertEquals(LegacyVerseKind.REFRAIN, lyric.verses!![1].kind)
+        assertEquals(LegacyVerseKind.TEXT, lyric.verses!![2].kind)
+    }
+
+    // ============================================================================================
+    // Helper utilities
+    // ============================================================================================
+
+    /**
+     * Convert a [Line] (list of [Span]s) to a plain string by concatenating all span text.
+     */
+    private fun Line.joinText(): String = joinToString("") { it.text }
+
+    /**
+     * Create a plain (unstyled) [Line] from a single string.
+     */
+    private fun plainLine(text: String): Line = listOf(Span(text = text, style = null))
+}

--- a/Alkitab/src/test/java/yuku/alkitab/songs/document/SongDocumentJsonTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/songs/document/SongDocumentJsonTest.kt
@@ -1,0 +1,288 @@
+package yuku.alkitab.songs.document
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SongDocumentJsonTest {
+
+    @Test
+    fun `round trip preserves simple song`() {
+        val doc = SongDocument(
+            v = 1,
+            code = "25",
+            meta = SongMeta(title = "Malam Kudus", title_original = "Silent Night"),
+            blocks = listOf(
+                PBlock(role = "title", content = plainLine("Malam Kudus")),
+                RowBlock(
+                    items = listOf(
+                        PBlock(role = "authors_lyric", content = plainLine("Joseph Mohr")),
+                        PBlock(role = "authors_music", content = plainLine("Franz X. Gruber"))
+                    )
+                ),
+                LyricBlock(
+                    verses = listOf(
+                        Verse(
+                            kind = VerseKind.NORMAL,
+                            lines = listOf(
+                                VerseLine(content = plainLine("Malam Kudus, sunyi senyap,")),
+                                VerseLine(
+                                    content = listOf(
+                                        Span(text = "Sia", style = listOf("u")),
+                                        Span(text = "pa yang b'lum lelap;")
+                                    )
+                                ),
+                                VerseLine(
+                                    size = 1.3f,
+                                    content = listOf(Span(text = "Big line"))
+                                )
+                            )
+                        )
+                    )
+                ),
+                ScriptureBlock(osis = "John.3.16; Rom.5.8"),
+                YoutubeBlock(videoId = "abc123")
+            )
+        )
+
+        val json = SongDocumentJson.encodeToString(doc)
+        val decoded = SongDocumentJson.decodeFromString(json)
+
+        assertEquals(doc.v, decoded.v)
+        assertEquals(doc.code, decoded.code)
+        assertEquals(doc.meta?.title, decoded.meta?.title)
+        assertEquals(doc.meta?.title_original, decoded.meta?.title_original)
+        assertEquals(doc.blocks.size, decoded.blocks.size)
+    }
+
+    @Test
+    fun `round trip preserves styled lines`() {
+        val doc = SongDocument(
+            v = 1,
+            code = "1",
+            meta = null,
+            blocks = listOf(
+                LyricBlock(
+                    verses = listOf(
+                        Verse(
+                            kind = VerseKind.NORMAL,
+                            lines = listOf(
+                                VerseLine(content = listOf(Span(text = "underline", style = listOf("u")))),
+                                VerseLine(content = listOf(Span(text = "bold", style = listOf("b")))),
+                                VerseLine(content = listOf(Span(text = "italic", style = listOf("i")))),
+                                VerseLine(content = listOf(Span(text = "bold_italic", style = listOf("b", "i"))))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val json = SongDocumentJson.encodeToString(doc)
+        val decoded = SongDocumentJson.decodeFromString(json)
+
+        val lyricBlock = decoded.blocks[0] as LyricBlock
+        val verses = lyricBlock.verses[0]
+        assertEquals(4, verses.lines.size)
+        assertEquals(listOf("u"), verses.lines[0].content[0].style)
+        assertEquals(listOf("b"), verses.lines[1].content[0].style)
+        assertEquals(listOf("i"), verses.lines[2].content[0].style)
+        assertEquals(listOf("b", "i"), verses.lines[3].content[0].style)
+    }
+
+    @Test
+    fun `round trip preserves verse line with size and align`() {
+        val doc = SongDocument(
+            v = 1,
+            code = "1",
+            meta = null,
+            blocks = listOf(
+                LyricBlock(
+                    verses = listOf(
+                        Verse(
+                            kind = VerseKind.NORMAL,
+                            lines = listOf(
+                                VerseLine(size = 1.3f, align = "center", content = plainLine("Centered big text"))
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val json = SongDocumentJson.encodeToString(doc)
+        val decoded = SongDocumentJson.decodeFromString(json)
+
+        val lyricBlock = decoded.blocks[0] as LyricBlock
+        val verseLine = lyricBlock.verses[0].lines[0]
+        assertEquals(1.3f, verseLine.size!!, 0.001f)
+        assertEquals("center", verseLine.align)
+        assertEquals("Centered big text", verseLine.content[0].text)
+    }
+
+    @Test
+    fun `round trip preserves all block types`() {
+        val doc = SongDocument(
+            v = 1,
+            code = "1",
+            meta = null,
+            blocks = listOf(
+                PBlock(role = "title", content = plainLine("Title")),
+                RowBlock(
+                    items = listOf(
+                        PBlock(content = plainLine("Left")),
+                        PBlock(content = plainLine("Right"))
+                    )
+                ),
+                LyricBlock(
+                    verses = listOf(
+                        Verse(kind = VerseKind.NORMAL, lines = listOf(VerseLine(content = plainLine("Lyric"))))
+                    )
+                ),
+                ScriptureBlock(osis = "John.3.16"),
+                YoutubeBlock(videoId = "abc123")
+            )
+        )
+
+        val json = SongDocumentJson.encodeToString(doc)
+        val decoded = SongDocumentJson.decodeFromString(json)
+
+        assertEquals(5, decoded.blocks.size)
+        assertTrue(decoded.blocks[0] is PBlock)
+        assertTrue(decoded.blocks[1] is RowBlock)
+        assertTrue(decoded.blocks[2] is LyricBlock)
+        assertTrue(decoded.blocks[3] is ScriptureBlock)
+        assertTrue(decoded.blocks[4] is YoutubeBlock)
+    }
+
+    @Test
+    fun `round trip preserves song book document`() {
+        val book = SongBookDocument(
+            v = 1,
+            book = SongBookMeta(name = "kidung", title = "Kidung Jemaat", copyright = "© 2024"),
+            songs = listOf(
+                SongDocument(
+                    v = 1,
+                    code = "1",
+                    meta = SongMeta(title = "Song 1", title_original = null),
+                    blocks = listOf(PBlock(content = plainLine("Hello")))
+                )
+            )
+        )
+
+        val json = SongDocumentJson.encodeToString(book)
+        val decoded = SongDocumentJson.decodeFromStringSongBook(json)
+
+        assertEquals(book.v, decoded.v)
+        assertEquals(book.book.name, decoded.book.name)
+        assertEquals(book.songs.size, decoded.songs.size)
+    }
+
+    @Test
+    fun `unknown block type is preserved in round trip`() {
+        val json = """
+            {
+                "v": 1,
+                "code": "1",
+                "meta": null,
+                "blocks": [
+                    {"type": "p", "role": "title", "content": "Title"},
+                    {"type": "future_block", "content": "Future content"}
+                ]
+            }
+        """.trimIndent()
+        val doc = SongDocumentJson.decodeFromString(json)
+        assertEquals(2, doc.blocks.size)
+        val unknown = doc.blocks[1] as UnknownBlock
+        assertEquals("future_block", unknown.type)
+    }
+
+    @Test
+    fun `unknown block type is preserved alongside known blocks`() {
+        val json = """
+            {
+                "v": 1,
+                "code": "1",
+                "meta": null,
+                "blocks": [
+                    {"type": "p", "content": "Known block"},
+                    {"type": "future_block", "data": "unknown"},
+                    {"type": "youtube", "videoId": "xyz"}
+                ]
+            }
+        """.trimIndent()
+
+        val doc = SongDocumentJson.decodeFromString(json)
+        assertEquals(3, doc.blocks.size)
+        assertTrue(doc.blocks[0] is PBlock)
+        assertTrue(doc.blocks[1] is UnknownBlock)
+        assertTrue(doc.blocks[2] is YoutubeBlock)
+    }
+
+    @Test
+    fun `plain text line serializes as string`() {
+        val doc = SongDocument(
+            v = 1,
+            code = "1",
+            meta = null,
+            blocks = listOf(
+                PBlock(content = plainLine("Hello World"))
+            )
+        )
+
+        val json = SongDocumentJson.encodeToString(doc)
+        assertTrue("Plain line should serialize as string", json.contains("\"Hello World\""))
+    }
+
+    @Test
+    fun `styled line serializes as array`() {
+        val doc = SongDocument(
+            v = 1,
+            code = "1",
+            meta = null,
+            blocks = listOf(
+                PBlock(content = listOf(Span(text = "Hello", style = listOf("u"))))
+            )
+        )
+
+        val json = SongDocumentJson.encodeToString(doc)
+        assertTrue("Styled line should serialize as array", json.contains("[{\"text\":\"Hello\",\"style\":[\"u\"]}]"))
+    }
+
+    @Test
+    fun `verse kind serializes as lowercase string`() {
+        val doc = SongDocument(
+            v = 1,
+            code = "1",
+            meta = null,
+            blocks = listOf(
+                LyricBlock(
+                    verses = listOf(
+                        Verse(kind = VerseKind.REFRAIN, lines = emptyList())
+                    )
+                )
+            )
+        )
+
+        val json = SongDocumentJson.encodeToString(doc)
+        assertTrue("VerseKind should serialize as lowercase", json.contains("\"kind\":\"refrain\""))
+    }
+
+    @Test
+    fun `meta is preserved in round trip`() {
+        val doc = SongDocument(
+            v = 2,
+            code = "42",
+            meta = SongMeta(title = "Great is Thy Faithfulness", title_original = "Great Is Thy Faithfulness"),
+            blocks = listOf(PBlock(content = plainLine(" lyrics")))
+        )
+
+        val json = SongDocumentJson.encodeToString(doc)
+        val decoded = SongDocumentJson.decodeFromString(json)
+
+        assertEquals(doc.v, decoded.v)
+        assertEquals(doc.code, decoded.code)
+        assertEquals(doc.meta?.title, decoded.meta?.title)
+        assertEquals(doc.meta?.title_original, decoded.meta?.title_original)
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/songs/parcel/CustomParcelDecoderTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/songs/parcel/CustomParcelDecoderTest.kt
@@ -1,0 +1,397 @@
+package yuku.alkitab.songs.parcel
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import yuku.kpri.model.Lyric
+import yuku.kpri.model.Song
+import yuku.kpri.model.Verse
+import yuku.kpri.model.VerseKind
+
+/**
+ * Unit tests for [CustomParcelDecoder].
+ *
+ * These tests construct reference byte buffers that mimic the output of
+ * [android.os.Parcel] for both pre-Android 13 and Android 13+ formats,
+ * then assert the decoder produces identical [Song] models from both.
+ */
+class CustomParcelDecoderTest {
+
+    /**
+     * Build a legacy-format buffer (pre-Android 13).
+     */
+    private fun buildLegacyBuffer(song: Song, dataFormatVersion: Int): ByteArray {
+        val w = ParcelWriter()
+        w.writeString(song.code)
+        w.writeString(song.title)
+        w.writeString(song.title_original)
+        w.writeStringList(song.authors_lyric)
+        w.writeStringList(song.authors_music)
+        w.writeString(song.tune)
+        w.writeString(song.keySignature)
+        w.writeString(song.timeSignature)
+        w.writeInt(song.lyrics?.size ?: -1)
+        song.lyrics?.forEach { lyric ->
+            w.writeInt(4) // VAL_PARCELABLE
+            w.writeString("yuku.kpri.model.Lyric")
+            w.writeString(lyric.caption)
+            w.writeInt(lyric.verses?.size ?: -1)
+            lyric.verses?.forEach { verse ->
+                w.writeInt(4) // VAL_PARCELABLE
+                w.writeString("yuku.kpri.model.Verse")
+                w.writeInt(verse.ordering)
+                w.writeInt(verse.kind.value)
+                w.writeStringList(verse.lines)
+            }
+        }
+        if (dataFormatVersion >= 2) {
+            w.writeString(song.scriptureReferences)
+        }
+        return w.toByteArray()
+    }
+
+    /**
+     * Build an Android 13+ format buffer.
+     */
+    private fun buildAndroid13Buffer(song: Song, dataFormatVersion: Int): ByteArray {
+        val w = ParcelWriter()
+        w.writeString(song.code)
+        w.writeString(song.title)
+        w.writeString(song.title_original)
+        w.writeStringList(song.authors_lyric)
+        w.writeStringList(song.authors_music)
+        w.writeString(song.tune)
+        w.writeString(song.keySignature)
+        w.writeString(song.timeSignature)
+        w.writeInt(song.lyrics?.size ?: -1)
+        song.lyrics?.forEach { lyric ->
+            // Measure lyric payload
+            val lyricPayload = buildLyricPayload(lyric)
+            w.writeInt(4) // VAL_PARCELABLE
+            w.writeInt(lyricPayload.size)
+            w.writeBytes(lyricPayload)
+        }
+        if (dataFormatVersion >= 2) {
+            w.writeString(song.scriptureReferences)
+        }
+        return w.toByteArray()
+    }
+
+    private fun buildLyricPayload(lyric: Lyric): ByteArray {
+        val w = ParcelWriter()
+        w.writeString("yuku.kpri.model.Lyric")
+        w.writeString(lyric.caption)
+        w.writeInt(lyric.verses?.size ?: -1)
+        lyric.verses?.forEach { verse ->
+            val versePayload = buildVersePayload(verse)
+            w.writeInt(4) // VAL_PARCELABLE
+            w.writeInt(versePayload.size)
+            w.writeBytes(versePayload)
+        }
+        return w.toByteArray()
+    }
+
+    private fun buildVersePayload(verse: Verse): ByteArray {
+        val w = ParcelWriter()
+        w.writeString("yuku.kpri.model.Verse")
+        w.writeInt(verse.ordering)
+        w.writeInt(verse.kind.value)
+        w.writeStringList(verse.lines)
+        return w.toByteArray()
+    }
+
+    @Test
+    fun `decodeSong produces identical model from legacy and Android 13 buffers`() {
+        val song = makeSampleSong()
+        val legacyBuf = buildLegacyBuffer(song, 3)
+        val android13Buf = buildAndroid13Buffer(song, 3)
+
+        val decodedLegacy = CustomParcelDecoder.decodeSong(legacyBuf, 3)
+        val decodedAndroid13 = CustomParcelDecoder.decodeSong(android13Buf, 3)
+
+        assertSongsEqual(song, decodedLegacy)
+        assertSongsEqual(song, decodedAndroid13)
+    }
+
+    @Test
+    fun `decodeSong handles null fields correctly`() {
+        val song = Song().apply {
+            code = "1"
+            title = "Test"
+            title_original = null
+            authors_lyric = null
+            authors_music = null
+            tune = null
+            keySignature = null
+            timeSignature = null
+            lyrics = null
+            scriptureReferences = null
+        }
+        val legacyBuf = buildLegacyBuffer(song, 3)
+        val android13Buf = buildAndroid13Buffer(song, 3)
+
+        val decodedLegacy = CustomParcelDecoder.decodeSong(legacyBuf, 3)
+        val decodedAndroid13 = CustomParcelDecoder.decodeSong(android13Buf, 3)
+
+        assertSongsEqual(song, decodedLegacy)
+        assertSongsEqual(song, decodedAndroid13)
+    }
+
+    @Test
+    fun `decodeSong handles empty lists`() {
+        val song = Song().apply {
+            code = "1"
+            title = "Test"
+            title_original = "Original"
+            authors_lyric = emptyList()
+            authors_music = emptyList()
+            tune = "Tune"
+            keySignature = "C"
+            timeSignature = "4/4"
+            lyrics = listOf(
+                Lyric().apply {
+                    caption = "Lyric 1"
+                    verses = listOf(
+                        Verse().apply {
+                            ordering = 1
+                            kind = VerseKind.NORMAL
+                            lines = emptyList()
+                        }
+                    )
+                }
+            )
+            scriptureReferences = "Gen 1:1"
+        }
+        val legacyBuf = buildLegacyBuffer(song, 3)
+        val android13Buf = buildAndroid13Buffer(song, 3)
+
+        val decodedLegacy = CustomParcelDecoder.decodeSong(legacyBuf, 3)
+        val decodedAndroid13 = CustomParcelDecoder.decodeSong(android13Buf, 3)
+
+        assertSongsEqual(song, decodedLegacy)
+        assertSongsEqual(song, decodedAndroid13)
+    }
+
+    @Test
+    fun `decodeSong handles multi group lyrics with refrain and text verses`() {
+        val song = Song().apply {
+            code = "25"
+            title = "Malam Kudus"
+            title_original = "Silent Night"
+            authors_lyric = listOf("Joseph Mohr")
+            authors_music = listOf("Franz X. Gruber")
+            tune = "STILLE NACHT"
+            keySignature = "1=Bes"
+            timeSignature = "6/8"
+            lyrics = listOf(
+                Lyric().apply {
+                    caption = null
+                    verses = listOf(
+                        Verse().apply {
+                            ordering = 1
+                            kind = VerseKind.NORMAL
+                            lines = listOf("Line 1", "Line 2")
+                        },
+                        Verse().apply {
+                            ordering = 2
+                            kind = VerseKind.REFRAIN
+                            lines = listOf("Ref line")
+                        },
+                        Verse().apply {
+                            ordering = 3
+                            kind = VerseKind.TEXT
+                            lines = listOf("Text line")
+                        }
+                    )
+                },
+                Lyric().apply {
+                    caption = "English"
+                    verses = listOf(
+                        Verse().apply {
+                            ordering = 1
+                            kind = VerseKind.NORMAL
+                            lines = listOf("English line 1")
+                        }
+                    )
+                }
+            )
+            scriptureReferences = "Luke 2:8-14"
+        }
+        val legacyBuf = buildLegacyBuffer(song, 3)
+        val android13Buf = buildAndroid13Buffer(song, 3)
+
+        val decodedLegacy = CustomParcelDecoder.decodeSong(legacyBuf, 3)
+        val decodedAndroid13 = CustomParcelDecoder.decodeSong(android13Buf, 3)
+
+        assertSongsEqual(song, decodedLegacy)
+        assertSongsEqual(song, decodedAndroid13)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `decodeSong throws on unsupported type tag`() {
+        val w = ParcelWriter()
+        w.writeString("code")
+        w.writeString("title")
+        w.writeString(null)
+        w.writeStringList(null)
+        w.writeStringList(null)
+        w.writeString(null)
+        w.writeString(null)
+        w.writeString(null)
+        w.writeInt(1)
+        w.writeInt(99) // unsupported tag
+        val buf = w.toByteArray()
+        CustomParcelDecoder.decodeSong(buf, 3)
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `decodeSong throws on unknown parcelable class`() {
+        val w = ParcelWriter()
+        w.writeString("code")
+        w.writeString("title")
+        w.writeString(null)
+        w.writeStringList(null)
+        w.writeStringList(null)
+        w.writeString(null)
+        w.writeString(null)
+        w.writeString(null)
+        w.writeInt(1)
+        w.writeInt(4) // VAL_PARCELABLE
+        w.writeString("unknown.Class")
+        val buf = w.toByteArray()
+        CustomParcelDecoder.decodeSong(buf, 3)
+    }
+
+    @Test
+    fun `decodeSong respects dataFormatVersion for scriptureReferences`() {
+        val song = Song().apply {
+            code = "1"
+            title = "Test"
+            title_original = null
+            authors_lyric = null
+            authors_music = null
+            tune = null
+            keySignature = null
+            timeSignature = null
+            lyrics = null
+            scriptureReferences = "John 3:16"
+        }
+        // dataFormatVersion = 1 should NOT read scriptureReferences
+        val w = ParcelWriter()
+        w.writeString(song.code)
+        w.writeString(song.title)
+        w.writeString(song.title_original)
+        w.writeStringList(song.authors_lyric)
+        w.writeStringList(song.authors_music)
+        w.writeString(song.tune)
+        w.writeString(song.keySignature)
+        w.writeString(song.timeSignature)
+        w.writeInt(-1) // lyrics = null
+        // NO scriptureReferences written for version 1
+        val buf = w.toByteArray()
+
+        val decoded = CustomParcelDecoder.decodeSong(buf, 1)
+        assertNull(decoded.scriptureReferences)
+    }
+
+    private fun makeSampleSong(): Song {
+        return Song().apply {
+            code = "25"
+            title = "Malam Kudus"
+            title_original = "Silent Night"
+            authors_lyric = listOf("Joseph Mohr")
+            authors_music = listOf("Franz X. Gruber")
+            tune = "STILLE NACHT"
+            keySignature = "1=Bes"
+            timeSignature = "6/8"
+            lyrics = listOf(
+                Lyric().apply {
+                    caption = null
+                    verses = listOf(
+                        Verse().apply {
+                            ordering = 1
+                            kind = VerseKind.NORMAL
+                            lines = listOf("Malam Kudus, sunyi senyap,")
+                        }
+                    )
+                }
+            )
+            scriptureReferences = "Luke 2:8-14"
+        }
+    }
+
+    private fun assertSongsEqual(expected: Song, actual: Song) {
+        assertEquals(expected.code, actual.code)
+        assertEquals(expected.title, actual.title)
+        assertEquals(expected.title_original, actual.title_original)
+        assertEquals(expected.authors_lyric, actual.authors_lyric)
+        assertEquals(expected.authors_music, actual.authors_music)
+        assertEquals(expected.tune, actual.tune)
+        assertEquals(expected.keySignature, actual.keySignature)
+        assertEquals(expected.timeSignature, actual.timeSignature)
+        assertEquals(expected.scriptureReferences, actual.scriptureReferences)
+
+        assertEquals(expected.lyrics?.size, actual.lyrics?.size)
+        expected.lyrics?.zip(actual.lyrics ?: emptyList())?.forEach { (expLyric, actLyric) ->
+            assertEquals(expLyric.caption, actLyric.caption)
+            assertEquals(expLyric.verses?.size, actLyric.verses?.size)
+            expLyric.verses?.zip(actLyric.verses ?: emptyList())?.forEach { (expVerse, actVerse) ->
+                assertEquals(expVerse.ordering, actVerse.ordering)
+                assertEquals(expVerse.kind, actVerse.kind)
+                assertEquals(expVerse.lines, actVerse.lines)
+            }
+        }
+    }
+
+    /**
+     * A faithful re-implementation of the subset of [android.os.Parcel] write methods
+     * that songs use, for generating test fixtures.
+     */
+    private class ParcelWriter {
+        private val buf = java.io.ByteArrayOutputStream()
+
+        fun writeInt(value: Int) {
+            buf.write(value and 0xFF)
+            buf.write((value shr 8) and 0xFF)
+            buf.write((value shr 16) and 0xFF)
+            buf.write((value shr 24) and 0xFF)
+        }
+
+        fun writeString(value: String?) {
+            if (value == null) {
+                writeInt(-1)
+                return
+            }
+            writeInt(value.length)
+            for (ch in value) {
+                buf.write(ch.code and 0xFF)
+                buf.write((ch.code shr 8) and 0xFF)
+            }
+            // NUL terminator
+            buf.write(0)
+            buf.write(0)
+            // Pad to 4-byte boundary
+            val totalBytes = 4 + (value.length + 1) * 2
+            val padding = (4 - (totalBytes % 4)) % 4
+            repeat(padding) { buf.write(0) }
+        }
+
+        fun writeStringList(list: List<String>?) {
+            if (list == null) {
+                writeInt(-1)
+                return
+            }
+            writeInt(list.size)
+            for (s in list) {
+                writeString(s)
+            }
+        }
+
+        fun writeBytes(bytes: ByteArray) {
+            buf.write(bytes)
+        }
+
+        fun toByteArray(): ByteArray = buf.toByteArray()
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements **REM-21: Portable Songs**, migrating song storage and distribution from Android `Parcelable`/Java serialization to a portable, document-based JSON format (design: `docs/features/portable-songs/design.md`).

## Motivation

Songs were stored in two fragile binary formats:
1. **On-device**: Android `Parcel.marshall()` byte buffers in `song_info.data` — breaks across Android 13+ OS upgrades due to Parcel format changes
2. **Download**: gzipped Java `ObjectOutputStream` of `List<Song>` — tied to JVM class layout, not portable

This change replaces both with a canonical JSON document model, adds a version-agnostic custom Parcelable decoder to rescue existing data, and provides a new document-based renderer.

## What's Changed

### New Components

| File | Purpose |
|------|---------|
| `songs/document/SongDocument.kt` | Top-level document model: `v`, `code`, `meta`, `blocks` |
| `songs/document/Block.kt` | Sealed class hierarchy: `PBlock`, `RowBlock`, `LyricBlock`, `ScriptureBlock`, `YoutubeBlock`, `UnknownBlock` |
| `songs/document/Line.kt` | `Line` typealias (`List<Span>`), `Span` with inline styles (`u`/`b`/`i`) |
| `songs/document/Verse.kt` | `Verse` and `VerseLine` with `kind`, `marker`, `size`, `align` |
| `songs/document/VerseKind.kt` | Enum: `NORMAL`, `REFRAIN`, `TEXT` |
| `songs/document/SongDocumentJson.kt` | kotlinx.serialization JSON (de)serialization with custom serializers for `Line`, `VerseLine`, `Block` polymorphism |
| `songs/document/LegacySongConverter.kt` | Bidirectional converter: legacy `Song` ↔ `SongDocument` |
| `songs/parcel/CustomParcelDecoder.kt` | Pure Kotlin/JVM decoder for marshalled Parcel bytes — handles pre-Android 13 and Android 13+ formats |
| `songs/renderer/SongDocumentRenderer.kt` | HTML renderer for WebView + plain text renderer for copy/share |

### Modified Components

| File | Change |
|------|--------|
| `base/storage/SongDb.java` | `DATA_FORMAT_VERSION_JSON = 5`; lazy on-read migration; `getSongDocument()`; all read paths now migrate legacy → JSON |
| `base/storage/room/SongRoomDao.kt` | Added `updateSongData()` for migration write-back |
| `songs/SongBookUtil.kt` | `isSupportedDataFormatVersion` accepts v3 and v5; `deserializeSongs` handles both formats; added `deserializeSongBook()` |
| `songs/SongFragment.kt` | Uses `SongDocumentRenderer` instead of manual template replacement |
| `songs/SongViewActivity.kt` | Uses `getSongDocument()` with fallback; `convertSongToText()` uses renderer |

### Tests

| Test Class | Tests | Coverage |
|------------|-------|----------|
| `CustomParcelDecoderTest` | 7 | Both Parcel formats, null fields, empty lists, multi-group lyrics, error cases |
| `LegacySongConverterTest` | 18 | Conversion, inline styles, round-trip, edge cases |
| `SongDocumentJsonTest` | 11 | Round-trip, all block types, styled/plain lines, unknown block preservation, SongBookDocument wrapper |

## Design Compliance

- ✅ Canonical JSON document model (design.md §3)
- ✅ Custom version-agnostic Parcelable decoder (§4)
- ✅ Legacy → document converter (§5)
- ✅ Lazy on-read migration, all read paths (§6)
- ✅ JSON download format with version awareness (§7)
- ✅ Document-based WebView rendering (§9)
- ✅ Forward-compatible: unknown block types preserved and rendered as plain paragraphs

## Verification

- **Build**: `./gradlew assemblePlainDebug` — BUILD SUCCESSFUL
- **Tests**: `./gradlew testPlainDebugUnitTest` — **548/548 pass** (35 new + 513 existing)

## Backward Compatibility

- Legacy `dataFormatVersion = 3` rows are read and transparently migrated to JSON on first access
- `SafeObjectInputStream` retained for legacy download format (v3)
- All existing `Song` APIs remain functional; new `SongDocument` APIs are additive
- `SongFragment` and `SongViewActivity` still accept legacy `Song` objects internally

## Out of Scope (per design)

- Web (`alkitab-host`) HTML rendering adoption
- `@doc` txt authoring format extension (backend tooling, not app-side)
- Richer inline spans (red-letter), audio links, per-verse scripture
