### PR TITLE
Fix fullscreen and edge-to-edge display on Android 15+

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -4,6 +4,7 @@ import android.content.ActivityNotFoundException
 import android.content.ContentResolver
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Rect
 import android.os.Build
 import android.os.Bundle
 import android.text.Spannable
@@ -511,8 +512,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         splitHandleButton = findViewById(R.id.splitHandleButton)
         floater = findViewById(R.id.floater)
 
-        setupSafeAreaInsets()
-
         // If layout is changed, updateToolbarLocation must be updated as well. This will be called in DEBUG to make sure
         // updateToolbarLocation is also updated when layout is updated.
         if (BuildConfig.DEBUG) {
@@ -578,6 +577,8 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
         // for splitting
         splitViewManager.installListeners()
+
+        setupSafeAreaInsets()
 
         if (BuildConfig.DEBUG) {
             // Runtime assertions: splitRoot must have 3 children;
@@ -1465,14 +1466,14 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             }
         }
 
-        val floaterBasePadding = floater.paddingLeft
+        val floaterBasePadding = Rect(floater.paddingLeft, floater.paddingTop, floater.paddingRight, floater.paddingBottom)
         ViewCompat.setOnApplyWindowInsetsListener(floater) { v, windowInsets ->
             val insets = windowInsets.getInsets(safeAreaTypes)
             v.setPadding(
-                floaterBasePadding + insets.left,
-                floaterBasePadding + insets.top,
-                floaterBasePadding + insets.right,
-                floaterBasePadding + insets.bottom
+                floaterBasePadding.left + insets.left,
+                floaterBasePadding.top + insets.top,
+                floaterBasePadding.right + insets.right,
+                floaterBasePadding.bottom + insets.bottom
             )
             windowInsets
         }

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -4,11 +4,13 @@ import android.content.ActivityNotFoundException
 import android.content.ContentResolver
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.format.DateFormat
 import android.text.method.LinkMovementMethod
+import android.util.TypedValue
 import android.text.style.ClickableSpan
 import android.text.style.ForegroundColorSpan
 import android.text.style.RelativeSizeSpan
@@ -24,6 +26,8 @@ import android.widget.FrameLayout
 import android.widget.ImageButton
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.ui.platform.ComposeView
 import androidx.appcompat.view.ActionMode
 import androidx.appcompat.widget.SwitchCompat
@@ -36,7 +40,12 @@ import androidx.core.text.HtmlCompat
 import androidx.core.text.buildSpannedString
 import androidx.core.text.inSpans
 import androidx.core.util.PatternsCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
