### PR TITLE
Fix authors_music being right-aligned by default in song rendering

### DIFF
--- a/Alkitab/src/main/assets/templates/song.css
+++ b/Alkitab/src/main/assets/templates/song.css
@@ -83,14 +83,19 @@
 
 .authors_lyric {
 	font-family: sans-serif;
-	float: left;
 	font-size: 87.5%;
 }
 
 .authors_music {
 	font-family: sans-serif;
-	float: right;
 	font-size: 87.5%;
+}
+
+/* Inside an authors row, the composer sits at the end even when the
+   lyricist is absent (the classic legacy layout). A bare authors_music
+   paragraph outside a row stays start-aligned. */
+.row .authors_music {
+	margin-left: auto;
 }
 
 .scriptureReferences {

--- a/Alkitab/src/main/assets/templates/song.css
+++ b/Alkitab/src/main/assets/templates/song.css
@@ -91,13 +91,6 @@
 	font-size: 87.5%;
 }
 
-/* Inside an authors row, the composer sits at the end even when the
-   lyricist is absent (the classic legacy layout). A bare authors_music
-   paragraph outside a row stays start-aligned. */
-.row .authors_music {
-	margin-left: auto;
-}
-
 .scriptureReferences {
 	font-family: sans-serif;
 }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/LegacySongConverter.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/LegacySongConverter.kt
