### PR TITLE
Pin Compose surfaces to a dark scheme

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioTheme.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioTheme.kt
@@ -1,12 +1,8 @@
 package yuku.alkitab.base.audio.ui
 
-import android.content.res.Configuration
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalConfiguration
 
 /**
  * Single Compose theme used by every audio-bar surface ([AudioBar],
@@ -15,22 +11,15 @@ import androidx.compose.ui.platform.LocalConfiguration
  * Material 3 [MaterialTheme] here, rather than threading one through every
  * call site.
  *
- * Strategy: derive the color scheme from [isSystemInDarkTheme] (which already
- * follows AppCompat's `MODE_NIGHT_*` setting via the activity's resources
- * configuration) so the bar picks up the same light/dark state as the rest of
- * the app — without us having to re-implement custom-theme selection in
- * Compose. When users override the reading theme to e.g. sepia, that's a
- * concern of [AudioHighlightColor], not the bar chrome.
+ * The scheme is dark whatever the system theme is, for the reason
+ * [yuku.alkitab.base.compose.BibleAppTheme] gives. When users override the
+ * reading theme to e.g. sepia, that's a concern of [AudioHighlightColor], not
+ * the bar chrome.
  */
 @Composable
 fun AudioTheme(content: @Composable () -> Unit) {
-    val isDark = LocalConfiguration.current.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
-        Configuration.UI_MODE_NIGHT_YES || isSystemInDarkTheme()
-
-    val colorScheme = if (isDark) darkColorScheme() else lightColorScheme()
-
     MaterialTheme(
-        colorScheme = colorScheme,
+        colorScheme = darkColorScheme(),
         content = content,
     )
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/compose/BibleAppTheme.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/compose/BibleAppTheme.kt
@@ -1,34 +1,34 @@
 package yuku.alkitab.base.compose
 
 import android.os.Build
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import yuku.alkitab.base.util.BookColorUtil
 
+/**
+ * Theme for the app's Compose surfaces.
+ *
+ * The scheme is dark whatever the system theme is, because the XML screens
+ * these surfaces sit among are dark unconditionally: the base theme descends
+ * from a dark MaterialComponents theme and the app never sets a night mode.
+ * A surface that followed the system would be the only light thing in an
+ * otherwise dark app. Once the remaining XML screens are ported, the whole app
+ * can follow the system together.
+ */
 @Composable
 fun BibleAppTheme(content: @Composable () -> Unit) {
-    val dark = isSystemInDarkTheme()
     val ctx = LocalContext.current
     val colors = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        if (dark) dynamicDarkColorScheme(ctx) else dynamicLightColorScheme(ctx)
+        dynamicDarkColorScheme(ctx)
     } else {
-        if (dark) darkColorScheme() else lightColorScheme()
+        darkColorScheme()
     }
     MaterialTheme(colorScheme = colors, content = content)
 }
 
-/** Theme-aware book name color. Picks [BookColorUtil.getForegroundOnDark] or
- *  [BookColorUtil.getForegroundOnLight] based on the current Compose theme. */
-@Composable
-fun bookForegroundColor(bookId: Int): Color = if (isSystemInDarkTheme()) {
-    Color(BookColorUtil.getForegroundOnDark(bookId))
-} else {
-    Color(BookColorUtil.getForegroundOnLight(bookId))
-}
+/** Book name color legible on the dark surfaces Compose draws. */
+fun bookForegroundColor(bookId: Int): Color = Color(BookColorUtil.getForegroundOnDark(bookId))


### PR DESCRIPTION
The XML screens are dark unconditionally — the base theme descends from a dark MaterialComponents theme and the app never sets a night mode — while the Compose surfaces derived their scheme from the system setting. On a device in light mode that made the Compose screens the only light things in an otherwise dark app.

## Approach

The system-following lived in exactly two functions, and every Compose surface routes through one of them:

- `BibleAppTheme` — Goto screen, text appearance panel, sync login, and everything hosted by `ComposeBottomSheetHost` (highlight sheet, color picker, song search sheet).
- `AudioTheme` — audio bar, speed sheet, source picker dialog.

Both now pick a dark scheme whatever the system theme is. `bookForegroundColor` follows, always returning the on-dark variant, so it no longer needs to be a composable. Dynamic color on Android 12+ is unchanged — it is just always the dark scheme. A grep confirms no `isSystemInDarkTheme`, `lightColorScheme` or `UI_MODE_NIGHT` read remains in the Compose code.

Following the system is worth doing once most of the UI is ported to Compose and the app can switch as a whole; each theme carries a comment saying so.

## Verification

Driven on an API 35 emulator with the system in **light** mode, which is what exposes the mismatch. Every surface renders dark after the change:

- Goto screen — type tab, and the book grid whose colors switch to the on-dark pink/blue
- Song search sheet (`ComposeBottomSheetHost`)
- Compose sync login
- Audio bar

`assemblePlainDebug`, `testPlainDebugUnitTest` and `testPlainReleaseUnitTest` pass.

## Notes

- The Compose song viewer and `VerseItemCompose` have no theme wrapper — they paint from the reading preferences and never followed the system, so they are untouched.
- `BookColorUtil.getForegroundOnLight` is now unused. It is kept deliberately: it is one of a symmetric trio of color helpers and is what the eventual system-following work needs back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
