### PR TITLE
Lower the song search sheet and highlight matches

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/SongDb.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/SongDb.java
@@ -253,7 +253,9 @@ public class SongDb {
                         rowBookName,
                         rowCode,
                         c.isNull(colTitle) ? null : c.getString(colTitle),
-                        c.isNull(colTitleOriginal) ? null : c.getString(colTitleOriginal)
+                        c.isNull(colTitleOriginal) ? null : c.getString(colTitleOriginal),
+                        // preview up to 2 matching lyric lines under the result (deep search only)
+                        SongFilter.findLyricSnippet(doc, cf, 2)
                     ));
                 }
             }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongFilter.java
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongFilter.java
@@ -138,4 +138,49 @@ public class SongFilter {
 		m.reset(s);
 		return m.find();
 	}
+
+	/**
+	 * All [start, end) ranges in {@code text} that any filter token matches, so the search UI can
+	 * highlight the matched substrings the same way the verse search highlights hits. Ranges may
+	 * overlap when tokens overlap; callers that render spans (e.g. Compose AnnotatedString) handle
+	 * that fine. Returns an empty list for an empty filter.
+	 */
+	public static List<int[]> matchRanges(CharSequence text, CompiledFilter cf) {
+		List<int[]> res = new ArrayList<>();
+		if (text == null || cf.ps == null) return res;
+		for (final Pattern p : cf.ps) {
+			Matcher m = p.matcher(text);
+			while (m.find()) {
+				if (m.end() > m.start()) res.add(new int[] { m.start(), m.end() });
+			}
+		}
+		return res;
+	}
+
+	/**
+	 * Up to {@code maxLines} lyric lines of {@code doc} that contain any filter token, joined by
+	 * {@code '\n'}, to preview where a deep-search hit occurred. Returns null when the filter is
+	 * empty or no lyric line matches (e.g. the hit was only in the title/authors, already shown).
+	 */
+	public static String findLyricSnippet(SongDocument doc, CompiledFilter cf, int maxLines) {
+		if (cf.ps == null) return null;
+
+		List<String> picked = new ArrayList<>();
+		for (String line : SongDocumentSearch.lyricLines(doc)) {
+			boolean lineMatches = false;
+			for (final Pattern p : cf.ps) {
+				if (p.matcher(line).find()) {
+					lineMatches = true;
+					break;
+				}
+			}
+			if (lineMatches) {
+				picked.add(line);
+				if (picked.size() >= maxLines) break;
+			}
+		}
+
+		if (picked.isEmpty()) return null;
+		return String.join("\n", picked);
+	}
 }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongInfo.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongInfo.kt
@@ -5,9 +5,14 @@ import kotlinx.parcelize.Parcelize
 
 /**
  * A concise record of a song without "opening" its contents.
+ *
+ * [snippet] is populated only by the deep ("include lyrics") search path
+ * ([yuku.alkitab.base.storage.SongDb.listSongInfosByBookNameAndDeepFilter]) and
+ * holds up to a couple of matching lyric lines to preview under the search result.
+ * It is null for ordinary metadata listings.
  */
 @Parcelize
