### PR TITLE
Compose night theme polish: highlight sheet, Goto background

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioTheme.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioTheme.kt
@@ -1,25 +1,19 @@
 package yuku.alkitab.base.audio.ui
 
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
+import yuku.alkitab.base.compose.BibleAppTheme
 
 /**
  * Single Compose theme used by every audio-bar surface ([AudioBar],
- * future speed bottom sheet). The audio bar is the project's first Compose
- * surface, so we own the bridge between the existing AppCompat theme and a
- * Material 3 [MaterialTheme] here, rather than threading one through every
- * call site.
+ * [SpeedBottomSheet]). It delegates to [yuku.alkitab.base.compose.BibleAppTheme]
+ * so the bar chrome draws from the very same palette as the rest of the app's
+ * Compose surfaces — the bar sits directly against them, so any divergence
+ * (e.g. one scheme dynamic and the other not) shows up as a mismatched grey.
  *
- * The scheme is dark whatever the system theme is, for the reason
- * [yuku.alkitab.base.compose.BibleAppTheme] gives. When users override the
- * reading theme to e.g. sepia, that's a concern of [AudioHighlightColor], not
- * the bar chrome.
+ * When users override the reading theme to e.g. sepia, that's a concern of
+ * [AudioHighlightColor], not the bar chrome.
  */
 @Composable
 fun AudioTheme(content: @Composable () -> Unit) {
-    MaterialTheme(
-        colorScheme = darkColorScheme(),
-        content = content,
-    )
+    BibleAppTheme(content)
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/GotoScreen.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/GotoScreen.kt
@@ -68,11 +68,14 @@ fun GotoScreen(
     var menuOpen by remember { mutableStateOf(false) }
 
     Scaffold(
+        // Same role the audio bar paints itself with, so the two read as one
+        // surface when the bar is showing over the reader behind this screen.
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
         topBar = {
             // Single bar: back button, tabs (taking remaining width), overflow menu —
             // mirroring the legacy XML where TabLayout sat inside Toolbar.
             Surface(
-                color = MaterialTheme.colorScheme.surface,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
                 tonalElevation = 0.dp,
             ) {
                 Row(

--- a/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/GridTab.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/compose/goto/GridTab.kt
@@ -169,7 +169,9 @@ private fun NumericGrid(count: Int, onClick: (Int) -> Unit) {
 private fun GridCell(text: String, color: Color, onClick: () -> Unit) {
     Surface(
         onClick = onClick,
-        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        // One step above the screen background so the cells stay readable as
+        // discrete tiles instead of merging into one slab.
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
         modifier = Modifier.fillMaxWidth().height(48.dp).padding(2.dp),
     ) {
         Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxWidth()) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/dialog/TypeHighlightDialog.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/dialog/TypeHighlightDialog.kt
@@ -20,8 +20,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
@@ -39,6 +37,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
@@ -102,6 +101,7 @@ class TypeHighlightDialog {
         verseText: CharSequence?,
     ) {
         val activity = context.findActivity() ?: return
+        val hasExistingHighlight = App.services.storage.db.anyVerseHasHighlight(ariBookChapter, selectedVerses)
         ComposeBottomSheetHost.show(activity) { dismiss ->
             HighlightSheetContent(
                 title = title,
@@ -109,6 +109,7 @@ class TypeHighlightDialog {
                 selectedVerseCount = selectedVerses.size(),
                 defaultColorRgb = defaultColorRgb,
                 info = info,
+                hasExistingHighlight = hasExistingHighlight,
                 onPickColor = { colorRgb, range ->
                     applySelection(ariBookChapter, selectedVerses, colorRgb, range, verseText)
                     listener.onOk(colorRgb)
@@ -199,6 +200,7 @@ private fun HighlightSheetContent(
     selectedVerseCount: Int,
     defaultColorRgb: Int,
     info: Highlights.Info?,
+    hasExistingHighlight: Boolean,
     onPickColor: (colorRgb: Int, range: Pair<Int, Int>?) -> Unit,
     onOpenColorPicker: (currentColorRgb: Int, currentRange: Pair<Int, Int>?) -> Unit,
     onDelete: () -> Unit,
@@ -236,7 +238,7 @@ private fun HighlightSheetContent(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
-                imageVector = Icons.Filled.Star,
+                painter = painterResource(R.drawable.ic_ink_highlighter),
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.size(24.dp),
@@ -277,8 +279,10 @@ private fun HighlightSheetContent(
         Spacer(Modifier.height(16.dp))
 
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            TextButton(onClick = onDelete) {
-                Text(stringResource(R.string.delete))
+            if (hasExistingHighlight) {
+                TextButton(onClick = onDelete) {
+                    Text(stringResource(R.string.delete))
+                }
             }
             Spacer(Modifier.weight(1f))
             TextButton(onClick = onCancel) {
@@ -293,21 +297,31 @@ private fun HighlightSheetContent(
     }
 }
 
-/** Read-only verse text. Drag-select within it picks the partial-highlight range. */
+/**
+ * Read-only verse text. Drag-select within it picks the partial-highlight range.
+ *
+ * It sits on the reading background so the verse reads the same here as it does
+ * in [yuku.alkitab.base.IsiActivity], where the user just selected it.
+ */
 @Composable
 private fun VerseTextSelectable(
     value: TextFieldValue,
     onValueChange: (TextFieldValue) -> Unit,
 ) {
+    val applied = App.services.uiDimensions.applied()
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
         readOnly = true,
         textStyle = LocalTextStyle.current.copy(
-            color = Color(App.services.uiDimensions.applied().fontColor),
+            color = Color(applied.fontColor),
             fontSize = 16.sp,
         ),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .background(Color(applied.backgroundColor))
+            .padding(8.dp),
     )
 }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/storage/InternalDb.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/storage/InternalDb.java
@@ -353,6 +353,35 @@ public class InternalDb {
     }
 
     /**
+     * Whether at least one of the selected verses currently has a highlight.
+     *
+     * <p>This is not the same as {@link #getHighlightColorRgb(int, IntArrayList)} returning -1:
+     * that also happens when the selected verses carry a mix of colors.
+     */
+    public boolean anyVerseHasHighlight(int ari_bookchapter, IntArrayList selectedVerses_1) {
+        int ariMin = ari_bookchapter & 0xffffff00;
+        int ariMax = ari_bookchapter | 0x000000ff;
+        boolean[] highlighted = new boolean[256];
+
+        try (Cursor c = helper.getReadableDatabase().query(
+            Db.TABLE_Marker, new String[]{Db.Marker.ari}, Db.Marker.ari + ">? and " + Db.Marker.ari + "<=? and " + Db.Marker.kind + "=?",
+            new String[]{String.valueOf(ariMin), String.valueOf(ariMax), String.valueOf(Marker.Kind.highlight.code)},
+            null, null, null
+        )) {
+            final int col_ari = c.getColumnIndexOrThrow(Db.Marker.ari);
+
+            while (c.moveToNext()) {
+                highlighted[c.getInt(col_ari) & 0xff] = true;
+            }
+        }
+
+        for (int i = 0; i < selectedVerses_1.size(); i++) {
+            if (highlighted[selectedVerses_1.get(i)]) return true;
+        }
+        return false;
+    }
+
+    /**
      * Get the highlight info for a single verse
      */
     public Highlights.Info getHighlightColorRgb(final int ari) {

--- a/Alkitab/src/main/res/drawable/ic_ink_highlighter.xml
+++ b/Alkitab/src/main/res/drawable/ic_ink_highlighter.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+	android:width="24dp"
+	android:height="24dp"
+	android:viewportWidth="960"
+	android:viewportHeight="960">
+	<!-- Material Symbols "ink_highlighter". The artwork is authored in a
+		"0 -960 960 960" viewBox, so the group shifts it down into Android's
+		"0 0 960 960" viewport. -->
+	<group android:translateY="960">
+		<path
+			android:fillColor="#fff"
+			android:pathData="M544-400 440-504 240-304l104 104 200-200Zm-47-161 104 104 199-199-104-104-199 199Zm-84-28 216 216-229 229q-24 24-56 24t-56-24l-2-2-26 26H60l126-126-2-2q-24-24-24-56t24-56l229-229Zm0 0 227-227q24-24 56-24t56 24l104 104q24 24 24 56t-24 56L629-373 413-589Z" />
+	</group>
+</vector>

--- a/Alkitab/src/test/java/yuku/alkitab/base/storage/InternalDbTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/storage/InternalDbTest.kt
@@ -3,6 +3,7 @@ package yuku.alkitab.base.storage
 import android.app.Application
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -531,6 +532,43 @@ class InternalDbTest {
         val ariBc = Ari.encode(0, 1, 0)
         val verses = IntArrayList().apply { add(1); add(2) }
         assertEquals(-1, db.getHighlightColorRgb(ariBc, verses))
+    }
+
+    @Test
+    fun `anyVerseHasHighlight is false when none of the selected verses are highlighted`() {
+        val ariBc = Ari.encode(0, 1, 0)
+        db.updateOrInsertHighlights(ariBc, IntArrayList().apply { add(5) }, 0x111111)
+
+        val verses = IntArrayList().apply { add(1); add(2) }
+        assertFalse(db.anyVerseHasHighlight(ariBc, verses))
+    }
+
+    @Test
+    fun `anyVerseHasHighlight is true when only some of the selected verses are highlighted`() {
+        val ariBc = Ari.encode(0, 1, 0)
+        db.updateOrInsertHighlights(ariBc, IntArrayList().apply { add(2) }, 0x111111)
+
+        val verses = IntArrayList().apply { add(1); add(2); add(3) }
+        assertTrue(db.anyVerseHasHighlight(ariBc, verses))
+    }
+
+    @Test
+    fun `anyVerseHasHighlight is true for mixed colors, where getHighlightColorRgb only reports -1`() {
+        val ariBc = Ari.encode(0, 1, 0)
+        db.updateOrInsertHighlights(ariBc, IntArrayList().apply { add(1) }, 0x111111)
+        db.updateOrInsertHighlights(ariBc, IntArrayList().apply { add(2) }, 0x222222)
+
+        val selected = IntArrayList().apply { add(1); add(2) }
+        assertEquals(-1, db.getHighlightColorRgb(ariBc, selected))
+        assertTrue(db.anyVerseHasHighlight(ariBc, selected))
+    }
+
+    @Test
+    fun `anyVerseHasHighlight ignores highlights in other chapters`() {
+        db.updateOrInsertHighlights(Ari.encode(0, 2, 0), IntArrayList().apply { add(1) }, 0x111111)
+
+        val verses = IntArrayList().apply { add(1) }
+        assertFalse(db.anyVerseHasHighlight(Ari.encode(0, 1, 0), verses))
     }
 
     // endregion


### PR DESCRIPTION
Follow-ups now that the Compose surfaces default to a dark scheme.

## Highlight bottom sheet

- **Verse sits on the reading background.** The verse text block is drawn on `uiDimensions.applied().backgroundColor` — the same color `IsiActivity` paints behind verse content — with 8dp padding and a 6dp corner radius. The verse now reads the same in the sheet as it does on the page the user selected it from.
- **Delete button hidden when there is nothing to delete.** Existence is asked of the DB directly through a new `InternalDb.anyVerseHasHighlight(ariBc, selectedVerses)`. The existing `getHighlightColorRgb(int, IntArrayList)` can't answer this: it returns `-1` both when no verse is highlighted *and* when the selection carries a mix of colors, and in the mixed case the delete button should stay.
- **Title icon** swapped from `Icons.Filled.Star` to Material Symbols' *ink highlighter*, added as `res/drawable/ic_ink_highlighter.xml`. The artwork is authored in a `0 -960 960 960` viewBox, so a `<group android:translateY="960">` shifts it into Android's `0 0 960 960` viewport.

## Goto (Compose)

They were **not** already the same — the two diverged twice over:

1. Different color roles: Goto's `Scaffold` fell through to `colorScheme.background` (top bar on `surface`), while the audio bar paints `surfaceContainerHigh`.
2. Different schemes: `BibleAppTheme` uses `dynamicDarkColorScheme` on Android 12+, `AudioTheme` used a static `darkColorScheme()`, so on a device with dynamic color the Goto screen was wallpaper-tinted and the bar wasn't.

Both are fixed: `AudioTheme` now delegates to `BibleAppTheme` (one scheme for every Compose surface), and the Goto `Scaffold` and its top bar are explicitly `surfaceContainerHigh`.

`GridTab`'s cells also used `surfaceContainerHigh`, so against the new screen background they'd have merged into a single slab — they're bumped to `surfaceContainerHighest` to stay readable as discrete tiles.

## Testing

- `./gradlew assemblePlainDebug` — BUILD SUCCESSFUL
- `./gradlew testPlainDebugUnitTest --tests "yuku.alkitab.base.storage.InternalDbTest"` — BUILD SUCCESSFUL, including 4 new Robolectric tests covering `anyVerseHasHighlight` (none highlighted, partially highlighted, mixed colors, and other-chapter highlights ignored).
- The vector drawable was rasterized off-device to confirm the path renders as the highlighter pen rather than a mangled outline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjpjxMV4Gr7H4LoaKhEZre)_