### PR TITLE
Polish Compose sync login: Indonesian strings, narrow-screen wrapping, light-mode icon

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/compose/sync/SyncLoginScreen.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/compose/sync/SyncLoginScreen.kt
@@ -4,7 +4,6 @@ import android.text.method.LinkMovementMethod
 import android.widget.TextView
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -18,6 +17,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.CloudSync
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -50,11 +50,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.util.PatternsCompat
@@ -295,11 +295,15 @@ fun SyncLoginScreen(
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp, vertical = 8.dp),
         ) {
-            Image(
-                painter = painterResource(R.drawable.sync_intro),
+            // A theme-tinted vector, so it stays visible in both light and dark. (The legacy XML
+            // screen keeps its own raster illustration, which was drawn for a dark background.)
+            Icon(
+                imageVector = Icons.Filled.CloudSync,
                 contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier
-                    .padding(horizontal = 24.dp)
+                    .padding(top = 8.dp)
+                    .size(72.dp)
                     .align(Alignment.CenterHorizontally),
             )
 
@@ -310,13 +314,12 @@ fun SyncLoginScreen(
                     .align(Alignment.CenterHorizontally),
             )
 
-            // The primary-flow picker. Change-password is a secondary flow reached from the bottom
-            // link, so it isn't one of the segments.
-            if (mode != SyncLoginMode.CHANGE_PASSWORD) {
+            // The primary-flow picker has just the two account flows. Reset is reached from the
+            // "Forgot password?" link, and Change password from the link at the bottom.
+            if (mode == SyncLoginMode.SIGN_IN || mode == SyncLoginMode.CREATE_ACCOUNT) {
                 val segments = listOf(
                     SyncLoginMode.SIGN_IN to R.string.sync_login_mode_sign_in,
                     SyncLoginMode.CREATE_ACCOUNT to R.string.sync_login_mode_create_account,
-                    SyncLoginMode.RESET to R.string.sync_login_mode_reset,
                 )
                 SingleChoiceSegmentedButtonRow(
                     modifier = Modifier
@@ -329,8 +332,14 @@ fun SyncLoginScreen(
                             onClick = { switchMode(segMode) },
                             enabled = !submitting,
                             shape = SegmentedButtonDefaults.itemShape(index, segments.size),
+                            // Drop the check icon: on narrow (~320dp) screens it steals the width the
+                            // label needs, forcing an ellipsis. Without it the label can wrap instead.
+                            icon = {},
                         ) {
-                            Text(stringResource(labelRes))
+                            Text(
+                                text = stringResource(labelRes),
+                                textAlign = TextAlign.Center,
+                            )
                         }
                     }
                 }
@@ -463,7 +472,7 @@ fun SyncLoginScreen(
                 }
             }
 
-            if (mode == SyncLoginMode.CHANGE_PASSWORD) {
+            if (mode == SyncLoginMode.RESET || mode == SyncLoginMode.CHANGE_PASSWORD) {
                 TextButton(
                     onClick = { switchMode(SyncLoginMode.SIGN_IN) },
                     enabled = !submitting,

--- a/Alkitab/src/main/res/values-in/strings.xml
+++ b/Alkitab/src/main/res/values-in/strings.xml
@@ -381,6 +381,17 @@
     <string name="sync_login_dialog_confirm_password_hint">Ketik ulang password</string>
     <string name="sync_login_form_forgot_password_success">Periksa email untuk arahan selanjutnya.</string>
     <string name="sync_login_form_change_password_success">Password sudah diganti.</string>
+    <string name="sync_login_form_confirm_password_mismatch">Password tidak sama.</string>
+    <string name="sync_login_form_show_password">Tampilkan password</string>
+    <string name="sync_login_form_hide_password">Sembunyikan password</string>
+    <string name="sync_login_mode_sign_in">Login</string>
+    <string name="sync_login_mode_create_account">Buat akun</string>
+    <string name="sync_login_reset_password_title">Atur ulang password</string>
+    <string name="sync_login_action_send_reset_email">Kirim email atur ulang</string>
+    <string name="sync_login_forgot_password_link">Lupa password?</string>
+    <string name="sync_login_reset_password_help">Masukkan email akun Anda dan kami akan mengirim tautan untuk mengatur ulang password Anda.</string>
+    <string name="sync_login_current_password_hint">Password saat ini</string>
+    <string name="sync_login_back_to_sign_in">Kembali ke login</string>
     <string name="pref_textPadding_title">Beri jarak sekitar teks</string>
     <string name="pref_textPadding_summary">Lebih sedikit teks per barisnya agar mudah dibaca</string>
     <string name="pref_bottomToolbarOnText_title">Navigasi ayat di bawah</string>

--- a/Alkitab/src/main/res/values/strings.xml
+++ b/Alkitab/src/main/res/values/strings.xml
@@ -422,7 +422,6 @@
 	<string name="sync_login_dialog_confirm_password_hint">Confirm password</string>
 	<string name="sync_login_mode_sign_in">Sign in</string>
 	<string name="sync_login_mode_create_account">Create account</string>
-	<string name="sync_login_mode_reset">Reset</string>
 	<string name="sync_login_reset_password_title">Reset password</string>
 	<string name="sync_login_action_send_reset_email">Send reset email</string>
 	<string name="sync_login_forgot_password_link">Forgot password?</string>


### PR DESCRIPTION
Follow-up to #247, addressing feedback on the experimental Compose sync login screen. All changes stay behind the `useComposeSyncLogin` flag; the legacy XML screen is untouched.

## Fixes

**1. Localization** — the strings the new screen introduced only existed in the default (English) resources, so an app set to Indonesian fell back to English for the mode pills, buttons and labels. Added `values-in` (Indonesian) translations for all of them (matching existing app terminology, e.g. "Login", "Buat akun", "Lupa password?", "Ganti password"). Verified by rendering the screen under an Indonesian locale.

**2. Segmented control on narrow screens** — dropped **Reset** as a segment (the "Forgot password?" link already leads there), leaving just **Sign in | Create account**. In reset mode the segmented control now hides (like change-password) and offers "Back to sign in". Removed the per-segment check icon and centered + wrapped the label, so long text like "Create account" **wraps to a second line instead of ellipsizing** at ~320dp. Verified by rendering at 320dp (fits on one line) and at a forced-narrow width (wraps cleanly, segment grows in height).

**3. Header illustration in light mode** — the raster `sync_intro` art was drawn for the dark legacy background (white/light line-art) and nearly disappears on the light Compose surface. Replaced it, **in Compose only**, with a theme-tinted `CloudSync` vector icon that reads well in both light and dark. The legacy XML screen keeps the original raster art.

## Testing

- `./gradlew assemblePlainDebug` succeeds.
- Rendered the screen via Robolectric at 320dp, a forced-narrow width, and under an Indonesian locale to confirm all three fixes (the throwaway render test was removed before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmHAcCoZPpg1ykDXaEhjVj)_