### PR TITLE
Keep split-version labels clear of the gesture bar on nav-inset-underreporting devices

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -1437,12 +1437,21 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         val panelBackForwardListBaseBottomMargin = (panelBackForwardList.layoutParams as ViewGroup.MarginLayoutParams).bottomMargin
         ViewCompat.setOnApplyWindowInsetsListener(nontoolbar) { v, windowInsets ->
             val insets = windowInsets.getInsets(safeAreaTypes)
+            // On gesture navigation some devices under-report the bottom
+            // systemBars inset: the gesture "pill" sits below the reported
+            // navigation-bar inset, so a label lifted only by `insets.bottom`
+            // still overlaps it. The mandatory system-gesture inset reliably
+            // covers the home-gesture area, so fold it into the bottom edge.
+            // Only the bottom is taken — the left/right back-gesture zones are
+            // ignored so verse text stays edge-to-edge horizontally.
+            val gestureBottom = windowInsets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures()).bottom
+            val safeBottom = maxOf(insets.bottom, gestureBottom)
             v.setPadding(insets.left, 0, insets.right, 0)
 
             val topEdgeCovered = !fullScreen && !isBottomToolbarOnText()
             val topInset = if (topEdgeCovered) 0 else insets.top
             val bottomEdgeCovered = (!fullScreen && isBottomToolbarOnText()) || root.requireViewById<View>(R.id.audio_bar).height > 0
-            val bottomInset = if (bottomEdgeCovered) 0 else insets.bottom
+            val bottomInset = if (bottomEdgeCovered) 0 else safeBottom
             val stackedSplit = splitHandleButton.isVisible && splitRoot.orientation == LinearLayout.VERTICAL
             lsSplit0.setViewVerticalInsets(topInset, if (stackedSplit) 0 else bottomInset)
             lsSplit1.setViewVerticalInsets(if (stackedSplit) 0 else topInset, bottomInset)

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/LabeledSplitHandleButtonLabelInsetTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/LabeledSplitHandleButtonLabelInsetTest.kt
@@ -1,0 +1,100 @@
+package yuku.alkitab.base.widget
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color as AndroidColor
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import yuku.afw.App as AfwApp
+import yuku.alkitab.debug.R
+
+/**
+ * Regression guard for the side-by-side (vertical bar) split handle keeping its
+ * two version labels inside the safe area while the bar itself draws
+ * edge-to-edge behind the system bars / gesture navigation pill.
+ *
+ * The bar spans the whole window height; the bottom label ("label2") must be
+ * lifted by the supplied bottom inset so it never overlaps the gesture bar, and
+ * the top label ("label1") lifted by the top inset. The test renders the handle
+ * with native graphics and scans the inset bands for stray label pixels.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = AfwApp::class, sdk = [34], qualifiers = "w360dp-h800dp-xhdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class LabeledSplitHandleButtonLabelInsetTest {
+
+    @Before
+    fun setUp() {
+        AfwApp.initWithAppContext(ApplicationProvider.getApplicationContext())
+    }
+
+    private fun buildActivity(): AppCompatActivity {
+        val activity = Robolectric.buildActivity(AppCompatActivity::class.java).setup().get()
+        activity.setTheme(R.style.Theme_Alkitab)
+        return activity
+    }
+
+    private data class Bands(val top: Int, val bottom: Int)
+
+    /** Renders the vertical-bar handle and returns intruding label pixel counts in each inset band. */
+    private fun renderAndScan(topInset: Int, bottomInset: Int): Bands {
+        val density = ApplicationProvider.getApplicationContext<android.content.Context>().resources.displayMetrics.density
+        val thickness = (24 * density).toInt()
+        val height = (800 * density).toInt()
+
+        val button = LabeledSplitHandleButton(buildActivity(), null).apply {
+            setOrientation(SplitHandleButton.Orientation.horizontal) // vertical bar = side-by-side
+            setLabel1("KJV ▼")
+            setLabel2("TB ▼")
+            setVerticalInsets(topInset, bottomInset)
+        }
+        val ws = View.MeasureSpec.makeMeasureSpec(thickness, View.MeasureSpec.EXACTLY)
+        val hs = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY)
+        button.measure(ws, hs)
+        button.layout(0, 0, thickness, height)
+
+        val bitmap = Bitmap.createBitmap(thickness, height, Bitmap.Config.ARGB_8888)
+        button.draw(Canvas(bitmap))
+
+        // Sample the bar background from a spot with no label or center icon.
+        val bg = bitmap.getPixel(1, (height * 0.5f).toInt() - (60 * density).toInt())
+
+        fun scan(yFrom: Int, yTo: Int): Int {
+            var n = 0
+            for (y in yFrom until yTo) for (x in 0 until thickness) {
+                val p = bitmap.getPixel(x, y)
+                val d = Math.abs(AndroidColor.red(p) - AndroidColor.red(bg)) +
+                    Math.abs(AndroidColor.green(p) - AndroidColor.green(bg)) +
+                    Math.abs(AndroidColor.blue(p) - AndroidColor.blue(bg))
+                if (d > 40) n++
+            }
+            return n
+        }
+        return Bands(top = scan(0, topInset), bottom = scan(height - bottomInset, height))
+    }
+
+    @Test
+    fun `the bottom label is lifted out of the bottom inset band (gesture bar)`() {
+        val density = ApplicationProvider.getApplicationContext<android.content.Context>().resources.displayMetrics.density
+        val bottomInset = (48 * density).toInt()
+        val bands = renderAndScan(topInset = 0, bottomInset = bottomInset)
+        assertEquals("bottom label must not intrude into the gesture-bar band", 0, bands.bottom)
+    }
+
+    @Test
+    fun `the top label is lifted out of the top inset band (status bar or cutout)`() {
+        val density = ApplicationProvider.getApplicationContext<android.content.Context>().resources.displayMetrics.density
+        val topInset = (32 * density).toInt()
+        val bands = renderAndScan(topInset = topInset, bottomInset = (48 * density).toInt())
+        assertEquals("top label must not intrude into the top inset band", 0, bands.top)
+    }
+}


