### PR TITLE
Extend verse area and split handle edge-to-edge with labels kept in the safe area

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -1443,6 +1443,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             val stackedSplit = splitHandleButton.isVisible && splitRoot.orientation == LinearLayout.VERTICAL
             lsSplit0.setViewBottomInset(if (stackedSplit) 0 else bottomInset)
             lsSplit1.setViewBottomInset(bottomInset)
+            splitHandleButton.setBottomInset(bottomInset)
 
             panelBackForwardList.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                 bottomMargin = panelBackForwardListBaseBottomMargin + bottomInset

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -1426,24 +1426,27 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         // Pads the verse area on the edges where no other bar of ours already
         // covers the inset: the toolbar covers one vertical edge when visible,
         // and the audio bar applies its own bottom inset whenever it is
-        // showing. The bottom inset is not applied to `nontoolbar` itself but
-        // handed to the verse lists as extra scroll-past padding
-        // (clipToPadding=false), so the text draws edge-to-edge behind the
-        // navigation bar while the scrolled-to-end verses stay above it. In a
-        // stacked split only the bottom pane touches the window bottom.
+        // showing. The vertical insets are not applied to `nontoolbar` itself
+        // but handed to the verse lists as extra scroll-past padding
+        // (clipToPadding=false) and to the split handle for its labels, so
+        // the text and the handle bar draw edge-to-edge behind the system
+        // bars and cutout while the scrolled-to-edge verses and the labels
+        // stay inside the safe area. In a stacked split only the top pane
+        // touches the window top and only the bottom pane the window bottom.
         val panelBackForwardList = nontoolbar.findViewById<View>(R.id.panelBackForwardList)
         val panelBackForwardListBaseBottomMargin = (panelBackForwardList.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin
         ViewCompat.setOnApplyWindowInsetsListener(nontoolbar) { v, windowInsets ->
             val insets = windowInsets.getInsets(safeAreaTypes)
-            val top = if (!fullScreen && !isBottomToolbarOnText()) 0 else insets.top
-            v.setPadding(insets.left, top, insets.right, 0)
+            v.setPadding(insets.left, 0, insets.right, 0)
 
+            val topEdgeCovered = !fullScreen && !isBottomToolbarOnText()
+            val topInset = if (topEdgeCovered) 0 else insets.top
             val bottomEdgeCovered = (!fullScreen && isBottomToolbarOnText()) || root.requireViewById<View>(R.id.audio_bar).height > 0
             val bottomInset = if (bottomEdgeCovered) 0 else insets.bottom
             val stackedSplit = splitHandleButton.isVisible && splitRoot.orientation == LinearLayout.VERTICAL
-            lsSplit0.setViewBottomInset(if (stackedSplit) 0 else bottomInset)
-            lsSplit1.setViewBottomInset(bottomInset)
-            splitHandleButton.setBottomInset(bottomInset)
+            lsSplit0.setViewVerticalInsets(topInset, if (stackedSplit) 0 else bottomInset)
+            lsSplit1.setViewVerticalInsets(if (stackedSplit) 0 else topInset, bottomInset)
+            splitHandleButton.setVerticalInsets(topInset, bottomInset)
 
             panelBackForwardList.updateLayoutParams<ViewGroup.MarginLayoutParams> {
                 bottomMargin = panelBackForwardListBaseBottomMargin + bottomInset

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesController.kt
@@ -127,12 +127,12 @@ interface VersesController {
     fun setViewPadding(padding: Rect)
 
     /**
-     * Extra bottom padding from window insets, kept separate from (and added
-     * below) [setViewPadding]'s preference-derived padding, so the list draws
-     * edge-to-edge behind the navigation bar while the scrolled-to-end verses
-     * stay above it.
+     * Extra vertical padding from window insets, kept separate from (and
+     * added to) [setViewPadding]'s preference-derived padding, so the list
+     * draws edge-to-edge behind the system bars and display cutout while the
+     * scrolled-to-edge verses stay inside the safe area.
      */
-    fun setViewBottomInset(bottomInset: Int)
+    fun setViewVerticalInsets(topInset: Int, bottomInset: Int)
     fun setViewScrollbarThumb(thumb: Drawable)
 
     /**

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -55,6 +55,7 @@ class VersesControllerImpl(
     private val audioHighlight = AudioHighlight()
 
     private val basePadding = Rect()
+    private var topInset = 0
     private var bottomInset = 0
 
     private val dataVersionNumber = AtomicInteger()
@@ -491,14 +492,21 @@ class VersesControllerImpl(
         applyPadding()
     }
 
-    override fun setViewBottomInset(bottomInset: Int) {
-        if (this.bottomInset == bottomInset) return
+    override fun setViewVerticalInsets(topInset: Int, bottomInset: Int) {
+        if (this.topInset == topInset && this.bottomInset == bottomInset) return
+        // RecyclerView keeps the first visible item's pixel position when
+        // padding changes, which would leave a list resting at the very top
+        // with its first verse inside the freshly-unsafe area (e.g. the
+        // cutout band after entering fullscreen), so re-anchor it.
+        val atTop = !rv.canScrollVertically(-1)
+        this.topInset = topInset
         this.bottomInset = bottomInset
         applyPadding()
+        if (atTop) rv.scrollToPosition(0)
     }
 
     private fun applyPadding() {
-        rv.setPadding(basePadding.left, basePadding.top, basePadding.right, basePadding.bottom + bottomInset)
+        rv.setPadding(basePadding.left, basePadding.top + topInset, basePadding.right, basePadding.bottom + bottomInset)
     }
 
     override fun setViewScrollbarThumb(thumb: Drawable) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/LabeledSplitHandleButton.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/LabeledSplitHandleButton.java
@@ -31,6 +31,7 @@ public class LabeledSplitHandleButton extends SplitHandleButton {
     boolean label2down = false;
     boolean rotatedown = false;
     float density;
+    int bottomInset = 0;
 
     ButtonPressListener buttonPressListener;
     int primaryColor;
@@ -90,6 +91,17 @@ public class LabeledSplitHandleButton extends SplitHandleButton {
         invalidate();
     }
 
+    /**
+     * When the handle is a vertical bar (side-by-side split), the bar itself
+     * extends edge-to-edge behind the navigation bar; this lifts the bottom
+     * label (and its touch target) back into the safe area.
+     */
+    public void setBottomInset(int bottomInset) {
+        if (this.bottomInset == bottomInset) return;
+        this.bottomInset = bottomInset;
+        invalidate();
+    }
+
     @Override
     public boolean onTouchEvent(final MotionEvent event) {
         // check if touch is at label1, label2, rotate button, or neither
@@ -104,23 +116,28 @@ public class LabeledSplitHandleButton extends SplitHandleButton {
             // length is the width or the height
             final int length;
 
+            // shift of the end label away from the bar's far end
+            final int endInset;
+
             if (orientation == Orientation.vertical) {
                 pos = event.getX();
                 length = getWidth();
+                endInset = 0;
             } else {
                 pos = event.getY();
                 length = getHeight();
+                endInset = bottomInset;
             }
 
             if (action == MotionEvent.ACTION_DOWN) {
                 label1down = pos < maxLabel1sz;
-                label2down = pos > length - maxLabel2sz;
+                label2down = pos > length - maxLabel2sz - endInset;
                 rotatedown = pos >= (length - rotatelength) * 0.5f && pos <= (length + rotatelength) * 0.5f;
             }
 
             if (action == MotionEvent.ACTION_UP && buttonPressListener != null) {
                 label1pressed = label1down && pos < maxLabel1sz;
-                label2pressed = label2down && pos > length - maxLabel2sz;
+                label2pressed = label2down && pos > length - maxLabel2sz - endInset;
                 rotatepressed = rotatedown && pos >= (length - rotatelength) * 0.5f && pos <= (length + rotatelength) * 0.5f;
 
                 if (rotatepressed) {
@@ -186,9 +203,8 @@ public class LabeledSplitHandleButton extends SplitHandleButton {
                     if (orientation == Orientation.vertical) canvas.clipRect(0, 0, label1length, thickness);
                     else canvas.clipRect(0, 0, thickness, label1length);
                 } else if (label2down) {
-                    final float fr1 = length - label2length;
-                    if (orientation == Orientation.vertical) canvas.clipRect(fr1, 0, length, thickness);
-                    else canvas.clipRect(0, fr1, thickness, length);
+                    if (orientation == Orientation.vertical) canvas.clipRect(length - label2length, 0, length, thickness);
+                    else canvas.clipRect(0, length - label2length - bottomInset, thickness, length);
                 }
 
                 canvas.drawColor(accentColor);
@@ -226,7 +242,7 @@ public class LabeledSplitHandleButton extends SplitHandleButton {
                 canvas.rotate(-90);
 
                 labelPaint.setTextAlign(Paint.Align.LEFT);
-                canvas.drawText(label2, -length + pad, base, labelPaint);
+                canvas.drawText(label2, -length + pad + bottomInset, base, labelPaint);
 
                 canvas.restore();
             } else {

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/LabeledSplitHandleButton.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/LabeledSplitHandleButton.java
@@ -31,6 +31,7 @@ public class LabeledSplitHandleButton extends SplitHandleButton {
     boolean label2down = false;
     boolean rotatedown = false;
     float density;
+    int topInset = 0;
     int bottomInset = 0;
 
     ButtonPressListener buttonPressListener;
@@ -93,11 +94,13 @@ public class LabeledSplitHandleButton extends SplitHandleButton {
 
     /**
      * When the handle is a vertical bar (side-by-side split), the bar itself
-     * extends edge-to-edge behind the navigation bar; this lifts the bottom
-     * label (and its touch target) back into the safe area.
+     * extends edge-to-edge behind the status/navigation bars and cutout;
+     * this shifts the two labels (and their touch targets) back into the
+     * safe area.
      */
-    public void setBottomInset(int bottomInset) {
-        if (this.bottomInset == bottomInset) return;
+    public void setVerticalInsets(int topInset, int bottomInset) {
+        if (this.topInset == topInset && this.bottomInset == bottomInset) return;
+        this.topInset = topInset;
         this.bottomInset = bottomInset;
         invalidate();
     }
@@ -116,27 +119,30 @@ public class LabeledSplitHandleButton extends SplitHandleButton {
             // length is the width or the height
             final int length;
 
-            // shift of the end label away from the bar's far end
+            // shifts of the labels away from the bar's ends
+            final int startInset;
             final int endInset;
 
             if (orientation == Orientation.vertical) {
                 pos = event.getX();
                 length = getWidth();
+                startInset = 0;
                 endInset = 0;
             } else {
                 pos = event.getY();
                 length = getHeight();
+                startInset = topInset;
                 endInset = bottomInset;
             }
 
             if (action == MotionEvent.ACTION_DOWN) {
-                label1down = pos < maxLabel1sz;
+                label1down = pos < maxLabel1sz + startInset;
                 label2down = pos > length - maxLabel2sz - endInset;
                 rotatedown = pos >= (length - rotatelength) * 0.5f && pos <= (length + rotatelength) * 0.5f;
             }
 
             if (action == MotionEvent.ACTION_UP && buttonPressListener != null) {
-                label1pressed = label1down && pos < maxLabel1sz;
+                label1pressed = label1down && pos < maxLabel1sz + startInset;
                 label2pressed = label2down && pos > length - maxLabel2sz - endInset;
                 rotatepressed = rotatedown && pos >= (length - rotatelength) * 0.5f && pos <= (length + rotatelength) * 0.5f;
 
@@ -201,7 +207,7 @@ public class LabeledSplitHandleButton extends SplitHandleButton {
 
                 if (label1down) {
                     if (orientation == Orientation.vertical) canvas.clipRect(0, 0, label1length, thickness);
-                    else canvas.clipRect(0, 0, thickness, label1length);
+                    else canvas.clipRect(0, 0, thickness, label1length + topInset);
                 } else if (label2down) {
                     if (orientation == Orientation.vertical) canvas.clipRect(length - label2length, 0, length, thickness);
                     else canvas.clipRect(0, length - label2length - bottomInset, thickness, length);
@@ -225,7 +231,7 @@ public class LabeledSplitHandleButton extends SplitHandleButton {
                 canvas.rotate(-90);
 
                 labelPaint.setTextAlign(Paint.Align.RIGHT);
-                canvas.drawText(label1, -pad, base, labelPaint);
+                canvas.drawText(label1, -pad - topInset, base, labelPaint);
 
                 canvas.restore();
             } else {


### PR DESCRIPTION
## What

Follow-up to #231 (these two commits were pushed to that branch after it was squash-merged, so they never landed):

- **Side-by-side split handle labels stay in the safe area.** The vertical split handle bar draws edge-to-edge behind the status/navigation bars and cutout; the version-name labels at its two ends (plus their touch targets and pressed highlights) are shifted inward by the window insets so they remain visible and tappable.
- **Top edge now mirrors the bottom.** Where the toolbar does not cover the top (fullscreen with a display cutout, bottom-toolbar preference), the verse container no longer clips below the status bar/cutout: the verse lists take the top inset as scroll-past padding (`setViewVerticalInsets`) and the split handle bar reaches the window top. In a stacked split the top pane gets the top inset and the bottom pane the bottom inset; side-by-side panes get both.
- **Re-anchor lists resting at scroll top when insets change.** RecyclerView preserves the first item's pixel position on padding changes, which left the first verse sitting inside the cutout band right after entering fullscreen until the user scrolled.

## Verification

API 35 emulator with the simulated tall cutout: fullscreen side-by-side shows the handle bar spanning the full screen height through the cutout band with "◀ AYT" just below the cutout; both panes start below the cutout immediately after toggling fullscreen; non-fullscreen keeps the bottom label lifted above the navigation bar. `assemblePlainDebug`, `testPlainDebugUnitTest`, and `testPlainReleaseUnitTest` pass on top of current develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)