### PR TITLE
Scroll songs, devotion, reading plan and markers behind the nav bar

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/DevotionActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/DevotionActivity.java
@@ -224,7 +224,7 @@ public class DevotionActivity extends BaseLeftDrawerActivity implements LeftDraw
 
         final Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-        setupEdgeToEdgeDisplay(toolbar);
+        setupEdgeToEdgeDisplayWithoutBottomInset(toolbar);
 
         final ActionBar actionBar = getSupportActionBar();
         assert actionBar != null;
@@ -234,6 +234,7 @@ public class DevotionActivity extends BaseLeftDrawerActivity implements LeftDraw
         root = findViewById(R.id.root);
         lContent = findViewById(R.id.lContent);
         scrollContent = findViewById(R.id.scrollContent);
+        applyScrollPastBottomInset(scrollContent);
 
         root.setTwofingerEnabled(false);
         root.setListener(root_listener);

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/MarkerListActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/MarkerListActivity.kt
@@ -97,7 +97,7 @@ class MarkerListActivity : BaseActivity() {
 
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
-        setupEdgeToEdgeDisplay(toolbar)
+        setupEdgeToEdgeDisplayWithoutBottomInset(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
         root = findViewById(R.id.root)
@@ -106,6 +106,7 @@ class MarkerListActivity : BaseActivity() {
         bClearFilter = findViewById(R.id.bClearFilter)
         progress = findViewById(R.id.progress)
         lv = findViewById(android.R.id.list)
+        applyScrollPastBottomInset(lv)
 
         filter_kind = Marker.Kind.fromCode(intent.getIntExtra(EXTRA_filter_kind, 0)) ?: error("Must specify marker kind")
         filter_labelId = intent.getLongExtra(EXTRA_filter_labelId, 0)

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/MarkersActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/MarkersActivity.java
@@ -17,6 +17,9 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -49,6 +52,7 @@ public class MarkersActivity extends BaseActivity {
 
     RecyclerView lv;
     View bGotoSync;
+    View panelGotoSync;
 
     MarkerFilterAdapter adapter;
     ItemTouchHelper itemTouchHelper;
@@ -64,7 +68,7 @@ public class MarkersActivity extends BaseActivity {
 
         final Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-        setupEdgeToEdgeDisplay(toolbar);
+        setupEdgeToEdgeDisplayWithoutBottomInset(toolbar);
         final ActionBar ab = getSupportActionBar();
         assert ab != null;
         ab.setDisplayHomeAsUpEnabled(true);
@@ -82,6 +86,29 @@ public class MarkersActivity extends BaseActivity {
         bGotoSync = findViewById(R.id.bGotoSync);
         bGotoSync.setOnClickListener(v -> startActivity(SyncSettingsActivity.createIntent()));
 
+        panelGotoSync = findViewById(R.id.panelGotoSync);
+        final int panelGotoSyncHeight = panelGotoSync.getLayoutParams().height;
+
+        // The sync panel, when shown, is the bar the window bottom belongs to:
+        // it grows by the inset so its background reaches under the navigation
+        // bar while the button stays above.
+        ViewCompat.setOnApplyWindowInsetsListener(panelGotoSync, (v, windowInsets) -> {
+            final Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), insets.bottom);
+            final ViewGroup.LayoutParams lp = v.getLayoutParams();
+            lp.height = panelGotoSyncHeight + insets.bottom;
+            v.setLayoutParams(lp);
+            return windowInsets;
+        });
+
+        lv.setClipToPadding(false);
+        ViewCompat.setOnApplyWindowInsetsListener(lv, (v, windowInsets) -> {
+            final Insets insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            final int bottom = panelGotoSync.getVisibility() == View.VISIBLE ? 0 : insets.bottom;
+            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), bottom);
+            return windowInsets;
+        });
+
         AppEvents.observe(this, AppEvents.markersReload, () -> adapter.reload());
     }
 
@@ -91,7 +118,9 @@ public class MarkersActivity extends BaseActivity {
 
         // hide sync button if we are already syncing
         final String syncAccountName = Preferences.getString(R.string.pref_syncAccountName_key);
-        findViewById(R.id.panelGotoSync).setVisibility(syncAccountName != null ? View.GONE : View.VISIBLE);
+        panelGotoSync.setVisibility(syncAccountName != null ? View.GONE : View.VISIBLE);
+        // the panel that just appeared or went away decides whether the list takes the bottom inset
+        ViewCompat.requestApplyInsets(lv);
     }
 
     @Override

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/ReadingPlanActivity.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/ReadingPlanActivity.java
@@ -108,7 +108,7 @@ public class ReadingPlanActivity extends BaseLeftDrawerActivity implements LeftD
 
         final Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-        setupEdgeToEdgeDisplay(toolbar);
+        setupEdgeToEdgeDisplayWithoutBottomInset(toolbar);
 
         actionBar = getSupportActionBar();
         assert actionBar != null;
@@ -120,6 +120,7 @@ public class ReadingPlanActivity extends BaseLeftDrawerActivity implements LeftD
 
         lsReadingPlan = findViewById(R.id.lsTodayReadings);
         lsReadingPlan.setAdapter(readingPlanAdapter = new ReadingPlanAdapter());
+        applyScrollPastBottomInset(lsReadingPlan);
 
         bToday = findViewById(R.id.bToday);
         bToday.setOnClickListener(new View.OnClickListener() {

--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/base/BaseActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/base/BaseActivity.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.util.TypedValue
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.activity.enableEdgeToEdge
 import androidx.annotation.CallSuper
@@ -119,6 +120,32 @@ abstract class BaseActivity : AppCompatActivity() {
      * [applySafeAreaPadding] separately.
      */
     protected fun setupEdgeToEdgeDisplay(toolbar: Toolbar) {
+        setupEdgeToEdgeToolbar(toolbar)
+        setupContainerInsets(toolbar.parent as View, includeTop = false, includeBottom = true)
+    }
+
+    /**
+     * [setupEdgeToEdgeDisplay] for an activity whose content scrolls behind
+     * the navigation bar: the container keeps its bottom edge at the window
+     * bottom and the content itself adds the bottom inset as scroll-past
+     * padding. The keyboard inset is left out as well, so this suits content
+     * without text input.
+     */
+    protected fun setupEdgeToEdgeDisplayWithoutBottomInset(toolbar: Toolbar) {
+        setupEdgeToEdgeToolbar(toolbar)
+        setupContainerInsets(toolbar.parent as View, includeTop = false, includeBottom = false)
+    }
+
+    /**
+     * [setupEdgeToEdgeDisplay] for an activity whose layout has no toolbar:
+     * the whole container is padded into the safe area, including the top.
+     */
+    protected fun setupEdgeToEdgeDisplayWithoutToolbar(container: View) {
+        enableEdgeToEdgeInternal(hasToolbar = false)
+        setupContainerInsets(container, includeTop = true, includeBottom = true)
+    }
+
+    private fun setupEdgeToEdgeToolbar(toolbar: Toolbar) {
         enableEdgeToEdgeInternal(hasToolbar = true)
 
         val tv = TypedValue()
@@ -131,17 +158,21 @@ abstract class BaseActivity : AppCompatActivity() {
             v.updateLayoutParams { height = actionBarSize + insets.top }
             windowInsets
         }
-
-        setupContainerInsets(toolbar.parent as View, includeTop = false)
     }
 
     /**
-     * [setupEdgeToEdgeDisplay] for an activity whose layout has no toolbar:
-     * the whole container is padded into the safe area, including the top.
+     * Lets a scrolling view's content draw through the bottom system bar
+     * while keeping its last item scrollable clear of that bar, the way the
+     * verse list behaves. Pairs with [setupEdgeToEdgeDisplayWithoutBottomInset].
      */
-    protected fun setupEdgeToEdgeDisplayWithoutToolbar(container: View) {
-        enableEdgeToEdgeInternal(hasToolbar = false)
-        setupContainerInsets(container, includeTop = true)
+    protected fun applyScrollPastBottomInset(view: ViewGroup) {
+        val basePaddingBottom = view.paddingBottom
+        view.clipToPadding = false
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, windowInsets ->
+            val insets = windowInsets.getInsets(SAFE_AREA_TYPES)
+            v.updatePadding(bottom = basePaddingBottom + insets.bottom)
+            windowInsets
+        }
     }
 
     /**
@@ -165,7 +196,7 @@ abstract class BaseActivity : AppCompatActivity() {
         }
     }
 
-    private fun setupContainerInsets(container: View, includeTop: Boolean) {
+    private fun setupContainerInsets(container: View, includeTop: Boolean, includeBottom: Boolean) {
         val basePadding = Rect(container.paddingLeft, container.paddingTop, container.paddingRight, container.paddingBottom)
         ViewCompat.setOnApplyWindowInsetsListener(container) { v, windowInsets ->
             val insets = windowInsets.getInsets(SAFE_AREA_TYPES or WindowInsetsCompat.Type.ime())
@@ -173,7 +204,7 @@ abstract class BaseActivity : AppCompatActivity() {
                 basePadding.left + insets.left,
                 basePadding.top + if (includeTop) insets.top else 0,
                 basePadding.right + insets.right,
-                basePadding.bottom + insets.bottom,
+                basePadding.bottom + if (includeBottom) insets.bottom else 0,
             )
             windowInsets
         }

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongComposeContent.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongComposeContent.kt
@@ -5,9 +5,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
@@ -132,12 +135,18 @@ fun SongDocumentComposable(
         // long-press to select and copy any part of the lyrics. Scripture,
         // YouTube, and patch-text links inside stay tappable.
         SelectionContainer {
+            // Room to scroll the last line clear of the navigation bar the
+            // song draws behind.
+            val bottomInset = WindowInsets.safeDrawing
+                .asPaddingValues()
+                .calculateBottomPadding()
+
             Box(
                 modifier = modifier
                     .fillMaxWidth()
                     .verticalScroll(rememberScrollState())
                     // body padding: 16px vertical, 8px horizontal (song.html <body>)
-                    .padding(horizontal = 8.dp, vertical = 16.dp),
+                    .padding(start = 8.dp, top = 16.dp, end = 8.dp, bottom = 16.dp + bottomInset),
             ) {
                 Column(modifier = Modifier.fillMaxWidth()) {
                     // The song code sits in the left gutter; when the first block is the

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongFragment.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongFragment.kt
@@ -9,7 +9,10 @@ import android.view.ViewGroup
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.postDelayed
+import kotlin.math.roundToInt
 import yuku.alkitab.base.fr.base.BaseFragment
 import yuku.alkitab.debug.R
 import yuku.alkitab.songs.newdoc.SongDocument
@@ -18,6 +21,7 @@ import yuku.alkitab.songs.newdoc.SongDocumentRenderer
 
 class SongFragment : BaseFragment(), SongTextZoomable {
     private lateinit var webview: WebView
+    private var bottomInsetDp = 0
 
     private val args by lazy { requireArguments() }
     private val doc: SongDocument by lazy { SongDocumentJson.decode(args.getString(ARG_songJson)!!) }
@@ -44,6 +48,13 @@ class SongFragment : BaseFragment(), SongTextZoomable {
             textZoom = 100
         }
 
+        ViewCompat.setOnApplyWindowInsetsListener(webview) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+            bottomInsetDp = (insets.bottom / v.resources.displayMetrics.density).roundToInt()
+            applyBottomInset()
+            windowInsets
+        }
+
         return res
     }
 
@@ -52,10 +63,26 @@ class SongFragment : BaseFragment(), SongTextZoomable {
         renderSong(doc)
     }
 
+    /**
+     * Gives the page room to scroll its last line clear of the navigation bar
+     * it draws behind. The margin belongs to the document rather than to the
+     * WebView, whose padding would shorten the viewport and keep the lyrics
+     * out of the area behind the bar altogether. CSS pixels are device-
+     * independent pixels here, the same unit the template's font sizes use.
+     */
+    private fun applyBottomInset() {
+        webview.evaluateJavascript("document.body.style.marginBottom = '${bottomInsetDp}px';", null)
+    }
+
     private val webViewClient: WebViewClient = object : WebViewClient() {
         override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
             val activity: Activity? = activity
             return activity is ShouldOverrideUrlLoadingHandler && activity.shouldOverrideUrlLoading(this, request) || super.shouldOverrideUrlLoading(view, request)
+        }
+
+        override fun onPageFinished(view: WebView, url: String?) {
+            super.onPageFinished(view, url)
+            applyBottomInset()
         }
 
         var pendingResize = false

--- a/Alkitab/src/main/java/yuku/alkitab/songs/SongViewActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/songs/SongViewActivity.kt
@@ -243,7 +243,7 @@ class SongViewActivity : BaseLeftDrawerActivity(), SongFragment.ShouldOverrideUr
 
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
-        setupEdgeToEdgeDisplay(toolbar)
+        setupEdgeToEdgeDisplayWithoutBottomInset(toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.setHomeAsUpIndicator(R.drawable.ic_menu_white_24dp)
 

--- a/Alkitab/src/main/res/layout/activity_markers.xml
+++ b/Alkitab/src/main/res/layout/activity_markers.xml
@@ -16,7 +16,10 @@
 		android:layout_height="0dp"
 		android:layout_weight="1" />
 
-	<RelativeLayout
+	<!-- A FrameLayout, not a RelativeLayout: gravity honors the bottom padding
+	     that keeps the button out of the navigation bar the panel extends
+	     behind, while centerVertical would ignore it. -->
+	<FrameLayout
 		android:id="@+id/panelGotoSync"
 		android:layout_width="match_parent"
 		android:layout_height="52dp"
@@ -27,12 +30,11 @@
 			style="?buttonBarButtonStyle"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
-			android:layout_alignParentEnd="true"
-			android:layout_centerVertical="true"
+			android:layout_gravity="center_vertical|end"
 			android:background="?selectableItemBackgroundBorderless"
 			android:padding="16dp"
 			android:text="@string/bl_sync_suggest"
 			android:textColor="#fff" />
-	</RelativeLayout>
+	</FrameLayout>
 
 </LinearLayout>


### PR DESCRIPTION
The songs, devotion, reading plan, markers and marker list screens stopped their content above the navigation bar instead of drawing through it like the verse reader. `setupEdgeToEdgeDisplay` pads the toolbar's parent container by the bottom inset, so on a 720x1280 gesture-nav device the content container ended at y=1244. On the devotion screen the leftover band showed the transparent window as a black bar, since only the scroll view carries the reading background.

## Approach

`BaseActivity` gains the two pieces these screens share:

- `setupEdgeToEdgeDisplayWithoutBottomInset` — keeps the container's bottom edge at the window bottom.
- `applyScrollPastBottomInset` — gives a scrolling view `clipToPadding=false` plus the bottom inset as padding, so content draws through the bar while the last item still scrolls clear of it. This is what the verse list already does via `setViewVerticalInsets`.

The devotion scroll view, reading plan list and marker list use both. The songs screen needs one per renderer:

- Compose viewer: the inset is added inside the scrolling `Box`, following the `AudioBar` precedent.
- WebView viewer: the document's bottom margin is set from the inset. View padding would shorten the viewport instead, which keeps the lyrics out of the area behind the bar rather than letting them scroll through it.

On the markers screen the sync suggestion panel, when shown, is the view the window bottom belongs to, so it grows by the inset (background under the bar, button above) and the list takes the inset only when the panel is hidden. That panel becomes a `FrameLayout` — `RelativeLayout`'s `centerVertical` ignores padding, which left the button in the gesture area at 1184-1262 instead of ending at 1244.

## Verification

Built and driven on an API 35 emulator (720x1280, gesture nav, 36px bottom inset). Content containers measured before -> after:

| Screen | Before | After |
| --- | --- | --- |
| Songs (Compose) | `[0,220][720,1244]` | `[0,220][720,1280]` |
| Songs (WebView) | text clipped at 1244 | text nodes render down to 1280 |
| Devotion | `[0,220][720,1244]` | `[0,220][720,1280]` |
| Reading plan | list capped at 1244 | `[0,305][720,1280]` |
| Markers | `[0,220][720,1244]` | `[0,220][720,1280]`, or `[0,220][720,1166]` with the sync panel at `[0,1166][720,1280]` |
| Marker list | `[0,220][720,1244]` | `[0,220][720,1280]` |

At maximum scroll the last line still rests above the gesture bar on every screen, so nothing is hidden at rest.

The markers panel switching visibility while the activity is alive was exercised by temporarily flipping the condition in `onStart`: `GONE -> VISIBLE` shrinks the list to 1166, and `VISIBLE -> GONE` restores both the full height and the scroll-past padding (bottom row rests at 1244, not 1280). The temporary toggle was reverted before this commit.

Settings was checked as a control and still ends at 1244, so screens on the original helper are untouched. `assemblePlainDebug`, `testPlainDebugUnitTest` and `testPlainReleaseUnitTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