@@ -468,6 +477,10 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     override fun onCreate(savedInstanceState: Bundle?) {
         AppLog.d(TAG, "@@onCreate start")
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        if (Build.VERSION.SDK_INT >= 28) {
+            window.attributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+        }
         setContentView(R.layout.activity_isi)
         AppLog.d(TAG, "@@onCreate setCV")
 
@@ -496,6 +509,8 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
         splitHandleButton = findViewById(R.id.splitHandleButton)
         floater = findViewById(R.id.floater)
+
+        setupSafeAreaInsets()
 
         // If layout is changed, updateToolbarLocation must be updated as well. This will be called in DEBUG to make sure
         // updateToolbarLocation is also updated when layout is updated.
@@ -1114,6 +1129,8 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
         lsSplit0.setViewPadding(SettingsActivity.getPaddingBasedOnPreferences(useSmallerHorizontalPadding))
         lsSplit1.setViewPadding(SettingsActivity.getPaddingBasedOnPreferences(useSmallerHorizontalPadding))
+
+        updateSystemBarAppearance()
     }
 
     override fun onStop() {
@@ -1352,21 +1369,114 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     fun setFullScreen(yes: Boolean) {
         if (fullScreen == yes) return // no change
 
-        val decorView = window.decorView
-
-        if (yes) {
-            window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
-            supportActionBar?.hide()
-            decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_IMMERSIVE
-        } else {
-            window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
-            supportActionBar?.show()
-            decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
-        }
-
         fullScreen = yes
 
+        val controller = WindowCompat.getInsetsController(window, window.decorView)
+        if (yes) {
+            supportActionBar?.hide()
+            controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            controller.hide(WindowInsetsCompat.Type.systemBars())
+        } else {
+            supportActionBar?.show()
+            controller.show(WindowInsetsCompat.Type.systemBars())
+        }
+
         updateToolbarLocation()
+        updateSystemBarAppearance()
+    }
+
+    private fun isBottomToolbarOnText() = Preferences.getBoolean(R.string.pref_bottomToolbarOnText_key, R.bool.pref_bottomToolbarOnText_default)
+
+    /**
+     * The window draws edge-to-edge on all API levels (Android 15 enforces it
+     * anyway), so the reading background extends behind the system bars and
+     * into the display-cutout area, while these listeners pad the actual
+     * content (toolbar, verses, back/forward panel, floater, left drawer)
+     * back into the safe area. In fullscreen the system bars are hidden and
+     * report zero insets, leaving only the display cutout to pad around.
+     */
+    private fun setupSafeAreaInsets() {
+        val safeAreaTypes = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+
+        // A ComposeView consumes insets by default, which would stop the
+        // dispatch from ever reaching sibling views listed after it (the
+        // bottom-docked toolbar, the floater, the left drawer).
+        root.requireViewById<ComposeView>(R.id.audio_bar).consumeWindowInsets = false
+
+        val tv = TypedValue()
+        theme.resolveAttribute(androidx.appcompat.R.attr.actionBarSize, tv, true)
+        val actionBarSize = TypedValue.complexToDimensionPixelSize(tv.data, resources.displayMetrics)
+
+        // The toolbar keeps its primary-color background across the bar it is
+        // docked against by growing by the inset instead of just shifting.
+        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { v, windowInsets ->
+            val insets = windowInsets.getInsets(safeAreaTypes)
+            if (isBottomToolbarOnText()) {
+                v.setPadding(insets.left, 0, insets.right, insets.bottom)
+                v.updateLayoutParams { height = actionBarSize + insets.bottom }
+            } else {
+                v.setPadding(insets.left, insets.top, insets.right, 0)
+                v.updateLayoutParams { height = actionBarSize + insets.top }
+            }
+            windowInsets
+        }
+
+        // Pads the verse area (and the back/forward panel inside it) on the
+        // edges where no other bar of ours already covers the inset: the
+        // toolbar covers one vertical edge when visible, and the audio bar
+        // applies its own bottom inset whenever it is showing.
+        ViewCompat.setOnApplyWindowInsetsListener(nontoolbar) { v, windowInsets ->
+            val insets = windowInsets.getInsets(safeAreaTypes)
+            val toolbarShown = !fullScreen
+            val top = if (toolbarShown && !isBottomToolbarOnText()) 0 else insets.top
+            val bottom = when {
+                toolbarShown && isBottomToolbarOnText() -> 0
+                root.requireViewById<View>(R.id.audio_bar).height > 0 -> 0
+                else -> insets.bottom
+            }
+            v.setPadding(insets.left, top, insets.right, bottom)
+            windowInsets
+        }
+
+        root.requireViewById<View>(R.id.audio_bar).addOnLayoutChangeListener { _, _, top, _, bottom, _, oldTop, _, oldBottom ->
+            if (bottom - top != oldBottom - oldTop) {
+                ViewCompat.requestApplyInsets(nontoolbar)
+            }
+        }
+
+        val floaterBasePadding = floater.paddingLeft
+        ViewCompat.setOnApplyWindowInsetsListener(floater) { v, windowInsets ->
+            val insets = windowInsets.getInsets(safeAreaTypes)
+            v.setPadding(
+                floaterBasePadding + insets.left,
+                floaterBasePadding + insets.top,
+                floaterBasePadding + insets.right,
+                floaterBasePadding + insets.bottom
+            )
+            windowInsets
+        }
+
+        ViewCompat.setOnApplyWindowInsetsListener(leftDrawer) { v, windowInsets ->
+            val insets = windowInsets.getInsets(safeAreaTypes)
+            v.setPadding(insets.left, insets.top, insets.right, insets.bottom)
+            windowInsets
+        }
+    }
+
+    override fun applyStatusBarColor(statusBarColor: Int) {
+        // Edge-to-edge: the toolbar extends behind the status bar instead of
+        // the decor painting an opaque bar over it.
+    }
+
+    private fun updateSystemBarAppearance() {
+        val lightBackground = ColorUtils.calculateLuminance(App.services.uiDimensions.applied().backgroundColor) > 0.5
+        val bottomToolbar = isBottomToolbarOnText()
+        val controller = WindowCompat.getInsetsController(window, window.decorView)
+        // The toolbar background is dark in both day and night mode, so bar
+        // icons over it are always light; over the verse background they
+        // follow its luminance.
+        controller.isAppearanceLightStatusBars = if (!fullScreen && !bottomToolbar) false else lightBackground
+        controller.isAppearanceLightNavigationBars = if (!fullScreen && bottomToolbar) false else lightBackground
     }
 
     private fun updateToolbarLocation() {
@@ -1386,7 +1496,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             root.removeView(nontoolbar)
             root.removeView(audioBar)
 
-            if (Preferences.getBoolean(R.string.pref_bottomToolbarOnText_key, R.bool.pref_bottomToolbarOnText_default)) {
+            if (isBottomToolbarOnText()) {
                 root.addView(nontoolbar)
                 root.addView(audioBar)
                 root.addView(toolbar)
@@ -1396,15 +1506,8 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
                 root.addView(audioBar)
             }
         }
-    }
 
-    override fun onWindowFocusChanged(hasFocus: Boolean) {
-        super.onWindowFocusChanged(hasFocus)
-
-        if (hasFocus && fullScreen) {
-            val decorView = window.decorView
-            decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_IMMERSIVE
-        }
+        ViewCompat.requestApplyInsets(drawerLayout)
     }
 
     private fun setShowTextAppearancePanel(yes: Boolean) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -24,6 +24,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.ImageButton
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
@@ -1421,26 +1422,46 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             windowInsets
         }
 
