### PR TITLE
Make back/forward history panel capsule-shaped

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/base/BaseActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/base/BaseActivity.kt
@@ -2,6 +2,7 @@ package yuku.alkitab.base.ac.base
 
 import android.content.Context
 import android.graphics.Color
+import android.graphics.drawable.PaintDrawable
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.MenuItem
@@ -60,7 +61,12 @@ abstract class BaseActivity : AppCompatActivity() {
 
         supportActionBar?.setBackgroundDrawable(primaryColor.toDrawable())
 
-        findViewById<View>(R.id.panelBackForwardList)?.background = primaryColor.toDrawable()
+        findViewById<View>(R.id.panelBackForwardList)?.apply {
+            background = PaintDrawable(primaryColor).apply {
+                setCornerRadius(resources.getDimension(R.dimen.back_forward_list_corner_radius))
+            }
+            clipToOutline = true
+        }
 
         window.statusBarColor = statusBarColor
     }

--- a/Alkitab/src/main/res/drawable/back_forward_list_background.xml
+++ b/Alkitab/src/main/res/drawable/back_forward_list_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+	android:shape="rectangle">
+	<solid android:color="@color/primary" />
+	<corners android:radius="@dimen/back_forward_list_corner_radius" />
+</shape>

--- a/Alkitab/src/main/res/layout/activity_isi_content.xml
+++ b/Alkitab/src/main/res/layout/activity_isi_content.xml
@@ -132,7 +132,7 @@
 				android:layout_gravity="end|bottom"
 				android:layout_marginEnd="16dp"
 				android:layout_marginBottom="8dp"
-				android:background="@color/primary"
+				android:background="@drawable/back_forward_list_background"
 				android:elevation="8dp"
 				android:orientation="horizontal"
 				android:visibility="gone"

--- a/Alkitab/src/main/res/values/dimens.xml
+++ b/Alkitab/src/main/res/values/dimens.xml
@@ -4,4 +4,6 @@
 	<dimen name="panel_text_appearance_width">240dp</dimen>
 	<dimen name="reading_plan_day_heading_side_padding">0dp</dimen>
 	<dimen name="left_drawer_width">280dp</dimen>
+	<!-- Half of the 40dp back/forward button height, so the panel ends are fully rounded -->
+	<dimen name="back_forward_list_corner_radius">20dp</dimen>
 </resources>


### PR DESCRIPTION
## What changed

The back/forward navigation panel at the bottom-right of the reader (IsiActivity) now renders as a capsule (fully rounded ends) instead of a rectangle.

- `activity_isi_content.xml` — `panelBackForwardList` background now points to a new capsule shape drawable instead of flat `@color/primary`.
- `drawable/back_forward_list_background.xml` — new rounded-rectangle shape drawable filled with `@color/primary`.
- `dimens.xml` — new `back_forward_list_corner_radius` (20dp, half of the 40dp button height so the ends are fully round).
- `BaseActivity.applyNightModeColors()` — previously replaced the panel background at runtime with a plain rectangular `ColorDrawable`, which would have overridden any XML-only fix. It now builds a `PaintDrawable` with the same corner radius and sets `clipToOutline = true` so the buttons' press ripple and the vertical divider are clipped to the capsule.

## Notes for reviewers

- `clipToOutline` is set in code because the XML attribute requires API 31 while minSdk is 26.
- Night mode goes through the same `applyNightModeColors()` code path (only the fill color differs), so the capsule holds in both themes.

## Verification

- `./gradlew assemblePlainDebug` builds clean.
- Installed on an API 35 emulator, navigated Yohanes 3 → Kejadian 1 via Goto to populate history, and confirmed the panel renders as a proper capsule with ripples and divider clipped inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)