@@ -24,7 +24,9 @@ object LegacySongConverter {
         if (authorsLyric != null || authorsMusic != null) {
             val items = mutableListOf<PBlock>()
             authorsLyric?.let { items.add(PBlock(role = "authors_lyric", content = parseInlineLine(it))) }
-            authorsMusic?.let { items.add(PBlock(role = "authors_music", content = parseInlineLine(it))) }
+            // A solo composer carries explicit end alignment: the row's space-between
+            // layout only places it at the end when the lyricist item is also present.
+            authorsMusic?.let { items.add(PBlock(role = "authors_music", align = if (authorsLyric == null) "end" else null, content = parseInlineLine(it))) }
             blocks.add(RowBlock(items = items))
         }
 

--- a/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentRenderer.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentRenderer.kt
@@ -64,7 +64,7 @@ object SongDocumentRenderer {
 
         for (item in block.items) {
             when (item) {
-                is PBlock -> renderPBlock(item, sb)
+                is PBlock -> renderPBlock(item, sb, inRow = true)
                 is YoutubeBlock -> renderYoutubeBlock(item, sb)
                 is ScriptureBlock -> sb.append("<div class='scriptureReferences'>").append(renderScripture(item.osis)).append("</div>")
                 is GapBlock -> sb.append("<div style='height:").append(item.size ?: 1f).append("em'></div>")
@@ -85,11 +85,23 @@ object SongDocumentRenderer {
         return sb.toString()
     }
 
-    private fun renderPBlock(block: PBlock, sb: StringBuilder) {
+    private fun renderPBlock(block: PBlock, sb: StringBuilder, inRow: Boolean = false) {
         val cls = block.role?.takeIf { it in KNOWN_ROLES } ?: "body"
         val style = buildString {
             block.size?.takeIf { it.isFinite() }?.let { append("font-size:").append(it).append("em;") }
-            block.align?.takeIf { it in ALLOWED_ALIGNS }?.let { append("text-align:").append(it).append(";") }
+            block.align?.takeIf { it in ALLOWED_ALIGNS }?.let { align ->
+                if (inRow) {
+                    // A row item is a shrink-to-fit flex item, so text-align cannot move
+                    // it; align positions the item itself along the row's main axis.
+                    when (align) {
+                        "end" -> append("margin-inline-start:auto;")
+                        "center" -> append("margin-inline-start:auto;margin-inline-end:auto;")
+                        else -> {} // start: flex default
+                    }
+                } else {
+                    append("text-align:").append(align).append(";")
+                }
+            }
         }
         sb.append("<div class='").append(cls).append("'")
         if (style.isNotEmpty()) sb.append(" style='").append(style).append("'")

--- a/Alkitab/src/test/java/yuku/alkitab/songs/newdoc/PortableSongsBridgeTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/songs/newdoc/PortableSongsBridgeTest.kt
@@ -126,7 +126,16 @@ class PortableSongsBridgeTest {
         )
     }
 
-    private fun songs(): List<Song> = listOf(kri25(), nullsAndEmpties(), mixedKinds(), inlineStyled())
+    /** composer only, no lyricist — the converter keeps it at the row end via an explicit align. */
+    private fun soloComposer(): Song = Song().apply {
+        code = "S1"
+        title = "Solo Composer"
+        authors_lyric = mutableListOf()
+        authors_music = mutableListOf("Composer Only")
+        lyrics = mutableListOf(lyric(null, verse(1, VerseKind.NORMAL, "One plain line.")))
+    }
+
+    private fun songs(): List<Song> = listOf(kri25(), nullsAndEmpties(), mixedKinds(), inlineStyled(), soloComposer())
 
     // endregion
 
@@ -292,6 +301,42 @@ class PortableSongsBridgeTest {
         assertEquals("tune", (doc.blocks[2] as PBlock).role)
         assertEquals("musical", (doc.blocks[5] as PBlock).role)
         assertEquals("1=Bes 6/8", (doc.blocks[5] as PBlock).content.plainText())
+    }
+
+    @Test
+    fun `the converter marks a solo composer with align end, but stamps no align when both authors are present`() {
+        // solo composer: the row's space-between layout cannot place a lone item at the
+        // end, so the intent must be carried by the document itself
+        val doc = LegacySongConverter.convert(soloComposer())
+        val row = doc.blocks.filterIsInstance<RowBlock>().single()
+        val composer = row.items.filterIsInstance<PBlock>().single()
+        assertEquals("authors_music", composer.role)
+        assertEquals("end", composer.align)
+
+        // both authors: space-between already spreads them start/end
+        val doc2 = LegacySongConverter.convert(kri25())
+        val row2 = doc2.blocks.filterIsInstance<RowBlock>().single()
+        assertEquals(listOf("authors_lyric", "authors_music"), row2.items.filterIsInstance<PBlock>().map { it.role })
+        assertEquals(listOf(null, null), row2.items.filterIsInstance<PBlock>().map { it.align })
+    }
+
+    @Test
+    fun `the renderer positions an aligned row item with auto margins, and an aligned standalone paragraph with text-align`() {
+        // in a row: text-align cannot move a shrink-to-fit flex item, so align
+        // becomes main-axis positioning of the item itself
+        val doc = LegacySongConverter.convert(soloComposer())
+        val html = SongDocumentRenderer.renderDocument(doc, { it }, forPatchText = false)
+        assertTrue(html.contains("<div class='authors_music' style='margin-inline-start:auto;'>Composer Only</div>"))
+        assertFalse(html.contains("text-align"))
+
+        // standalone: align keeps its text-align meaning
+        val standalone = SongDocument(
+            code = "S2",
+            meta = Meta(title = "T", title_original = null),
+            blocks = listOf(PBlock(role = "authors_music", align = "end", content = Line.Plain("Composer Only"))),
+        )
+        val html2 = SongDocumentRenderer.renderDocument(standalone, { it }, forPatchText = false)
+        assertTrue(html2.contains("<div class='authors_music' style='text-align:end;'>Composer Only</div>"))
     }
 
     @Test

--- a/docs/features/portable-songs/design.md
+++ b/docs/features/portable-songs/design.md
@@ -274,7 +274,7 @@ The decoder yields the legacy field values; a converter maps them to canonical b
 1. `title` → `p` role `title`
 2. `title_original` → `p` role `title_original` (if present)
 3. `tune` → `p` role `tune` (if present)
-4. authors → a `row` with `p` role `authors_lyric` (lyricist, joined `"; "`) as the first item and `p` role `authors_music` (composer) as the last item; include only those present
+4. authors → a `row` with `p` role `authors_lyric` (lyricist, joined `"; "`) as the first item and `p` role `authors_music` (composer) as the last item; include only those present. A solo composer (no lyricist) carries `align: "end"` — the row's space-between layout only places it at the end when the lyricist item is also present
 5. `scriptureReferences` → `scripture` block (if present)
 6. `keySignature` + `timeSignature` → `p` role `musical`, content = `[keySignature, timeSignature].filter(present).join(" ")` (if either present)
 7. each legacy `Lyric` → a `lyric` block: `caption` preserved; each `Verse` becomes `{ kind, lines }` with `VerseKind` mapped and inline `<u>/<b>/<i>` parsed into spans (other raw text escaped); `Verse.ordering` dropped.
@@ -324,7 +324,7 @@ A song enters document mode with a `code <CODE>` line (required; `no` also accep
 - `@scripture <osis>` → a `scripture` block.
 - `@youtube <videoId>` → a `youtube` block.
 - `@gap` → a `gap` block. Combines with `@size=<float>` like other tags, e.g. `@size=2 @gap` for a double-height blank line.
-- `@row` … `@/row` → a `row` block; each line between the markers becomes a block item — usually a `p` (role/size/align tags apply per item), but `@youtube` / `@gap` / `@scripture` inside a row produce their own block types. Gives e.g. lyricist-left / composer-right, or musical notation beside a video link.
+- `@row` … `@/row` → a `row` block; each line between the markers becomes a block item — usually a `p` (role/size/align tags apply per item), but `@youtube` / `@gap` / `@scripture` inside a row produce their own block types. Gives e.g. lyricist-left / composer-right, or musical notation beside a video link. On a row item, `align` positions the item within the row (a shrink-to-fit flex item, where text alignment cannot move anything) — e.g. `@align=end` keeps a lone composer at the end.
 - **Lyric markers** `*N` / `*ref`[N] / `*reff`[N] / `*text`[N] / `*versi`/`*version <caption>` behave as in legacy, including auto-grouping (a normal verse number ≤ the last one starts a new `lyric` group). Subsequent non-marker lines are appended to the current verse.
   - **Verse lines** support leading **`@size=` / `@align=`** line-level tags, producing the `{ size?, align?, content }` verse-line form (role tags are not meaningful on a lyric line and stay literal).
 - A **blank line ends the current verse** (returns to paragraph mode). A following `*` marker reopens lyric mode.

--- a/docs/features/portable-songs/song-editor.html
+++ b/docs/features/portable-songs/song-editor.html
@@ -193,6 +193,10 @@ html, body {
 #song-render .align-start  { text-align: start; }
 #song-render .align-center { text-align: center; }
 #song-render .align-end    { text-align: end; }
+/* A row item is a shrink-to-fit flex item, so text-align cannot move it;
+   there align positions the item itself along the row's main axis. */
+#song-render .row > .align-center { margin-inline: auto; }
+#song-render .row > .align-end    { margin-inline-start: auto; }
 
 /* youtube link */
 #song-render .role-youtube a { color: #03a9f4; }
@@ -334,7 +338,7 @@ Maka jiwaku pun memuji-Mu,</code></pre>
 <li><code>@scripture &lt;osis&gt;</code> → a <code>scripture</code> block (OSIS, e.g. <code>John.3.16; Rom.5.8</code>; localized at render against the active Bible version).</li>
 <li><code>@youtube &lt;videoId&gt;</code> → a <code>youtube</code> block.</li>
 <li><code>@gap</code> → a <code>gap</code> block (blank vertical space, default 1em). Combines with <code>@size=&lt;float&gt;</code> like other tags, e.g. <code>@size=2 @gap</code> for a double-height gap.</li>
-<li><code>@row</code> … <code>@/row</code> → a <code>row</code> block; each line between the markers becomes a <code>p</code> item (its own role/size/align tags apply). Items spread start → end, e.g. lyricist-left / composer-right.</li>
+<li><code>@row</code> … <code>@/row</code> → a <code>row</code> block; each line between the markers becomes a <code>p</code> item (its own role/size/align tags apply). Items spread start → end, e.g. lyricist-left / composer-right. On a row item, <code>@align=</code> positions the item within the row — e.g. <code>@align=end</code> keeps a lone composer at the end.</li>
 <li><strong>Lyric markers</strong> <code>*N</code>, <code>*ref</code>[N]/<code>*reff</code>[N], <code>*text</code>[N], <code>*versi</code>/<code>*version &lt;caption&gt;</code> — same semantics + auto-grouping as legacy. Verse lines support leading <code>@size=</code> / <code>@align=</code> (per-line formatting).</li>
 <li><strong>Blank line ends the current verse</strong> (returns to paragraph mode); a following <code>*</code> marker reopens lyric mode.</li>
 <li>Unknown <code>@directive</code> → warned and skipped (not fatal).</li>
@@ -437,7 +441,7 @@ Maka jiwaku pun memuji-Mu,</code></pre>
 <li><code>@scripture &lt;osis&gt;</code> → blok <code>scripture</code> (OSIS, mis. <code>John.3.16; Rom.5.8</code>; dilokalkan saat render sesuai versi Alkitab aktif).</li>
 <li><code>@youtube &lt;videoId&gt;</code> → blok <code>youtube</code>.</li>
 <li><code>@gap</code> → blok <code>gap</code> (spasi vertikal kosong, default 1em). Dapat digabung dengan <code>@size=&lt;float&gt;</code> seperti tag lain, mis. <code>@size=2 @gap</code> untuk jarak dua kali lipat.</li>
-<li><code>@row</code> … <code>@/row</code> → blok <code>row</code>; setiap baris di antara penanda menjadi item <code>p</code> (tag role/size/align-nya sendiri berlaku). Item tersebar start → end, mis. pengarang lirik di kiri / pengarang musik di kanan.</li>
+<li><code>@row</code> … <code>@/row</code> → blok <code>row</code>; setiap baris di antara penanda menjadi item <code>p</code> (tag role/size/align-nya sendiri berlaku). Item tersebar start → end, mis. pengarang lirik di kiri / pengarang musik di kanan. Pada item row, <code>@align=</code> mengatur posisi item di dalam row — mis. <code>@align=end</code> menjaga pengarang musik tunggal tetap di ujung.</li>
 <li><strong>Penanda lirik</strong> <code>*N</code>, <code>*ref</code>[N]/<code>*reff</code>[N], <code>*text</code>[N], <code>*versi</code>/<code>*version &lt;caption&gt;</code> — semantik + auto-grup sama seperti legacy. Baris bait mendukung <code>@size=</code> / <code>@align=</code> di depan (format per baris).</li>
 <li><strong>Baris kosong mengakhiri bait</strong> saat ini (kembali ke mode paragraf); penanda <code>*</code> berikutnya membuka kembali mode lirik.</li>
 <li><code>@directive</code> tak dikenal → diberi peringatan dan dilewati (tidak fatal).</li>
@@ -970,11 +974,13 @@ function legacyToModel(song) {
     authorItems.push({ type: 'p', role: 'authors_lyric', content: song.authors_lyric.join('; ') });
   }
   if (song.authors_music && song.authors_music.length > 0) {
-    authorItems.push({ type: 'p', role: 'authors_music', content: song.authors_music.join('; ') });
+    // A solo composer carries explicit end alignment: the row's space-between
+    // layout only places it at the end when the lyricist item is also present.
+    const item = { type: 'p', role: 'authors_music', content: song.authors_music.join('; ') };
+    if (authorItems.length === 0) item.align = 'end';
+    authorItems.push(item);
   }
-  if (authorItems.length === 1) {
-    blocks.push(authorItems[0]);
-  } else if (authorItems.length === 2) {
+  if (authorItems.length > 0) {
     blocks.push({ type: 'row', items: authorItems });
   }
   // 5. scriptureReferences -> scripture block


### PR DESCRIPTION
## Problem

A bare `@authors_music` paragraph in a `@doc` song rendered right-aligned. The `float: right` on `.authors_music` (and `float: left` on `.authors_lyric`) in `templates/song.css` were leftovers from the legacy song renderer, which laid the two authors out side by side with floats.

Since the SongDocument renderer, authors from legacy songs are always wrapped in a `.row` flex container (`LegacySongConverter`), where floats are ignored on flex items — so the floats only affected standalone role paragraphs, which is exactly the bug.

## Fix

- **`song.css`**: drop the floats from `.authors_lyric` / `.authors_music`, so a standalone `authors_music` paragraph is start-aligned like any other paragraph. No role-specific layout rule replaces them — the end-alignment intent now lives in the document.
- **`LegacySongConverter`**: a solo composer (no lyricist) gets `align: "end"` on its row item, since the row's `space-between` layout only places it at the end when the lyricist item is also present. With both authors present, nothing changes.
- **`SongDocumentRenderer`**: `align` on a *row item* now maps to main-axis positioning (`margin-inline-start: auto` for `end`), because `text-align` cannot move a shrink-to-fit flex item. A standalone paragraph keeps the `text-align` meaning.
- **`song-editor.html`** (reference implementation): same rendering rule via CSS (`.row > .align-end { margin-inline-start: auto }`), and its legacy converter now always emits the authors row with the same solo-composer `align` — it previously emitted a standalone paragraph for a single author, diverging from the app converter and design.md §5.
- **`design.md`**: §5 (converter mapping) and §8.2 (`@row`) updated to specify the solo-composer `align` and the row-item `align` semantics.

## Tests

- New: converter stamps `align: "end"` on a solo composer but no `align` when both authors are present; renderer emits auto-margin for an aligned row item and `text-align` for an aligned standalone paragraph.
- New `soloComposer()` fixture added to the shared corpus driven through all parcel/JSON round-trip and equivalence tests in `PortableSongsBridgeTest`.
- `./gradlew testPlainDebugUnitTest` (song test classes) and `./gradlew assemblePlainDebug` pass; rendering of all four author shapes verified against `song.css` in headless Chromium.

## Note

Documents already persisted by the REM-21 lazy migration (converted before this change) store the solo-composer row without `align`; those will render the composer start-aligned. New conversions and downloads carry the alignment in the document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCQKgFaUV39Z9uhNYChLbs