### PR DESCRIPTION
## Problem

In the side-by-side split view, the vertical split handle bar draws edge-to-edge behind the system bars, and the bottom version short-name label is supposed to stay inside the safe area (introduced in #235). On some phones using **gesture navigation**, the bottom label still overlaps the gesture "pill" at the bottom of the screen.

## Diagnosis

I verified the existing `#235` label-lifting logic across four independent layers (native-graphics render, sensitivity control, inset computation, and full dispatch through the real `DrawerLayout`). In the standard configuration it is correct — given a bottom inset of *N*, the bottom label is lifted cleanly above the bottom *N* pixels with a small pad gap.

That means the overlap can only occur when the system reports a **~0 bottom inset**. This is a known behavior on some gesture-navigation devices/OEMs: the visible gesture pill sits *below* the reported `systemBars()` (navigation-bar) bottom inset, so lifting a label only by `insets.bottom` isn't enough.

## Fix

In `IsiActivity.setupSafeAreaInsets`, fold the **mandatory system-gesture** inset into the bottom edge:

```kotlin
val gestureBottom = windowInsets.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures()).bottom
val safeBottom = maxOf(insets.bottom, gestureBottom)
```

- Only the **bottom** is taken — the left/right back-gesture zones are deliberately ignored so verse text stays edge-to-edge horizontally.
- It's a `max`, so on devices that report the nav-bar inset correctly (or on 3-button nav, where the mandatory-gesture bottom is 0) the value is unchanged.
- Applies to both the split-handle labels and the verse lists' scroll-past padding, so scrolled-to-end verses also clear the gesture bar.

## Testing

- `./gradlew assemblePlainDebug` — success.
- New native-graphics regression test `LabeledSplitHandleButtonLabelInsetTest` renders the vertical-bar handle and asserts neither the top nor bottom version label intrudes into its inset band.
- Existing `widget` and `verses` unit tests pass.

Note: I could not reproduce the exact device behavior in the sandbox (no emulator/KVM), so this hardens the inset math against under-reporting rather than being confirmed on the specific device. Verification on the affected phone would be the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqRpo46gkDGf8tUZmuXN6v

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqRpo46gkDGf8tUZmuXN6v)_