### PR TITLE
Accept non-p blocks inside a row

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocument.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocument.kt
@@ -88,7 +88,7 @@ data class PBlock(
 @Serializable(with = RowBlockSerializer::class)
 data class RowBlock(
     override val size: Float? = null,
-    val items: List<PBlock> = emptyList(),
+    val items: List<Block> = emptyList(),
 ) : Block
 
 @Serializable(with = LyricBlockSerializer::class)

--- a/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentRenderer.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentRenderer.kt
@@ -31,7 +31,15 @@ object SongDocumentRenderer {
                 }
 
                 is RowBlock -> {
-                    for (item in block.items) renderPBlock(item, sb)
+                    for (item in block.items) {
+                        when (item) {
+                            is PBlock -> renderPBlock(item, sb)
+                            is YoutubeBlock -> renderYoutubeBlock(item, sb)
+                            is ScriptureBlock -> sb.append("<div class='scriptureReferences'>").append(renderScripture(item.osis)).append("</div>")
+                            is GapBlock -> sb.append("<div style='height:").append(item.size ?: 1f).append("em'></div>")
+                            else -> {}
+                        }
+                    }
                     if (!forPatchText) sb.append("<div class='break'></div>")
                 }
 

--- a/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentSearch.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentSearch.kt
@@ -24,7 +24,7 @@ object SongDocumentSearch {
     private fun collect(block: Block, out: MutableList<String>) {
         when (block) {
             is PBlock -> if (block.role == "tune") out.add(block.content.plainText())
-            is RowBlock -> for (item in block.items) {
+            is RowBlock -> for (item in block.items.filterIsInstance<PBlock>()) {
                 if (item.role == "authors_lyric" || item.role == "authors_music") out.add(item.content.plainText())
             }
             is LyricBlock -> for (verse in block.verses) {

--- a/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentSerializers.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentSerializers.kt
@@ -159,7 +159,7 @@ object RowBlockSerializer : KSerializer<RowBlock> {
             buildJsonObject {
                 put("type", "row")
                 value.size?.let { put("size", it) }
-                put("items", JsonArray(value.items.map { e.json.encodeToJsonElement(PBlock.serializer(), it) }))
+                put("items", JsonArray(value.items.map { e.json.encodeToJsonElement(BlockSerializer, it) }))
             },
         )
     }
@@ -169,7 +169,7 @@ object RowBlockSerializer : KSerializer<RowBlock> {
         val obj = d.decodeJsonElement().jsonObject
         return RowBlock(
             size = obj["size"]?.jsonPrimitive?.floatOrNull,
-            items = (obj["items"]?.jsonArray ?: JsonArray(emptyList())).map { d.json.decodeFromJsonElement(PBlock.serializer(), it) },
+            items = (obj["items"]?.jsonArray ?: JsonArray(emptyList())).map { d.json.decodeFromJsonElement(BlockSerializer, it) },
         )
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentSerializers.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentSerializers.kt
@@ -169,7 +169,7 @@ object RowBlockSerializer : KSerializer<RowBlock> {
         val obj = d.decodeJsonElement().jsonObject
         return RowBlock(
             size = obj["size"]?.jsonPrimitive?.floatOrNull,
-            items = (obj["items"]?.jsonArray ?: JsonArray(emptyList())).map { d.json.decodeFromJsonElement(BlockSerializer, it) },
+            items = obj["items"]?.jsonArray?.map { d.json.decodeFromJsonElement(BlockSerializer, it) } ?: emptyList(),
         )
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentText.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentText.kt
@@ -30,7 +30,7 @@ object SongDocumentText {
         doc.meta.title_original?.let { sb.append('(').append(it).append(')').append('\n') }
         sb.append('\n')
 
-        val rowItems = doc.blocks.filterIsInstance<RowBlock>().firstOrNull()?.items.orEmpty()
+        val rowItems = doc.blocks.filterIsInstance<RowBlock>().firstOrNull()?.items.orEmpty().filterIsInstance<PBlock>()
         rowItems.firstOrNull { it.role == "authors_lyric" }?.let { sb.append(it.content.plainText()).append('\n') }
         rowItems.firstOrNull { it.role == "authors_music" }?.let { sb.append(it.content.plainText()).append('\n') }
         doc.blocks.filterIsInstance<PBlock>().firstOrNull { it.role == "tune" }?.let {

--- a/Alkitab/src/test/java/yuku/alkitab/songs/SongBookUtilTest.java
+++ b/Alkitab/src/test/java/yuku/alkitab/songs/SongBookUtilTest.java
@@ -23,6 +23,7 @@ import yuku.alkitab.songs.newdoc.RowBlock;
 import yuku.alkitab.songs.newdoc.ScriptureBlock;
 import yuku.alkitab.songs.newdoc.SongDocument;
 import yuku.alkitab.songs.newdoc.SongDocumentJson;
+import yuku.alkitab.songs.newdoc.YoutubeBlock;
 import yuku.kpri.model.Lyric;
 import yuku.kpri.model.Song;
 import yuku.kpri.model.Verse;
@@ -92,8 +93,8 @@ public class SongBookUtilTest {
     private static PBlock firstRowItemWithRole(SongDocument doc, String role) {
         for (Block b : doc.getBlocks()) {
             if (b instanceof RowBlock) {
-                for (PBlock item : ((RowBlock) b).getItems()) {
-                    if (role.equals(item.getRole())) return item;
+                for (Block item : ((RowBlock) b).getItems()) {
+                    if (item instanceof PBlock && role.equals(((PBlock) item).getRole())) return (PBlock) item;
                 }
             }
         }
@@ -253,6 +254,32 @@ public class SongBookUtilTest {
         assertEquals(false, SongBookUtil.isSupportedDataFormatVersion(3));
         assertEquals(false, SongBookUtil.isSupportedDataFormatVersion(4));
         assertTrue(SongBookUtil.isSupportedDataFormatVersion(5));
+    }
+
+    @Test
+    public void deserializeRowContainingYoutubeBlock() throws Exception {
+        String json = "{\"dataFormatVersion\":5,\"songs\":[{\"code\":\"KK1\",\"meta\":{\"title\":\"T\"},"
+            + "\"blocks\":[{\"type\":\"row\",\"items\":["
+            + "{\"type\":\"p\",\"role\":\"musical\",\"content\":\"do=d 4/4\"},"
+            + "{\"type\":\"youtube\",\"videoId\":\"syUb69jiBnA\"}"
+            + "]}]}]}";
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzos = new GZIPOutputStream(baos)) {
+            gzos.write(json.getBytes(StandardCharsets.UTF_8));
+        }
+
+        List<SongDocument> result = SongBookUtil.deserializeSongs(new ByteArrayInputStream(baos.toByteArray()));
+        assertEquals(1, result.size());
+
+        RowBlock row = null;
+        for (Block b : result.get(0).getBlocks()) {
+            if (b instanceof RowBlock) row = (RowBlock) b;
+        }
+        assertNotNull(row);
+        assertEquals(2, row.getItems().size());
+        assertTrue(row.getItems().get(0) instanceof PBlock);
+        assertTrue(row.getItems().get(1) instanceof YoutubeBlock);
+        assertEquals("syUb69jiBnA", ((YoutubeBlock) row.getItems().get(1)).getVideoId());
     }
 
     @Test

--- a/docs/features/portable-songs/design.md
+++ b/docs/features/portable-songs/design.md
@@ -68,7 +68,7 @@ A block is discriminated by `type`. **Every** block may carry an optional `size`
 | `type`      | Shape | Purpose |
 |-------------|-------|---------|
 | `p`         | `{ type:"p", role?, size?, align?, content: Line }` | A single line of text. `role` selects default formatting; `align` is line-level. |
-| `row`       | `{ type:"row", size?, items: PBlock[] }` | Horizontal container; items are spread start → end (first = start/left, last = end/right). Used for "lyricist left / composer right". |
+| `row`       | `{ type:"row", size?, items: Block[] }` | Horizontal container; items are spread start → end (first = start/left, last = end/right). Items are usually `p`, but may be `youtube` / `gap` / `scripture`. Used for "lyricist left / composer right", or musical notation beside a video link. |
 | `lyric`     | `{ type:"lyric", role?, size?, caption?: Line, verses: Verse[] }` | A lyric group (stanza set). |
 | `scripture` | `{ type:"scripture", role?, size?, osis: string }` | Scripture reference(s) as an OSIS string, e.g. `"John.3.16; Rom.5.8"`. |
 | `youtube`   | `{ type:"youtube", role?, size?, videoId: string }` | An embedded YouTube reference (single required `videoId`). |
@@ -324,7 +324,7 @@ A song enters document mode with a `code <CODE>` line (required; `no` also accep
 - `@scripture <osis>` → a `scripture` block.
 - `@youtube <videoId>` → a `youtube` block.
 - `@gap` → a `gap` block. Combines with `@size=<float>` like other tags, e.g. `@size=2 @gap` for a double-height blank line.
-- `@row` … `@/row` → a `row` block; each line between the markers is parsed as a `p` item (role/size/align tags apply per item), giving e.g. lyricist-left / composer-right.
+- `@row` … `@/row` → a `row` block; each line between the markers becomes a block item — usually a `p` (role/size/align tags apply per item), but `@youtube` / `@gap` / `@scripture` inside a row produce their own block types. Gives e.g. lyricist-left / composer-right, or musical notation beside a video link.
 - **Lyric markers** `*N` / `*ref`[N] / `*reff`[N] / `*text`[N] / `*versi`/`*version <caption>` behave as in legacy, including auto-grouping (a normal verse number ≤ the last one starts a new `lyric` group). Subsequent non-marker lines are appended to the current verse.
   - **Verse lines** support leading **`@size=` / `@align=`** line-level tags, producing the `{ size?, align?, content }` verse-line form (role tags are not meaningful on a lyric line and stay literal).
 - A **blank line ends the current verse** (returns to paragraph mode). A following `*` marker reopens lyric mode.


### PR DESCRIPTION
## Problem

Downloading the KK song book crashed with a parse-failure dialog: **"p block missing 'content'"**.

Root cause: a `@doc` song places `@youtube` inside a `@row` (musical notation left, video link right). Both the Java processor (`kidung-data`) and the Python reference (`alkitab-host`) faithfully emit that youtube as its own block inside the row's `items` — 745 such items in KK alone. But the app's `RowBlockSerializer` decoded **every** row item through `PBlockSerializer`, which requires a `content` field. A `youtube` block has no `content`, so decoding threw `error("p block missing 'content'")`.

The producers are correct and stay byte-identical; the app was the odd one out.

## Fix

- `RowBlock.items` is now `List<Block>` (was `List<PBlock>`).
- Row items encode/decode polymorphically via `BlockSerializer`.
- Renderer dispatches each row item by block type (`p` / `youtube` / `scripture` / `gap`).
- Consumers that need a `p` (plain-text share, search index) filter to `PBlock`.
- Format doc updated to say row items are `Block[]`, usually `p` but possibly `youtube`/`gap`/`scripture`.

No producer or data change needed — already-deployed `kk-5.json.gz` parses once this ships.

## Tests

New regression test `SongBookUtilTest.deserializeRowContainingYoutubeBlock` decodes a gzipped book whose row holds a `p` + a `youtube`, asserting both survive. Full `*newdoc*`, `*PortableSongs*`, `*SongDb*`, `SongBookUtilTest` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)