### PR TITLE
Fix gutter verse number vertical alignment in Compose VerseItem

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.Typeface as ComposeTypeface
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.res.ResourcesCompat
@@ -304,6 +305,13 @@ private fun VerseItemComposeContent(
 private data class LineMetrics(
     val lineHeightSp: Float,
     val rowExtraPaddingPx: Int,
+    /**
+     * Extra space the body text's first line gains above its glyphs from
+     * `lineHeight` + `LineHeightStyle(Proportional, Trim.None)`. The gutter
+     * verse number is padded down by this much so its glyph top lines up with
+     * the first text line's glyph top.
+     */
+    val gutterTopPaddingPx: Int,
 )
 
 @Composable
@@ -323,10 +331,18 @@ private fun rememberLineMetrics(state: VerseItemComposeState): LineMetrics {
         val naturalLineHeightPx = fm.descent - fm.ascent + fm.leading
         val targetLineHeightPx = naturalLineHeightPx * state.lineSpacingMult
         val rowExtraPaddingPx = (naturalLineHeightPx * (state.lineSpacingMult - 1f) + 0.5f).toInt()
+        // LineHeightStyle Proportional distributes (lineHeight − glyphHeight)
+        // around the line in the ascent:descent ratio; Trim.None keeps the
+        // top share on the first line too. This is the ascent-side share.
+        val glyphHeightPx = fm.descent - fm.ascent
+        val gutterTopPaddingPx = if (glyphHeightPx <= 0f) 0 else {
+            ((targetLineHeightPx - glyphHeightPx) * (-fm.ascent) / glyphHeightPx + 0.5f).toInt().coerceAtLeast(0)
+        }
         LineMetrics(
             // density.fontScale == 1f upstream → px ↔ sp == /density.
             lineHeightSp = targetLineHeightPx / density.density,
             rowExtraPaddingPx = rowExtraPaddingPx,
+            gutterTopPaddingPx = gutterTopPaddingPx,
         )
     }
 }
@@ -407,8 +423,17 @@ private fun VerseTextRegion(state: VerseItemComposeState, checked: Boolean, line
                     color = if (checked) textColor else Color(state.verseNumberColor),
                     fontSize = state.verseNumberFontSizeDp.sp,
                     fontWeight = FontWeight.Bold,
+                    // Drop the body text's full-size lineHeight: inheriting it
+                    // would sit the 0.7× number proportionally inside a
+                    // full-size line box, landing it on the body's first-line
+                    // baseline. Natural metrics + the small top padding keep
+                    // it top-aligned with the first line, like the legacy
+                    // VerseItem's gutter TextView.
+                    lineHeight = TextUnit.Unspecified,
                 ),
-                modifier = Modifier.align(Alignment.TopStart),
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(top = with(LocalDensity.current) { lineMetrics.gutterTopPaddingPx.toDp() }),
             )
         }
     }

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
@@ -307,9 +307,8 @@ private data class LineMetrics(
     val rowExtraPaddingPx: Int,
     /**
      * Extra space the body text's first line gains above its glyphs from
-     * `lineHeight` + `LineHeightStyle(Proportional, Trim.None)`. The gutter
-     * verse number is padded down by this much so its glyph top lines up with
-     * the first text line's glyph top.
+     * `lineHeight` + `LineHeightStyle(Proportional, Trim.None)`; the gutter
+     * verse number is padded down by this much to stay level with it.
      */
     val gutterTopPaddingPx: Int,
 )
@@ -331,9 +330,6 @@ private fun rememberLineMetrics(state: VerseItemComposeState): LineMetrics {
         val naturalLineHeightPx = fm.descent - fm.ascent + fm.leading
         val targetLineHeightPx = naturalLineHeightPx * state.lineSpacingMult
         val rowExtraPaddingPx = (naturalLineHeightPx * (state.lineSpacingMult - 1f) + 0.5f).toInt()
-        // LineHeightStyle Proportional distributes (lineHeight − glyphHeight)
-        // around the line in the ascent:descent ratio; Trim.None keeps the
-        // top share on the first line too. This is the ascent-side share.
         val glyphHeightPx = fm.descent - fm.ascent
         val gutterTopPaddingPx = if (glyphHeightPx <= 0f) 0 else {
             ((targetLineHeightPx - glyphHeightPx) * (-fm.ascent) / glyphHeightPx + 0.5f).toInt().coerceAtLeast(0)
@@ -423,12 +419,6 @@ private fun VerseTextRegion(state: VerseItemComposeState, checked: Boolean, line
                     color = if (checked) textColor else Color(state.verseNumberColor),
                     fontSize = state.verseNumberFontSizeDp.sp,
                     fontWeight = FontWeight.Bold,
-                    // Drop the body text's full-size lineHeight: inheriting it
-                    // would sit the 0.7× number proportionally inside a
-                    // full-size line box, landing it on the body's first-line
-                    // baseline. Natural metrics + the small top padding keep
-                    // it top-aligned with the first line, like the legacy
-                    // VerseItem's gutter TextView.
                     lineHeight = TextUnit.Unspecified,
                 ),
                 modifier = Modifier


### PR DESCRIPTION
## Problem

In the Compose version of `VerseItem`, when the verse number is separated from the verse text (gutter mode — formatted text starting with `@^` or `@1`..`@4`), the verse number rendered baseline-aligned with the first line of the verse text instead of top-aligned like the legacy `VerseItem`.

## Cause

The gutter `BasicText` copied the body text's `TextStyle`, inheriting the full-size `lineHeight` together with `LineHeightStyle(Proportional, Trim.None)`. Placing the 0.7×-size number proportionally inside a full-size line box lands its baseline exactly on the body text's first-line baseline (e.g. at 17dp font / 1.15 spacing: number baseline ≈ 17.9px vs text first baseline ≈ 17.8px).

The legacy view instead renders the gutter number in its own `TextView` with natural (small) line metrics, top-aligned in a shared `FrameLayout` — so it sits at the top.

## Fix

- Drop the inherited `lineHeight` (`TextUnit.Unspecified`) on the gutter number so it uses its natural line metrics.
- Pad it down by the ascent-side share of the extra first-line spacing that the body text gains from `lineHeight` + `Trim.None`, computed in `rememberLineMetrics` from the same font metrics already measured there. This keeps the number's glyph top aligned with the first text line's glyph top at any line-spacing multiplier.

## Verification

- `./gradlew assemblePlainDebug` builds clean.
- `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` passes.
- `VerseItemSideBySideSnapshotTest` snapshots: gutter cases (12, 12b, 13–16, 24–27) now match the legacy renderer's top alignment; inline-number cases (01, 03, 10, 11, …) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qyxmb6RapWpEygmeqvQg95

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qyxmb6RapWpEygmeqvQg95)_