### PR TITLE
fix(songs): NPE when listing songs with all books selected

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/SongDb.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/SongDb.java
@@ -156,12 +156,16 @@ public class SongDb {
         return Pair.create(row.getBookName(), unmarshallSong(row.getData(), row.getDataFormatVersion()));
     }
 
-    public List<SongInfo> listSongInfosByBookName(String bookName) {
+    public List<SongInfo> listSongInfosByBookName(@Nullable String bookName) {
         // Metadata-only listing: deliberately avoid SELECT * so we don't
         // pull the multi-kB `data` BLOB into the heap for every row. The
         // legacy facade used the same column-list trick (cf. the pre-Room
         // `listSongInfosByBookName` query projection).
-        final List<SongInfoMetaRow> rows = roomDao().listSongInfoMetasByBookName(bookName);
+        // Null bookName means "All song books" (the song list's book
+        // selector), same contract as the legacy facade's querySongs.
+        final List<SongInfoMetaRow> rows = (bookName == null)
+            ? roomDao().listAllSongInfoMetas()
+            : roomDao().listSongInfoMetasByBookName(bookName);
         final List<SongInfo> res = new ArrayList<>(rows.size());
         for (SongInfoMetaRow row : rows) {
             res.add(new SongInfo(row.getBookName(), row.getCode(), row.getTitle(), row.getTitle_original()));

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/SongRoomDao.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/SongRoomDao.kt
@@ -95,6 +95,18 @@ abstract class SongRoomDao {
     abstract fun listSongInfoMetasByBookName(bookName: String): List<SongInfoMetaRow>
 
     /**
+     * All-books variant of [listSongInfoMetasByBookName] for the
+     * "All song books" selection (`bookName == null` at the facade).
+     * Ordering matches the legacy facade's all-books query:
+     * `bookName asc, ordering asc`.
+     */
+    @Query(
+        "SELECT bookName, code, title, title_original FROM song_info " +
+            "ORDER BY bookName ASC, ordering ASC",
+    )
+    abstract fun listAllSongInfoMetas(): List<SongInfoMetaRow>
+
+    /**
      * Returns a [Cursor] over `(bookName, code, title, title_original, data, dataFormatVersion)`
      * for streaming the deep-filter scan in
      * [yuku.alkitab.base.storage.SongDb.listSongInfosByBookNameAndDeepFilter].

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/SongDbTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/SongDbTest.kt
@@ -217,6 +217,15 @@ class SongDbTest {
     }
 
     @Test
+    fun `listSongInfosByBookName with null bookName lists every book in display order`() {
+        dao.storeSongs("PKJ", listOf(song("P1", title = "Papa")), 3)
+        dao.storeSongs("NKB", listOf(song("A", title = "Alpha"), song("B", title = "Bravo")), 3)
+        val rows = dao.listSongInfosByBookName(null)
+        assertEquals(listOf("A", "B", "P1"), rows.map { it.code })
+        assertEquals(listOf("NKB", "NKB", "PKJ"), rows.map { it.bookName })
+    }
+
+    @Test
     fun `listSongInfosByBookNameAndDeepFilter applies title-substring matching`() {
         dao.storeSongs(
             "NKB",


### PR DESCRIPTION
## Summary

Fixes a production crash reported via Crashlytics:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Class java.lang.Object.getClass()' on a null object reference
    at yuku.alkitab.base.storage.room.SongRoomDao_Impl.listSongInfoMetasByBookName(SongRoomDao_Impl.java:8)
    at yuku.alkitab.base.storage.SongDb.listSongInfosByBookName(SongDb.java:164)
    at yuku.alkitab.songs.SongListActivity$SongLoader.loadInBackground(SongListActivity.java:344)
```

**Root cause:** REM-32 (SongDb → Room migration) regression. The song list's "All song books" selection passes `bookName == null` into `SongDb.listSongInfosByBookName`. The legacy `querySongs` treated null as "no WHERE clause, order by bookName asc, ordering asc", but the Room facade passed null straight into the non-null Kotlin DAO parameter `listSongInfoMetasByBookName(bookName: String)`, crashing in the generated binder. The deep-search path already handled null correctly — only the non-deep listing path regressed.

## Changes

- `SongRoomDao`: new `listAllSongInfoMetas()` projection query (`ORDER BY bookName ASC, ordering ASC`, matching the legacy all-books ordering)
- `SongDb.listSongInfosByBookName`: branch on null `bookName` + `@Nullable` annotation
- `SongDbTest`: regression test that reproduced the NPE before the fix

## Testing

- `./gradlew testPlainDebugUnitTest` — all green (new regression test failed with the same NPE before the fix)
- `./gradlew assemblePlainDebug` — builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)