### PR TITLE
Fix "Update Song Book" dataFormatVersion handling (REM-35)

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/SongDb.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/SongDb.java
@@ -39,7 +39,7 @@ import yuku.kpri.model.Song;
  * commonly written together during song-book installation
  * ({@code SongBookUtil.handleDownloadResult} calls
  * {@link #insertSongBookInfo(SongBookUtil.SongBookInfo)} then
- * {@link #storeSongs(String, List, int)}).
+ * {@link #storeSongs(String, List)}).
  *
  * <p>Cross-file note: this DAO is constructed with {@link SongDbHelper}
  * only so its constructor signature stays unchanged. The helper is no
@@ -144,9 +144,13 @@ public class SongDb {
     }
 
     /**
-     * Store to db songs in a book. Before the songs are stored, all songs of the specified book are deleted.
+     * Store to db songs in a book. Before the songs are stored, all songs of the specified book
+     * (at any {@code dataFormatVersion}) are deleted, so updating a mixed-version book leaves no
+     * stale rows behind. The payload is always written as JSON, so every row is stamped at
+     * {@link SongDocumentJson#DATA_FORMAT_VERSION} regardless of the version originally requested
+     * from the server (REM-35).
      */
-    public void storeSongs(String bookName, List<SongDocument> docs, int dataFormatVersion) {
+    public void storeSongs(String bookName, List<SongDocument> docs) {
         final int updateTime = Sqlitil.nowDateTime();
         final List<SongInfoEntity> entities = new ArrayList<>(docs.size());
         int ordering = 1;
@@ -158,12 +162,12 @@ public class SongDb {
                 doc.getMeta().getTitle(),
                 doc.getMeta().getTitle_original(),
                 ordering++,
-                dataFormatVersion,
+                SongDocumentJson.DATA_FORMAT_VERSION,
                 writeDocument(doc),
                 updateTime
             ));
         }
-        roomDao().replaceSongsForBookNameAndDataFormatVersion(bookName, dataFormatVersion, entities);
+        roomDao().replaceSongsForBookName(bookName, entities);
     }
 
     public SongDocument getSong(String bookName, String code) {
@@ -313,11 +317,6 @@ public class SongDb {
      */
     public void insertSongBookInfo(final SongBookUtil.SongBookInfo info) {
         roomDao().insertOrReplaceSongBookInfo(info.name, info.title, info.copyright);
-    }
-
-    public int getDataFormatVersionForSongs(final String bookName) {
-        final Integer res = roomDao().findDataFormatVersionForBookName(bookName);
-        return res == null ? 0 : res;
     }
 
     public int getSongUpdateTime(final String bookName, final String code) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/room/SongRoomDao.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/room/SongRoomDao.kt
@@ -23,12 +23,14 @@ import androidx.room.Transaction
  * failure — exact match for the legacy
  * `SQLiteDatabase.beginTransactionNonExclusive` pattern.
  *
- * `storeSongs` is similarly preserved as
- * [replaceSongsForBookNameAndDataFormatVersion]: a `@Transaction` method
- * that deletes every row matching `(bookName, dataFormatVersion)` and
- * re-inserts the supplied list. Each inserted row uses the supplied
- * pre-computed `ordering` index so the legacy "ordering of the songs for
- * display" semantics are exactly preserved.
+ * `storeSongs` is backed by [replaceSongsForBookName]: a `@Transaction`
+ * method that deletes every row for the book and re-inserts the supplied
+ * list. Each inserted row uses the supplied pre-computed `ordering` index
+ * so the legacy "ordering of the songs for display" semantics are exactly
+ * preserved. A song-book download replaces the whole book, so the delete is
+ * keyed by `bookName` alone — never by `(bookName, dataFormatVersion)`,
+ * which would leak rows of a different version and duplicate songs after a
+ * mixed-version book (REM-35).
  */
 @Dao
 abstract class SongRoomDao {
@@ -37,14 +39,6 @@ abstract class SongRoomDao {
 
     @Insert
     abstract fun insertSongInfo(entity: SongInfoEntity): Long
-
-    @Query(
-        "DELETE FROM song_info WHERE bookName = :bookName AND dataFormatVersion = :dataFormatVersion",
-    )
-    abstract fun deleteSongInfosByBookNameAndDataFormatVersion(
-        bookName: String,
-        dataFormatVersion: Int,
-    ): Int
 
     @Query("DELETE FROM song_info WHERE bookName = :bookName")
     abstract fun deleteSongInfosByBookName(bookName: String): Int
@@ -150,11 +144,6 @@ abstract class SongRoomDao {
     abstract fun writeBackJsonSongData(id: Long, data: ByteArray): Int
 
     @Query(
-        "SELECT dataFormatVersion FROM song_info WHERE bookName = :bookName LIMIT 1",
-    )
-    abstract fun findDataFormatVersionForBookName(bookName: String): Int?
-
-    @Query(
         "SELECT updateTime FROM song_info WHERE bookName = :bookName AND code = :code LIMIT 1",
     )
     abstract fun findUpdateTimeByBookNameAndCode(bookName: String, code: String): Int?
@@ -163,24 +152,28 @@ abstract class SongRoomDao {
     abstract fun countAllSongInfos(): Int
 
     /**
-     * Replace every `song_info` row for the given `(bookName, dataFormatVersion)`
-     * with the supplied entities. Mirrors the legacy facade's
-     * `storeSongs(bookName, songs, dataFormatVersion)` semantics — the
-     * count of pre-existing rows is unchanged from the caller's
-     * perspective, and the new rows get the caller-assigned `ordering`
+     * Replace every `song_info` row for the given `bookName` with the
+     * supplied entities. Backs the facade's `storeSongs(bookName, songs)`:
+     * a song-book download replaces the whole book, so the delete is keyed
+     * by `bookName` alone. The new rows get the caller-assigned `ordering`
      * indexes.
+     *
+     * Deleting by `bookName` alone (rather than `(bookName, dataFormatVersion)`)
+     * is what makes updating a mixed-version book safe — after REM-21's lazy
+     * per-row conversion a book can hold rows at several `dataFormatVersion`s,
+     * and a version-scoped delete would leave the non-matching rows behind,
+     * duplicating songs (REM-35).
      *
      * Wrapped in `@Transaction` so the delete and the inserts observe a
      * consistent snapshot and roll back together on failure — exact match
      * for the legacy `SQLiteDatabase.beginTransactionNonExclusive` pattern.
      */
     @Transaction
-    open fun replaceSongsForBookNameAndDataFormatVersion(
+    open fun replaceSongsForBookName(
         bookName: String,
-        dataFormatVersion: Int,
         entities: List<SongInfoEntity>,
     ) {
-        deleteSongInfosByBookNameAndDataFormatVersion(bookName, dataFormatVersion)
+        deleteSongInfosByBookName(bookName)
         for (entity in entities) {
             insertSongInfo(entity)
         }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongBookUtil.kt
@@ -186,7 +186,7 @@ object SongBookUtil {
                         Foreground.run { listener.onFailedOrCancelled(songBookInfo, null) }
                     } else {
                         App.services.storage.songDb.insertSongBookInfo(songBookInfo)
-                        App.services.storage.songDb.storeSongs(songBookInfo.name, songs, dataFormatVersion)
+                        App.services.storage.songDb.storeSongs(songBookInfo.name, songs)
                         Foreground.run { listener.onDownloadedAndInserted(songBookInfo) }
                     }
                 }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongViewActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongViewActivity.kt
@@ -535,7 +535,19 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
         val songBookInfo = SongBookUtil.getSongBookInfo(currentBookName)
 
         val currentSongCode = currentSong.code
-        val dataFormatVersion = App.services.storage.songDb.getDataFormatVersionForSongs(currentBookName)
+
+        // Always re-download and store at the current format. The stored payload is always JSON at
+        // this version, and the book may be mixed-version after REM-21's lazy per-row conversion, so
+        // requesting whatever version happened to be on a row would leave stale rows behind and could
+        // stamp a JSON payload with a legacy version (REM-35). Guard mirrors the alkitab:// path.
+        val dataFormatVersion = SongDocumentJson.DATA_FORMAT_VERSION
+        if (!SongBookUtil.isSupportedDataFormatVersion(dataFormatVersion)) {
+            MaterialAlertDialogBuilder(this)
+                .setMessage("Unsupported data format version: $dataFormatVersion")
+                .setPositiveButton(R.string.ok, null)
+                .show()
+            return
+        }
 
         SongBookUtil.downloadSongBook(this@SongViewActivity, songBookInfo, dataFormatVersion, object : SongBookUtil.OnDownloadSongBookListener {
             override fun onFailedOrCancelled(songBookInfo: SongBookUtil.SongBookInfo, e: Exception?) {

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/SongDbTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/SongDbTest.kt
@@ -16,6 +16,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import yuku.alkitab.base.storage.room.SongInfoEntity
 import yuku.alkitab.base.storage.room.SongRoomDatabase
+import yuku.alkitab.base.util.Sqlitil
 import yuku.alkitab.songs.SongBookUtil
 import yuku.alkitab.songs.newdoc.Block
 import yuku.alkitab.songs.newdoc.Line
@@ -113,7 +114,7 @@ class SongDbTest {
         }
 
     private fun store(bookName: String, vararg docs: SongDocument) {
-        dao.storeSongs(bookName, docs.toList(), SongDocumentJson.DATA_FORMAT_VERSION)
+        dao.storeSongs(bookName, docs.toList())
     }
 
     @Test
@@ -139,9 +140,9 @@ class SongDbTest {
     }
 
     @Test
-    fun `storeSongs replaces every existing song for the (bookName, dataFormatVersion) tuple`() {
-        dao.storeSongs("NKB", listOf(songDoc("001"), songDoc("002")), SongDocumentJson.DATA_FORMAT_VERSION)
-        dao.storeSongs("NKB", listOf(songDoc("003")), SongDocumentJson.DATA_FORMAT_VERSION)
+    fun `storeSongs replaces every existing song for the book`() {
+        store("NKB", songDoc("001"), songDoc("002"))
+        store("NKB", songDoc("003"))
 
         assertNull(dao.getSong("NKB", "001"))
         assertNull(dao.getSong("NKB", "002"))
@@ -149,15 +150,47 @@ class SongDbTest {
     }
 
     @Test
+    fun `updating a mixed-dataFormatVersion book replaces the whole book with version-5 JSON rows and no duplicates`() {
+        val roomDao = SongRoomDatabase.get(RuntimeEnvironment.getApplication()).songRoomDao()
+        // Reproduce a pre-REM-21 book left mixed-version by lazy per-row conversion: an unviewed
+        // legacy Parcelable row (dataFormatVersion 3) alongside a viewed JSON row (version 5), both
+        // in the same book. A version-scoped delete would only wipe one of them.
+        roomDao.insertSongInfo(
+            SongInfoEntity(0L, "NKB", "001", "Old 1", null, 1, 3, byteArrayOf(1, 2, 3), Sqlitil.nowDateTime()),
+        )
+        roomDao.insertSongInfo(
+            SongInfoEntity(
+                0L, "NKB", "002", "Old 2", null, 2,
+                SongDocumentJson.DATA_FORMAT_VERSION,
+                SongDocumentJson.encode(songDoc("002")).toByteArray(Charsets.UTF_8),
+                Sqlitil.nowDateTime(),
+            ),
+        )
+
+        // The "update song book" re-download stores the fresh payload.
+        store("NKB", songDoc("001"), songDoc("002"), songDoc("003"))
+
+        // No duplicates: each code appears exactly once, in display order.
+        val rows = roomDao.listSongInfosByBookName("NKB")
+        assertEquals(listOf("001", "002", "003"), rows.map { it.code })
+        // Every row is stamped at the JSON version...
+        assertTrue(rows.all { it.dataFormatVersion == SongDocumentJson.DATA_FORMAT_VERSION })
+        // ...and every row is readable via the facade (readDocument).
+        for (code in listOf("001", "002", "003")) {
+            assertNotNull(dao.getSong("NKB", code))
+        }
+    }
+
+    @Test
     fun `storeSongs preserves caller-supplied display ordering`() {
-        dao.storeSongs("NKB", listOf(songDoc("A"), songDoc("B"), songDoc("C")), SongDocumentJson.DATA_FORMAT_VERSION)
+        store("NKB", songDoc("A"), songDoc("B"), songDoc("C"))
         val codes = dao.listSongInfosByBookName("NKB").map { it.code }
         assertEquals(listOf("A", "B", "C"), codes)
     }
 
     @Test
     fun `getFirstSongFromBook returns the song with ordering = 1`() {
-        dao.storeSongs("NKB", listOf(songDoc("A"), songDoc("B")), SongDocumentJson.DATA_FORMAT_VERSION)
+        store("NKB", songDoc("A"), songDoc("B"))
         val first = dao.getFirstSongFromBook("NKB")
         assertNotNull(first)
         assertEquals("A", first!!.code)
@@ -170,8 +203,8 @@ class SongDbTest {
 
     @Test
     fun `getAnySong returns a pair of (bookName, doc) sorted by bookName then ordering`() {
-        dao.storeSongs("PKJ", listOf(songDoc("P1")), SongDocumentJson.DATA_FORMAT_VERSION)
-        dao.storeSongs("NKB", listOf(songDoc("N1")), SongDocumentJson.DATA_FORMAT_VERSION)
+        store("PKJ", songDoc("P1"))
+        store("NKB", songDoc("N1"))
         val pair = dao.getAnySong()
         assertNotNull(pair)
         assertEquals("NKB", pair!!.first)
@@ -185,11 +218,7 @@ class SongDbTest {
 
     @Test
     fun `listSongInfosByBookName returns lightweight SongInfo records in display order`() {
-        dao.storeSongs(
-            "NKB",
-            listOf(songDoc("A", title = "Alpha"), songDoc("B", title = "Bravo")),
-            SongDocumentJson.DATA_FORMAT_VERSION,
-        )
+        store("NKB", songDoc("A", title = "Alpha"), songDoc("B", title = "Bravo"))
         val rows = dao.listSongInfosByBookName("NKB")
         assertEquals(listOf("A", "B"), rows.map { it.code })
         assertEquals(listOf("Alpha", "Bravo"), rows.map { it.title })
@@ -197,12 +226,8 @@ class SongDbTest {
 
     @Test
     fun `listSongInfosByBookName with null bookName lists every book in display order`() {
-        dao.storeSongs("PKJ", listOf(songDoc("P1", title = "Papa")), SongDocumentJson.DATA_FORMAT_VERSION)
-        dao.storeSongs(
-            "NKB",
-            listOf(songDoc("A", title = "Alpha"), songDoc("B", title = "Bravo")),
-            SongDocumentJson.DATA_FORMAT_VERSION,
-        )
+        store("PKJ", songDoc("P1", title = "Papa"))
+        store("NKB", songDoc("A", title = "Alpha"), songDoc("B", title = "Bravo"))
         val rows = dao.listSongInfosByBookName(null)
         assertEquals(listOf("A", "B", "P1"), rows.map { it.code })
         assertEquals(listOf("NKB", "NKB", "PKJ"), rows.map { it.bookName })
@@ -210,14 +235,11 @@ class SongDbTest {
 
     @Test
     fun `listSongInfosByBookNameAndDeepFilter applies title-substring matching`() {
-        dao.storeSongs(
+        store(
             "NKB",
-            listOf(
-                songDoc("A", title = "Hosanna in the highest"),
-                songDoc("B", title = "Amazing grace"),
-                songDoc("C", title = "Holy holy holy"),
-            ),
-            SongDocumentJson.DATA_FORMAT_VERSION,
+            songDoc("A", title = "Hosanna in the highest"),
+            songDoc("B", title = "Amazing grace"),
+            songDoc("C", title = "Holy holy holy"),
         )
         val rows = dao.listSongInfosByBookNameAndDeepFilter("NKB", "holy")
         // "Holy holy holy" matches; the others do not.
@@ -226,8 +248,8 @@ class SongDbTest {
 
     @Test
     fun `listSongInfosByBookNameAndDeepFilter with null bookName scans every book`() {
-        dao.storeSongs("NKB", listOf(songDoc("A", title = "Hosanna")), SongDocumentJson.DATA_FORMAT_VERSION)
-        dao.storeSongs("PKJ", listOf(songDoc("P", title = "Hosanna")), SongDocumentJson.DATA_FORMAT_VERSION)
+        store("NKB", songDoc("A", title = "Hosanna"))
+        store("PKJ", songDoc("P", title = "Hosanna"))
         val rows = dao.listSongInfosByBookNameAndDeepFilter(null, "hosanna")
         assertEquals(2, rows.size)
     }
@@ -235,7 +257,7 @@ class SongDbTest {
     @Test
     fun `deep filter attaches up to two matching lyric lines as the result snippet`() {
         // songDoc's lyric lines are "Line 1", "Line 2", "Chorus" (in that order).
-        dao.storeSongs("NKB", listOf(songDoc("A")), SongDocumentJson.DATA_FORMAT_VERSION)
+        store("NKB", songDoc("A"))
 
         val rows = dao.listSongInfosByBookNameAndDeepFilter("NKB", "line")
         assertEquals(1, rows.size)
@@ -245,7 +267,7 @@ class SongDbTest {
 
     @Test
     fun `deep filter leaves the snippet null when only the title matches, not a lyric line`() {
-        dao.storeSongs("NKB", listOf(songDoc("A", title = "Hosanna in the highest")), SongDocumentJson.DATA_FORMAT_VERSION)
+        store("NKB", songDoc("A", title = "Hosanna in the highest"))
 
         val rows = dao.listSongInfosByBookNameAndDeepFilter("NKB", "hosanna")
         assertEquals(1, rows.size)
@@ -256,8 +278,8 @@ class SongDbTest {
     fun `deleteSongBook removes book metadata, every song, and vacuums without losing other books`() {
         dao.insertSongBookInfo(bookInfo(name = "NKB", title = "Buku NKB"))
         dao.insertSongBookInfo(bookInfo(name = "PKJ", title = "Buku PKJ"))
-        dao.storeSongs("NKB", listOf(songDoc("001"), songDoc("002")), SongDocumentJson.DATA_FORMAT_VERSION)
-        dao.storeSongs("PKJ", listOf(songDoc("P01")), SongDocumentJson.DATA_FORMAT_VERSION)
+        store("NKB", songDoc("001"), songDoc("002"))
+        store("PKJ", songDoc("P01"))
 
         val deleted = dao.deleteSongBook("NKB")
         assertEquals(2, deleted)
@@ -311,13 +333,6 @@ class SongDbTest {
     }
 
     @Test
-    fun `getDataFormatVersionForSongs returns 0 for empty book and the JSON version when present`() {
-        assertEquals(0, dao.getDataFormatVersionForSongs("NKB"))
-        store("NKB", songDoc("001"))
-        assertEquals(SongDocumentJson.DATA_FORMAT_VERSION, dao.getDataFormatVersionForSongs("NKB"))
-    }
-
-    @Test
     fun `getSongUpdateTime returns 0 for missing and a positive value for present`() {
         assertEquals(0, dao.getSongUpdateTime("NKB", "missing"))
         store("NKB", songDoc("001"))
@@ -356,7 +371,7 @@ class SongDbTest {
         p.recycle()
 
         val roomDao = SongRoomDatabase.get(RuntimeEnvironment.getApplication()).songRoomDao()
-        roomDao.insertSongInfo(SongInfoEntity(0L, "NKB", "L1", "Legacy Song", null, 1, 3, bytes, yuku.alkitab.base.util.Sqlitil.nowDateTime()))
+        roomDao.insertSongInfo(SongInfoEntity(0L, "NKB", "L1", "Legacy Song", null, 1, 3, bytes, Sqlitil.nowDateTime()))
 
         val doc = dao.getSong("NKB", "L1")
         assertNotNull(doc)
@@ -366,18 +381,20 @@ class SongDbTest {
         // The write-back runs on a background thread (Background.run) so the row doesn't flip to
         // dataFormatVersion 5 synchronously with the read that triggered it; poll for it instead of
         // asserting immediately.
-        awaitDataFormatVersion("NKB", SongDocumentJson.DATA_FORMAT_VERSION)
+        awaitDataFormatVersion(bookName = "NKB", code = "L1", expected = SongDocumentJson.DATA_FORMAT_VERSION)
 
         // idempotent: a second read returns the same document (now via the JSON path).
         val doc2 = dao.getSong("NKB", "L1")
         assertEquals(doc, doc2)
     }
 
-    private fun awaitDataFormatVersion(bookName: String, expected: Int, timeoutMs: Long = 2000) {
+    private fun awaitDataFormatVersion(bookName: String, code: String, expected: Int, timeoutMs: Long = 2000) {
+        val roomDao = SongRoomDatabase.get(RuntimeEnvironment.getApplication()).songRoomDao()
+        fun current() = roomDao.findSongInfoByBookNameAndCode(bookName, code)?.dataFormatVersion
         val deadline = System.currentTimeMillis() + timeoutMs
-        while (dao.getDataFormatVersionForSongs(bookName) != expected && System.currentTimeMillis() < deadline) {
+        while (current() != expected && System.currentTimeMillis() < deadline) {
             Thread.sleep(10)
         }
-        assertEquals(expected, dao.getDataFormatVersionForSongs(bookName))
+        assertEquals(expected, current())
     }
 }

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/room/SongRoomDaoTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/room/SongRoomDaoTest.kt
@@ -165,13 +165,6 @@ class SongRoomDaoTest {
     }
 
     @Test
-    fun `findDataFormatVersionForBookName returns null for empty book and the dataFormatVersion for present`() {
-        assertNull(dao.findDataFormatVersionForBookName("NKB"))
-        dao.insertSongInfo(songInfo(dataFormatVersion = 3))
-        assertEquals(3, dao.findDataFormatVersionForBookName("NKB"))
-    }
-
-    @Test
     fun `findUpdateTimeByBookNameAndCode returns null for missing and the updateTime for present`() {
         assertNull(dao.findUpdateTimeByBookNameAndCode("NKB", "missing"))
         dao.insertSongInfo(songInfo(code = "001", updateTime = 1_700_001_234))
@@ -179,32 +172,35 @@ class SongRoomDaoTest {
     }
 
     @Test
-    fun `replaceSongsForBookNameAndDataFormatVersion removes existing rows for the (bookName, dfv) tuple and inserts the new list`() {
+    fun `replaceSongsForBookName removes every existing row for the book regardless of dataFormatVersion and inserts the new list`() {
+        // A mixed-version book (REM-35): rows at several dataFormatVersions for the same book.
         dao.insertSongInfo(songInfo(code = "old1", dataFormatVersion = 3, ordering = 1))
-        dao.insertSongInfo(songInfo(code = "old2", dataFormatVersion = 3, ordering = 2))
-        dao.insertSongInfo(songInfo(code = "keep", dataFormatVersion = 2, ordering = 1))
+        dao.insertSongInfo(songInfo(code = "old2", dataFormatVersion = 5, ordering = 2))
+        // An unrelated book must survive untouched.
+        dao.insertSongInfo(songInfo(bookName = "PKJ", code = "keep", dataFormatVersion = 5, ordering = 1))
 
-        dao.replaceSongsForBookNameAndDataFormatVersion(
+        dao.replaceSongsForBookName(
             bookName = "NKB",
-            dataFormatVersion = 3,
             entities = listOf(
-                songInfo(code = "new1", dataFormatVersion = 3, ordering = 1),
-                songInfo(code = "new2", dataFormatVersion = 3, ordering = 2),
+                songInfo(code = "new1", dataFormatVersion = 5, ordering = 1),
+                songInfo(code = "new2", dataFormatVersion = 5, ordering = 2),
             ),
         )
 
-        val codes = dao.listSongInfosByBookName("NKB").map { it.code }.toSet()
+        val nkbCodes = dao.listSongInfosByBookName("NKB").map { it.code }.toSet()
         assertEquals(
-            "old rows at the matching dfv should be gone, the dfv=2 row should survive, and the two new rows should be present",
-            setOf("new1", "new2", "keep"),
-            codes,
+            "every old NKB row should be gone regardless of its dataFormatVersion, replaced by the new list",
+            setOf("new1", "new2"),
+            nkbCodes,
         )
+        val pkjCodes = dao.listSongInfosByBookName("PKJ").map { it.code }.toSet()
+        assertEquals("the unrelated book is untouched", setOf("keep"), pkjCodes)
     }
 
     @Test
-    fun `replaceSongsForBookNameAndDataFormatVersion is a clean wipe when passed an empty list`() {
+    fun `replaceSongsForBookName is a clean wipe when passed an empty list`() {
         dao.insertSongInfo(songInfo(code = "old1", dataFormatVersion = 3))
-        dao.replaceSongsForBookNameAndDataFormatVersion("NKB", 3, emptyList())
+        dao.replaceSongsForBookName("NKB", emptyList())
         assertTrue(dao.listSongInfosByBookName("NKB").isEmpty())
     }
 

--- a/docs/tech-debt-remediation/REM-35-songbook-update-dfv.md
+++ b/docs/tech-debt-remediation/REM-35-songbook-update-dfv.md
@@ -5,7 +5,7 @@
 **BRICE:** B=4 R=4 I=4 C=4 E=3 → **3.8**
 **Phase:** 1 — Quick Wins & Safety Fixes (2026-07 audit)
 
-**Status:** Not started.
+**Status:** Done (2026-07-20). `SongViewActivity.updateSongBook` now always requests and stores at `SongDocumentJson.DATA_FORMAT_VERSION` (with the `isSupportedDataFormatVersion` guard the `alkitab://` path has); `SongDb.storeSongs` dropped its `dataFormatVersion` parameter and always stamps rows at that version (the payload is always JSON); the replace primitive is now `SongRoomDao.replaceSongsForBookName` (delete by `bookName` alone), and the version-scoped `replaceSongsForBookNameAndDataFormatVersion` / `deleteSongInfosByBookNameAndDataFormatVersion` / `getDataFormatVersionForSongs` / `findDataFormatVersionForBookName` methods were removed as their last callers went away. Tests cover updating a mixed-version book (no duplicates, all rows at version 5, every row readable).
 
 **Problem:** After REM-21's lazy per-row conversion, a pre-REM-21 song book is mixed-`dataFormatVersion` (viewed rows at 5, unviewed rows still at 2/3/4). `updateSongBook()` feeds `getDataFormatVersionForSongs` (a `LIMIT 1` with no `ORDER BY` — nondeterministic for mixed books) into the re-download, and `storeSongs` deletes only rows matching that version while always writing JSON payloads. Result: duplicate songs, and/or JSON rows stamped with a legacy `dataFormatVersion` that crash on next read when dispatched to `LegacyParcelDecoder`.
 


### PR DESCRIPTION
## Problem

After REM-21's lazy per-row conversion, a pre-REM-21 song book can be **mixed-`dataFormatVersion`** — viewed rows already converted to JSON (version 5), unviewed rows still legacy Parcelable (2/3/4). The "Update Song Book" flow mishandled this:

- `updateSongBook()` fed `getDataFormatVersionForSongs()` — a `LIMIT 1` with **no `ORDER BY`**, so nondeterministic on a mixed book — into the re-download.
- `storeSongs()` deleted only the rows matching that version while **always writing JSON payloads**.

Result: duplicate songs, and/or JSON rows stamped with a legacy `dataFormatVersion` that crash on next read when dispatched to the legacy `Parcel` decoder.

## Changes

- **`SongViewActivity.updateSongBook`** now always requests and stores at `SongDocumentJson.DATA_FORMAT_VERSION`, with the `isSupportedDataFormatVersion` guard the `alkitab://` download path already has.
- **`SongDb.storeSongs`** drops its `dataFormatVersion` parameter and always stamps rows at `DATA_FORMAT_VERSION` — the payload it writes is always JSON anyway.
- The replace primitive is now **`SongRoomDao.replaceSongsForBookName`**, which deletes by `bookName` alone so a book update replaces the whole book regardless of the pre-existing rows' versions.
- Removed the now-unused `replaceSongsForBookNameAndDataFormatVersion`, `deleteSongInfosByBookNameAndDataFormatVersion`, `getDataFormatVersionForSongs`, and `findDataFormatVersionForBookName` (their last callers went away).

## Tests

- New `SongDbTest` case: updating a mixed-version book (a legacy dfv=3 row + a JSON dfv=5 row) → no duplicates, all rows at version 5, every row readable via `readDocument`.
- `SongRoomDaoTest` updated to cover `replaceSongsForBookName` removing every row for the book regardless of version, leaving unrelated books untouched.
- Verified locally: `./gradlew testPlainDebugUnitTest assemblePlainDebug` — full suite green, APK builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBmNFonQAvgi2fkeDkdH5D)_