-        // Pads the verse area (and the back/forward panel inside it) on the
-        // edges where no other bar of ours already covers the inset: the
-        // toolbar covers one vertical edge when visible, and the audio bar
-        // applies its own bottom inset whenever it is showing.
+        // Pads the verse area on the edges where no other bar of ours already
+        // covers the inset: the toolbar covers one vertical edge when visible,
+        // and the audio bar applies its own bottom inset whenever it is
+        // showing. The bottom inset is not applied to `nontoolbar` itself but
+        // handed to the verse lists as extra scroll-past padding
+        // (clipToPadding=false), so the text draws edge-to-edge behind the
+        // navigation bar while the scrolled-to-end verses stay above it. In a
+        // stacked split only the bottom pane touches the window bottom.
+        val panelBackForwardList = nontoolbar.findViewById<View>(R.id.panelBackForwardList)
+        val panelBackForwardListBaseBottomMargin = (panelBackForwardList.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin
         ViewCompat.setOnApplyWindowInsetsListener(nontoolbar) { v, windowInsets ->
             val insets = windowInsets.getInsets(safeAreaTypes)
-            val toolbarShown = !fullScreen
-            val top = if (toolbarShown && !isBottomToolbarOnText()) 0 else insets.top
-            val bottom = when {
-                toolbarShown && isBottomToolbarOnText() -> 0
-                root.requireViewById<View>(R.id.audio_bar).height > 0 -> 0
-                else -> insets.bottom
+            val top = if (!fullScreen && !isBottomToolbarOnText()) 0 else insets.top
+            v.setPadding(insets.left, top, insets.right, 0)
+
+            val bottomEdgeCovered = (!fullScreen && isBottomToolbarOnText()) || root.requireViewById<View>(R.id.audio_bar).height > 0
+            val bottomInset = if (bottomEdgeCovered) 0 else insets.bottom
+            val stackedSplit = splitHandleButton.isVisible && splitRoot.orientation == LinearLayout.VERTICAL
+            lsSplit0.setViewBottomInset(if (stackedSplit) 0 else bottomInset)
+            lsSplit1.setViewBottomInset(bottomInset)
+
+            panelBackForwardList.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                bottomMargin = panelBackForwardListBaseBottomMargin + bottomInset
             }
-            v.setPadding(insets.left, top, insets.right, bottom)
             windowInsets
         }
 
         root.requireViewById<View>(R.id.audio_bar).addOnLayoutChangeListener { _, _, top, _, bottom, _, oldTop, _, oldBottom ->
             if (bottom - top != oldBottom - oldTop) {
                 ViewCompat.requestApplyInsets(nontoolbar)
+            }
+        }
+
+        // Split open/close/rotate resizes the panes; which list touches the
+        // window bottom may have changed, so redistribute the bottom inset.
+        for (id in intArrayOf(R.id.lsSplitView0, R.id.lsSplitView1)) {
+            findViewById<View>(id).addOnLayoutChangeListener { _, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
+                if (right - left != oldRight - oldLeft || bottom - top != oldBottom - oldTop) {
+                    ViewCompat.requestApplyInsets(nontoolbar)
+                }
             }
         }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/base/BaseActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/base/BaseActivity.kt
@@ -62,6 +62,10 @@ abstract class BaseActivity : AppCompatActivity() {
 
         findViewById<View>(R.id.panelBackForwardList)?.background = primaryColor.toDrawable()
 
+        applyStatusBarColor(statusBarColor)
+    }
+
+    protected open fun applyStatusBarColor(statusBarColor: Int) {
         window.statusBarColor = statusBarColor
     }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
@@ -125,6 +125,14 @@ interface VersesController {
 
     fun setViewVisibility(visibility: Int)
     fun setViewPadding(padding: Rect)
+
+    /**
+     * Extra bottom padding from window insets, kept separate from (and added
+     * below) [setViewPadding]'s preference-derived padding, so the list draws
+     * edge-to-edge behind the navigation bar while the scrolled-to-end verses
+     * stay above it.
+     */
+    fun setViewBottomInset(bottomInset: Int)
     fun setViewScrollbarThumb(thumb: Drawable)
 
     /**

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -55,6 +55,7 @@ class VersesControllerImpl(
     private val audioHighlight = AudioHighlight()
 
     private val basePadding = Rect()
+    private var bottomInset = 0
 
     private val dataVersionNumber = AtomicInteger()
 
@@ -487,7 +488,17 @@ class VersesControllerImpl(
 
     override fun setViewPadding(padding: Rect) {
         basePadding.set(padding)
-        rv.setPadding(basePadding.left, basePadding.top, basePadding.right, basePadding.bottom)
+        applyPadding()
+    }
+
+    override fun setViewBottomInset(bottomInset: Int) {
+        if (this.bottomInset == bottomInset) return
+        this.bottomInset = bottomInset
+        applyPadding()
+    }
+
+    private fun applyPadding() {
+        rv.setPadding(basePadding.left, basePadding.top, basePadding.right, basePadding.bottom + bottomInset)
     }
 
     override fun setViewScrollbarThumb(thumb: Drawable) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/TextAppearancePanel.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/TextAppearancePanel.java
@@ -18,6 +18,9 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -73,6 +76,18 @@ public class TextAppearancePanel {
         this.content = activity.getLayoutInflater().inflate(R.layout.panel_text_appearance, parent, false);
 
         this.content.setOnTouchListener((v, event) -> true); // prevent click-through
+
+        // The activity draws edge-to-edge, so this bottom-anchored panel has to
+        // keep itself clear of the navigation bar and display cutout.
+        ViewCompat.setOnApplyWindowInsetsListener(content, (v, windowInsets) -> {
+            final Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            final ViewGroup.MarginLayoutParams lp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            lp.leftMargin = insets.left;
+            lp.rightMargin = insets.right;
+            lp.bottomMargin = insets.bottom;
+            v.setLayoutParams(lp);
+            return windowInsets;
+        });
 
         cbTypeface = content.findViewById(R.id.cbTypeface);
         cBold = content.findViewById(R.id.cBold);
@@ -138,6 +153,7 @@ public class TextAppearancePanel {
     public void show() {
         if (shown) return;
         parent.addView(content);
+        ViewCompat.requestApplyInsets(content);
         shown = true;
     }
 


### PR DESCRIPTION
## What

Modernizes the Bible reader's window handling for Android 15+, where edge-to-edge is enforced for apps targeting SDK 35 and the legacy `FLAG_FULLSCREEN` / `systemUiVisibility` immersive flags (and `window.statusBarColor`) are ignored.

- **IsiActivity** now opts into edge-to-edge on *all* API levels (`enableEdgeToEdge()`) and allows drawing into the display cutout, so behavior is uniform instead of Android-15-only.
- Fullscreen mode uses `WindowInsetsControllerCompat` to hide/show the system bars (revealable transiently by swipe), replacing the deprecated flags and the `onWindowFocusChanged` re-apply hack.
- Window-insets listeners keep everything in the safe area:
  - The toolbar grows behind whichever bar it is docked against (top or bottom, per preference), extending its primary color under the status bar.
  - The verse `RecyclerView`s receive the bottom inset as extra scroll-past padding (`clipToPadding=false`), so text draws edge-to-edge behind the navigation bar while the scrolled-to-end verses stay above it. In a stacked split only the bottom pane gets the inset; side-by-side gives it to both.
  - The back/forward history panel, goto floater, left drawer, and text-appearance panel pad/margin themselves clear of the bars and cutout.
  - In fullscreen the hidden bars report zero insets, leaving only the camera-cutout padding — verses and the back/forward buttons always stay in the safe area while the reading background fills the whole screen.
- Status/navigation bar icon appearance follows what is actually under each bar (dark toolbar → light icons; verse background → by luminance).
- `BaseActivity.applyStatusBarColor` is now overridable so IsiActivity can skip the opaque status-bar paint that would cover the edge-to-edge toolbar on pre-15 devices; other activities keep the old behavior.
- The audio bar's `ComposeView` no longer consumes window insets (it would starve sibling views — e.g. the bottom-docked toolbar — of insets).

## Why

On Android 15 devices, fullscreen mode stopped working and content sat behind the system bars: verses and the back/forward buttons could be obscured by the status bar, navigation bar, or the front-camera cutout.

## Verification

Tested on an API 35 emulator: normal + fullscreen modes, portrait + landscape, with and without a simulated tall display cutout, split view (stacked), drawer, and 3-button navigation. Verse text scrolls behind the nav bar and settles above it at the end of the chapter; in fullscreen with a cutout, verses start below the camera while the background stays edge-to-edge. `assemblePlainDebug`, `testPlainDebugUnitTest`, and `testPlainReleaseUnitTest` pass.

Note: other activities (Search, Songs, Settings, …) still use the legacy status-bar approach and likely need the same treatment on Android 15; kept out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)