-class SongInfo(
+class SongInfo @JvmOverloads constructor(
     @JvmField
     val bookName: String,
     @JvmField
@@ -16,4 +21,6 @@ class SongInfo(
     val title: String,
     @JvmField
     val title_original: String?,
+    @JvmField
+    val snippet: String? = null,
 ) : Parcelable

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongSearchSheet.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongSearchSheet.kt
@@ -4,10 +4,10 @@ import androidx.activity.ComponentActivity
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
@@ -43,13 +43,16 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
@@ -158,99 +161,114 @@ private fun SongSearchSheetContent(
     var query by remember { mutableStateOf(state.filterString) }
     val keyboard = LocalSoftwareKeyboardController.current
 
+    // Compiled once per committed filter, reused to highlight matched substrings in every
+    // visible result (same idea as the verse search hit highlighting).
+    val compiledFilter = remember(state.filterString) { SongFilter.compileFilter(state.filterString) }
+
     LaunchedEffect(Unit) {
         viewModel.searchIfNeeded()
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxHeight()
-            .imePadding()
-            .navigationBarsPadding(),
-    ) {
-        OutlinedTextField(
-            value = query,
-            onValueChange = {
-                query = it
-                viewModel.setFilterString(it)
-            },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            placeholder = { Text(stringResource(R.string.search)) },
-            leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
-            trailingIcon = if (query.isNotEmpty()) {
-                {
-                    IconButton(onClick = {
-                        query = ""
-                        viewModel.setFilterString("")
-                    }) {
-                        Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.delete))
-                    }
-                }
-            } else {
-                null
-            },
-            singleLine = true,
-            shape = RoundedCornerShape(28.dp),
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-            keyboardActions = KeyboardActions(onSearch = { keyboard?.hide() }),
-        )
+    // Cap the sheet height so its rounded top stays a bit below the status bar
+    // (a ModalBottomSheet's expanded height reaches right up to the status bar,
+    // which makes a fill-max-height sheet read as another fullscreen screen
+    // instead of a dialog). maxHeight here is the available sheet content height,
+    // already excluding the status bar; leaving a fixed gap keeps the curve visible.
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val sheetHeight = maxHeight - 48.dp
 
-        Row(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                .height(sheetHeight)
+                .imePadding()
+                .navigationBarsPadding(),
         ) {
-            SongBookFilterChip(
-                selectedBookName = state.selectedBookName,
-                onBookSelected = viewModel::setSelectedBookName,
-            )
-
-            FilterChip(
-                selected = state.deepSearch,
-                onClick = { viewModel.setDeepSearch(!state.deepSearch) },
-                label = { Text(stringResource(R.string.sn_deep_search_enabled)) },
-                leadingIcon = if (state.deepSearch) {
-                    { Icon(Icons.Filled.Check, contentDescription = null) }
+            OutlinedTextField(
+                value = query,
+                onValueChange = {
+                    query = it
+                    viewModel.setFilterString(it)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                placeholder = { Text(stringResource(R.string.search)) },
+                leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
+                trailingIcon = if (query.isNotEmpty()) {
+                    {
+                        IconButton(onClick = {
+                            query = ""
+                            viewModel.setFilterString("")
+                        }) {
+                            Icon(Icons.Filled.Close, contentDescription = stringResource(R.string.delete))
+                        }
+                    }
                 } else {
                     null
                 },
+                singleLine = true,
+                shape = RoundedCornerShape(28.dp),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = { keyboard?.hide() }),
             )
-        }
 
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(4.dp),
-        ) {
-            if (state.loading) {
-                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-            }
-        }
-
-        val listState = rememberLazyListState(viewModel.listScrollIndex, viewModel.listScrollOffset)
-        DisposableEffect(Unit) {
-            onDispose {
-                viewModel.listScrollIndex = listState.firstVisibleItemIndex
-                viewModel.listScrollOffset = listState.firstVisibleItemScrollOffset
-            }
-        }
-
-        val results = state.results.orEmpty()
-        LazyColumn(
-            state = listState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-        ) {
-            itemsIndexed(results) { index, songInfo ->
-                if (index > 0) HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                SongResultItem(
-                    songInfo = songInfo,
-                    onClick = { onSongSelected(songInfo) },
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                SongBookFilterChip(
+                    selectedBookName = state.selectedBookName,
+                    onBookSelected = viewModel::setSelectedBookName,
                 )
+
+                FilterChip(
+                    selected = state.deepSearch,
+                    onClick = { viewModel.setDeepSearch(!state.deepSearch) },
+                    label = { Text(stringResource(R.string.sn_deep_search_enabled)) },
+                    leadingIcon = if (state.deepSearch) {
+                        { Icon(Icons.Filled.Check, contentDescription = null) }
+                    } else {
+                        null
+                    },
+                )
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(4.dp),
+            ) {
+                if (state.loading) {
+                    LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+            }
+
+            val listState = rememberLazyListState(viewModel.listScrollIndex, viewModel.listScrollOffset)
+            DisposableEffect(Unit) {
+                onDispose {
+                    viewModel.listScrollIndex = listState.firstVisibleItemIndex
+                    viewModel.listScrollOffset = listState.firstVisibleItemScrollOffset
+                }
+            }
+
+            val results = state.results.orEmpty()
+            LazyColumn(
+                state = listState,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+            ) {
+                itemsIndexed(results) { index, songInfo ->
+                    if (index > 0) HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    SongResultItem(
+                        songInfo = songInfo,
+                        compiledFilter = compiledFilter,
+                        onClick = { onSongSelected(songInfo) },
+                    )
+                }
             }
         }
     }
@@ -346,8 +364,11 @@ private fun SongBookFilterChip(
 @Composable
 private fun SongResultItem(
     songInfo: SongInfo,
+    compiledFilter: SongFilter.CompiledFilter,
     onClick: () -> Unit,
 ) {
+    val hiliteColor = MaterialTheme.colorScheme.primary
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -355,14 +376,14 @@ private fun SongResultItem(
             .padding(horizontal = 16.dp, vertical = 10.dp),
     ) {
         Text(
-            text = "${songInfo.code}. ${songInfo.title}",
+            text = highlightMatches("${songInfo.code}. ${songInfo.title}", compiledFilter, hiliteColor),
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurface,
         )
         val titleOriginal = songInfo.title_original
         if (!titleOriginal.isNullOrEmpty()) {
             Text(
-                text = titleOriginal,
+                text = highlightMatches(titleOriginal, compiledFilter, hiliteColor),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -373,5 +394,43 @@ private fun SongResultItem(
             style = MaterialTheme.typography.labelMedium,
             color = MaterialTheme.colorScheme.primary,
         )
+
+        // Deep ("include lyrics") search: preview up to 2 matching lyric lines.
+        val snippet = songInfo.snippet
+        if (!snippet.isNullOrEmpty()) {
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = highlightMatches(snippet, compiledFilter, hiliteColor),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+/**
+ * Bolds and recolors every filter-token match inside [text] (via [SongFilter.matchRanges]),
+ * mirroring how the verse search highlights hits. Returns the plain string when nothing matches.
+ */
+private fun highlightMatches(
+    text: String,
+    compiledFilter: SongFilter.CompiledFilter,
+    color: Color,
+): AnnotatedString {
+    val ranges = SongFilter.matchRanges(text, compiledFilter)
+    if (ranges.isEmpty()) return AnnotatedString(text)
+
+    return buildAnnotatedString {
+        append(text)
+        val len = text.length
+        for (range in ranges) {
+            val start = range[0].coerceIn(0, len)
+            val end = range[1].coerceIn(start, len)
+            if (end > start) {
+                addStyle(SpanStyle(color = color, fontWeight = FontWeight.Bold), start, end)
+            }
+        }
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentSearch.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/newdoc/SongDocumentSearch.kt
@@ -21,6 +21,25 @@ object SongDocumentSearch {
         return texts
     }
 
+    /**
+     * Just the lyric verse lines, in document order — the song "body" used to build the
+     * matching-line snippet shown under a deep-search result. Unlike [searchableTexts] this
+     * excludes code/title/authors/tune, since those are already surfaced (and highlighted)
+     * as the result's title and book name.
+     */
+    @JvmStatic
+    fun lyricLines(doc: SongDocument): List<String> {
+        val lines = mutableListOf<String>()
+        for (block in doc.blocks) {
+            if (block is LyricBlock) {
+                for (verse in block.verses) {
+                    for (line in verse.lines) lines.add(line.plainText())
+                }
+            }
+        }
+        return lines
+    }
+
     private fun collect(block: Block, out: MutableList<String>) {
         when (block) {
             is PBlock -> if (block.role == "tune") out.add(block.content.plainText())

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/SongDbTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/SongDbTest.kt
@@ -233,6 +233,26 @@ class SongDbTest {
     }
 
     @Test
+    fun `deep filter attaches up to two matching lyric lines as the result snippet`() {
+        // songDoc's lyric lines are "Line 1", "Line 2", "Chorus" (in that order).
+        dao.storeSongs("NKB", listOf(songDoc("A")), SongDocumentJson.DATA_FORMAT_VERSION)
+
+        val rows = dao.listSongInfosByBookNameAndDeepFilter("NKB", "line")
+        assertEquals(1, rows.size)
+        // Both "Line 1" and "Line 2" match; capped at two, joined by a newline, in document order.
+        assertEquals("Line 1\nLine 2", rows[0].snippet)
+    }
+
+    @Test
+    fun `deep filter leaves the snippet null when only the title matches, not a lyric line`() {
+        dao.storeSongs("NKB", listOf(songDoc("A", title = "Hosanna in the highest")), SongDocumentJson.DATA_FORMAT_VERSION)
+
+        val rows = dao.listSongInfosByBookNameAndDeepFilter("NKB", "hosanna")
+        assertEquals(1, rows.size)
+        assertNull(rows[0].snippet)
+    }
+
+    @Test
     fun `deleteSongBook removes book metadata, every song, and vacuums without losing other books`() {
         dao.insertSongBookInfo(bookInfo(name = "NKB", title = "Buku NKB"))
         dao.insertSongBookInfo(bookInfo(name = "PKJ", title = "Buku PKJ"))

--- a/Alkitab/src/test/java/yuku/alkitab/songs/SongFilterTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/songs/SongFilterTest.kt
@@ -1,0 +1,40 @@
+package yuku.alkitab.songs
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-logic tests for [SongFilter.matchRanges], the helper that drives the
+ * search-result hit highlighting in the song search sheet.
+ */
+class SongFilterTest {
+    private fun ranges(text: String, filter: String): List<Pair<Int, Int>> {
+        val cf = SongFilter.compileFilter(filter)
+        return SongFilter.matchRanges(text, cf).map { it[0] to it[1] }
+    }
+
+    @Test
+    fun `matchRanges reports every case-insensitive occurrence of a token`() {
+        // "holy" appears three times in "Holy holy holy".
+        assertEquals(listOf(0 to 4, 5 to 9, 10 to 14), ranges("Holy holy holy", "holy"))
+    }
+
+    @Test
+    fun `matchRanges covers each token of a multi-token filter`() {
+        // Two tokens, one match each; both hits are reported regardless of token order.
+        val result = ranges("Amazing grace how sweet", "grace amazing")
+        assertTrue("expected a range for 'grace' in $result", result.contains(8 to 13))
+        assertTrue("expected a range for 'amazing' in $result", result.contains(0 to 7))
+    }
+
+    @Test
+    fun `matchRanges returns nothing for an empty filter`() {
+        assertEquals(emptyList<Pair<Int, Int>>(), ranges("Anything", "   "))
+    }
+
+    @Test
+    fun `matchRanges returns nothing when the token is absent`() {
+        assertEquals(emptyList<Pair<Int, Int>>(), ranges("Amazing grace", "hosanna"))
+    }
+}


### PR DESCRIPTION
## What & why

Three improvements to the song search bottom sheet (`SongSearchSheet`), which is already a Compose Material `ModalBottomSheet` hosted over `SongViewActivity` via `ComposeBottomSheetHost`:

### 1. Sheet opens slightly lower (curve visible)
The content used `.fillMaxHeight()`, forcing the `ModalBottomSheet` to expand right up to the status bar — so it read like another fullscreen screen rather than a dialog. It now sits inside a `BoxWithConstraints` and caps its height to `maxHeight - 48.dp`, leaving a gap below the status bar so the sheet's rounded top curve stays visible. This also brings the same tinted `surfaceContainerLow` surface used by the highlight dialog into view against the scrim (both sheets share the exact same `ModalBottomSheet` container color via the host).

### 2. Match highlighting in results
Every filter-token match in a result's title (code + title) and original title is now bolded and recolored, mirroring how the verse search highlights hits. Backed by a new `SongFilter.matchRanges(text, cf)` helper feeding a small Compose `AnnotatedString` builder.

### 3. Lyric snippet for "include lyrics" (deep) search
When deep search is on, `SongDb.listSongInfosByBookNameAndDeepFilter` now attaches up to two matching lyric lines to each `SongInfo` (`SongFilter.findLyricSnippet` + `SongDocumentSearch.lyricLines`). The sheet renders it as a max-2-line, ellipsized snippet under the title and book name, with the matched parts highlighted. The snippet is null for ordinary (non-deep) listings, so nothing changes there.

## Implementation notes
- `SongInfo` gains a nullable `snippet` field with `@JvmOverloads`, so the existing 4-arg Java construction site keeps compiling; only the deep-filter path passes the 5th argument.
- Highlighting reuses the existing tokenization (`SongFilter.compileFilter` / `QueryTokenizer`) for consistency with what actually matched.

## Testing
- `./gradlew assemblePlainDebug` — succeeds.
- `./gradlew testPlainDebugUnitTest` — full suite green, including:
  - New `SongFilterTest` (pure JUnit) covering `matchRanges` (case-insensitive, multi-token, empty/absent filters).
  - New `SongDbTest` cases: deep filter attaches up to two matching lyric lines as the snippet; snippet stays null when only the title matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vin2xn4FkMTc7BpvYjus16

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vin2xn4FkMTc7BpvYjus16)_