### PR TITLE
Fix speed control clipping in audio bar on narrow screens

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -228,26 +228,22 @@ private fun AudioBarTopRow(
     state: AudioBarUiState,
     onCommand: (AudioBarCommand) -> Unit,
 ) {
-    // Icon-only top row — earlier iterations included chapter-name text
-    // labels next to the skip-prev/next buttons ("Yesaya 10", "Yesaya 12"),
-    // but on a phone screen they crowded out the speed indicator and forced
-    // the close button to wrap. The chapter label is also redundant: the
-    // toolbar already shows the user's current chapter, and skipping
-    // prev/next is a universally-understood control.
+    // Icon-only top row: a speed chip on the left, the transport cluster
+    // (chapter/verse skip + play/pause) centered, and a close button on the
+    // right. Chapter-name text labels are intentionally omitted — the toolbar
+    // already shows the current chapter, and on a phone they crowd out the
+    // speed indicator and force the close button to wrap.
     //
-    // Centering the transport cluster: the speed chip and close button take
-    // their intrinsic width and the cluster is centered between two weighted
-    // Spacers. An earlier version instead wrapped speed/close in equal
-    // `weight(1f)` Boxes — but a Row measures the non-weighted cluster first
-    // and splits the *remaining* width equally between the two weighted
-    // slots. Because the speed label ("0,5×") is wider than the close icon,
-    // that equal split starved the speed slot: its width was forced onto the
-    // TextButton and, with `maxLines = 1, softWrap = false` and no ellipsis,
-    // the trailing "×" was clipped (worse under large font scales, where the
-    // text grows but the icon buttons don't). Weighted Spacers keep the
-    // cluster centered when there's slack and simply collapse to zero when
-    // it's tight, so the speed label is never measured narrower than its
-    // content.
+    // The speed chip and close button take their intrinsic width, and the
+    // cluster is centered between two weighted Spacers that collapse to zero
+    // when the row is tight. Wrapping the speed chip in a `weight(1f)` slot
+    // instead would clip it: a Row measures the non-weighted cluster first
+    // and splits the remaining width equally between weighted slots, and
+    // because the speed label ("0,5×") is wider than the close icon, an equal
+    // split can force the TextButton narrower than its text — which, with
+    // `maxLines = 1, softWrap = false` and no ellipsis, drops the trailing
+    // "×" (worse under large font scales, where the text grows but the icon
+    // buttons don't).
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -234,35 +234,27 @@ private fun AudioBarTopRow(
     // the close button to wrap. The chapter label is also redundant: the
     // toolbar already shows the user's current chapter, and skipping
     // prev/next is a universally-understood control.
-    // Three-slot row: equal-weight side slots make the transport cluster
-    // geometrically centered regardless of the speed/close widths, while the
-    // Row layout (unlike a Box overlay) keeps the side controls from
-    // overlapping the cluster on narrow screens — the weighted slots shrink
-    // and the cluster keeps its intrinsic width.
+    //
+    // Centering the transport cluster: the speed chip and close button take
+    // their intrinsic width and the cluster is centered between two weighted
+    // Spacers. An earlier version instead wrapped speed/close in equal
+    // `weight(1f)` Boxes — but a Row measures the non-weighted cluster first
+    // and splits the *remaining* width equally between the two weighted
+    // slots. Because the speed label ("0,5×") is wider than the close icon,
+    // that equal split starved the speed slot: its width was forced onto the
+    // TextButton and, with `maxLines = 1, softWrap = false` and no ellipsis,
+    // the trailing "×" was clipped (worse under large font scales, where the
+    // text grows but the icon buttons don't). Weighted Spacers keep the
+    // cluster centered when there's slack and simply collapse to zero when
+    // it's tight, so the speed label is never measured narrower than its
+    // content.
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        // Speed chip — tapping opens the [SpeedBottomSheet]. `softWrap = false`
-        // keeps locales that render with a comma decimal (e.g. "1,0×" in
-        // Indonesian) from wrapping into a stacked "1," / "0×" when the row
-        // is tight.
-        val locale = appLocale()
-        Box(modifier = Modifier.weight(1f)) {
-            TextButton(
-                onClick = { onCommand(AudioBarCommand.Speed) },
-                modifier = Modifier
-                    .align(Alignment.CenterStart)
-                    .padding(horizontal = 4.dp),
-            ) {
-                Text(
-                    text = stringResource(R.string.audio_bar_speed_format, formatSpeedNumber(state.speed, locale)),
-                    style = MaterialTheme.typography.labelLarge,
-                    maxLines = 1,
-                    softWrap = false,
-                )
-            }
-        }
+        SpeedButton(state = state, onCommand = onCommand)
+
+        Spacer(Modifier.weight(1f))
 
         ChapterNavButton(
             available = state.prevChapterLabel != null,
@@ -286,17 +278,9 @@ private fun AudioBarTopRow(
             onClick = { onCommand(AudioBarCommand.NextChapter) },
         )
 
-        Box(modifier = Modifier.weight(1f)) {
-            IconButton(
-                onClick = { onCommand(AudioBarCommand.Close) },
-                modifier = Modifier.align(Alignment.CenterEnd),
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_audio_close),
-                    contentDescription = stringResource(R.string.audio_bar_close),
-                )
-            }
-        }
+        Spacer(Modifier.weight(1f))
+
+        CloseButton(onCommand = onCommand)
     }
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,7 @@ Detailed documentation for each major feature module:
 
 ## Code Conventions
 
+- **IMPORTANT — Never write change-narrating comments.** Code comments must describe the code as it is *now*, not the history of how it got there. Do not reference past revisions, removed approaches, or the act of editing: no "previously", "used to", "formerly", "earlier iterations", "an earlier version", "we changed/renamed/moved this from…", "now uses…", "no longer…", and the like. Git history is the record of *change*; the code and its comments describe the *present*. When explaining why the current design was chosen over an alternative is genuinely useful, state it as present-tense rationale about the alternative ("the cluster is centered with Spacers because a weighted slot would clip the label"), not as a story about what the code used to do. This applies to all comments, KDoc/Javadoc, and commit-adjacent code — keep the narrative of change out of the source.
 - Mixed Java/Kotlin codebase (Kotlin preferred for new code, many files still Java)
 - JVM toolchain 17 across all modules
 - No obfuscation in ProGuard (`-dontobfuscate`), only shrinking


### PR DESCRIPTION
## Problem

On narrower screens (and at large font scales), the playback-speed indicator in the Bible audio player's portrait top row is cropped — the trailing `×` of e.g. `0,5×` is cut off and the label is jammed against the left edge.

## Root cause

The speed chip was wrapped in an equal-weight `Box(Modifier.weight(1f))` alongside the close button. A Compose `Row` measures the non-weighted transport cluster (the 5 icon buttons + spacers) first at its intrinsic width, then splits the *remaining* width **equally** between the two weighted slots. Because the speed label is wider than the close icon, the equal split starves the speed slot: its width is forced onto the `TextButton`, and with `maxLines = 1`, `softWrap = false` and no ellipsis, the trailing character is clipped. Large font scales make it worse, since the text grows but the icon buttons do not.

## Fix

Center the transport cluster with weighted `Spacer`s instead, and let the speed chip and close button take their intrinsic width. The spacers keep the cluster centered when there's slack and collapse to zero when the row is tight, so the speed label is never measured narrower than its content. This reuses the existing `SpeedButton`/`CloseButton` composables already used by the landscape row.

## Testing

- `./gradlew assemblePlainDebug` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMfsMMmLuGgw2DQABPtHKK