### PR TITLE
Fully Compose-based verse list behind the Verse (Compose) experimental setting

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -80,6 +80,7 @@ import yuku.alkitab.base.dialog.XrefDialog
 import yuku.alkitab.base.events.AppEvents
 import yuku.alkitab.base.model.MVersion
 import yuku.alkitab.base.model.MVersionDb
+import yuku.alkitab.base.settings.ExperimentalFlags
 import yuku.alkitab.base.settings.SettingsActivity
 import yuku.alkitab.base.storage.Prefkey
 import yuku.alkitab.base.util.AppLog
@@ -103,6 +104,8 @@ import yuku.alkitab.base.util.TargetDecoder
 import yuku.alkitab.base.util.safeQuery
 import yuku.alkitab.base.util.toIntArray
 import yuku.alkitab.base.verses.VerseAttributeLoader
+import yuku.alkitab.base.verses.VersesComposeControllerImpl
+import yuku.alkitab.base.verses.VersesComposeView
 import yuku.alkitab.base.verses.VersesController
 import yuku.alkitab.base.verses.VersesControllerImpl
 import yuku.alkitab.base.verses.VersesDataModel
@@ -542,11 +545,11 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         floater.setListener(gestureHandler)
 
         // listeners
-        lsSplit0 = VersesControllerImpl(
-            findViewById(R.id.lsSplitView0),
+        val useComposeVerses = ExperimentalFlags.useComposeVerseItem()
+        lsSplit0 = createVersesController(
+            useComposeVerses,
+            R.id.lsSplitView0,
             "lsSplit0",
-            VersesDataModel.EMPTY,
-            VersesUiModel.EMPTY,
             VersesListeners(
                 AttributeListener(), // have to be distinct from lsSplit1
                 lsSplit0_selectedVerses,
@@ -559,11 +562,10 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         )
 
         // additional setup for split1
-        lsSplit1 = VersesControllerImpl(
-            findViewById(R.id.lsSplitView1),
+        lsSplit1 = createVersesController(
+            useComposeVerses,
+            R.id.lsSplitView1,
             "lsSplit1",
-            VersesDataModel.EMPTY,
-            VersesUiModel.EMPTY,
             VersesListeners(
                 AttributeListener(), // have to be distinct from lsSplit0
                 lsSplit1_selectedVerses,
@@ -743,6 +745,39 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
 
         AppLog.d(TAG, "@@onCreate end")
+    }
+
+    /**
+     * Builds the verses controller for one split pane. With the Verse
+     * (Compose) experimental setting enabled, the [yuku.alkitab.base.verses.EmptyableRecyclerView]
+     * placed by the layout is swapped in place for a [VersesComposeView] —
+     * keeping the same view id, child index, and layout params so the
+     * split-view manager, the inset listeners, and the DEBUG layout
+     * assertions all keep operating on the pane view — and the fully
+     * Compose-based controller drives it. Otherwise the RecyclerView-based
+     * controller is used.
+     */
+    private fun createVersesController(
+        useComposeVerses: Boolean,
+        viewId: Int,
+        name: String,
+        listeners: VersesListeners,
+    ): VersesController {
+        return if (useComposeVerses) {
+            val recyclerView = findViewById<View>(viewId)
+            val parent = recyclerView.parent as ViewGroup
+            val childIndex = parent.indexOfChild(recyclerView)
+            val layoutParams = recyclerView.layoutParams
+            parent.removeViewAt(childIndex)
+
+            val composeView = VersesComposeView(this)
+            composeView.id = viewId
+            parent.addView(composeView, childIndex, layoutParams)
+
+            VersesComposeControllerImpl(composeView, name, VersesDataModel.EMPTY, VersesUiModel.EMPTY, listeners)
+        } else {
+            VersesControllerImpl(findViewById(viewId), name, VersesDataModel.EMPTY, VersesUiModel.EMPTY, listeners)
+        }
     }
 
     private fun applyAudioHighlightTo(controller: VersesController, verse_1: Int) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -749,13 +749,10 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
 
     /**
      * Builds the verses controller for one split pane. With the Verse
-     * (Compose) experimental setting enabled, the [yuku.alkitab.base.verses.EmptyableRecyclerView]
-     * placed by the layout is swapped in place for a [VersesComposeView] —
-     * keeping the same view id, child index, and layout params so the
-     * split-view manager, the inset listeners, and the DEBUG layout
-     * assertions all keep operating on the pane view — and the fully
-     * Compose-based controller drives it. Otherwise the RecyclerView-based
-     * controller is used.
+     * (Compose) experimental setting enabled, the pane's RecyclerView is
+     * swapped in place for a [VersesComposeView], keeping the same view id,
+     * child index, and layout params so the split-view manager, the inset
+     * listeners, and the DEBUG layout assertions keep operating on the pane.
      */
     private fun createVersesController(
         useComposeVerses: Boolean,

--- a/Alkitab/src/main/java/yuku/alkitab/base/settings/ExperimentalFragment.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/settings/ExperimentalFragment.kt
@@ -1,11 +1,26 @@
 package yuku.alkitab.base.settings
 
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.preference.CheckBoxPreference
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import yuku.alkitab.base.events.AppEvents
 import yuku.alkitab.debug.R
 
 class ExperimentalFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.settings_experimental)
+
+        // The reader activity builds its verse content view (RecyclerView vs
+        // fully Compose) once at creation, so toggling this flag requires the
+        // activity to be restarted for it to take effect.
+        val prefUseComposeVerseItem = findPreference<CheckBoxPreference>(getString(R.string.pref_useComposeVerseItem_key))
+        prefUseComposeVerseItem?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, _ ->
+            // do this after this method returns true
+            Handler(Looper.getMainLooper()).post { AppEvents.emitNeedsRestart() }
+            true
+        }
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/settings/ExperimentalFragment.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/settings/ExperimentalFragment.kt
@@ -13,9 +13,8 @@ class ExperimentalFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.settings_experimental)
 
-        // The reader activity builds its verse content view (RecyclerView vs
-        // fully Compose) once at creation, so toggling this flag requires the
-        // activity to be restarted for it to take effect.
+        // The reader builds its verse content view once at creation, so this
+        // flag only takes effect after the activity is restarted.
         val prefUseComposeVerseItem = findPreference<CheckBoxPreference>(getString(R.string.pref_useComposeVerseItem_key))
         prefUseComposeVerseItem?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, _ ->
             // do this after this method returns true

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
@@ -271,10 +271,7 @@ internal fun verseItemContentDescription(context: Context, s: VerseItemComposeSt
 /**
  * Runs the rendered verse text through the dictionary app's analyzer content
  * provider and wraps every recognized word in an underlined, tappable
- * [LinkAnnotation] that opens the dictionary — the Compose counterpart of the
- * legacy row's [yuku.alkitab.base.widget.DictionaryLinkSpan] decoration
- * (a ClickableSpan rendered underlined in the link color, which
- * `Appearances.applyTextAppearance` pins to the reading font color).
+ * [LinkAnnotation] that opens the dictionary.
  *
  * Returns [render] unchanged when the provider is unavailable, reports
  * nothing, or the query fails.
@@ -361,7 +358,7 @@ fun attributeViewScale(fontSizeDp: Float) = when {
 /**
  * Builds the immutable per-row state consumed by [VerseItemComposeContent].
  * Shared by the RecyclerView-hosted [VerseItemComposeView] rows and the fully
- * Compose verse list so both paths render identically.
+ * Compose verse list, so both paths render identically.
  *
  * @param currentPosition resolves the row's position at interaction time
  * (a RecyclerView rebind can move a row, so the position must not be captured
@@ -419,10 +416,8 @@ fun buildVerseItemComposeState(
         renderResult
     }
 
-    // Pre-resolve progress-mark captions at build time so the accessibility
-    // path — which TalkBack can hit repeatedly per row — doesn't run a DB
-    // query on every read. Mirrors the values the legacy
-    // VerseItem.getContentDescription resolves inline.
+    // Pre-resolve progress-mark captions so the accessibility path, which
+    // TalkBack can hit repeatedly per row, doesn't run a DB query per read.
     val progressMarkBits = data.versesAttributes.progressMarkBitsMap_[index]
     val progressMarkCaptions: List<String?> = (0 until AttributeView.PROGRESS_MARK_TOTAL_COUNT).map { presetId ->
         if (progressMarkBits and (1 shl (AttributeView.PROGRESS_MARK_BITS_START + presetId)) == 0) {
@@ -477,8 +472,6 @@ fun buildVerseItemComposeState(
             }
         },
         onInlineLinkClick = { type, arif ->
-            // Reuse the same factory as the legacy path so footnote / xref
-            // dialogs etc. open with identical semantics.
             listeners.inlineLinkSpanFactory_.create(type, arif).onClick(inlineLinkViewProvider())
         },
         onPinDropped = { presetId ->

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
@@ -55,12 +55,15 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
 import yuku.afw.storage.Preferences
+import yuku.alkitab.base.App
 import yuku.alkitab.base.widget.AttributeView
 import yuku.alkitab.base.widget.LeftDrawer.PROGRESS_MARK_DRAG_MIME_TYPE
 import yuku.alkitab.base.widget.VerseInlineLinkSpan
 import yuku.alkitab.base.widget.VerseRendererCompose
 import yuku.alkitab.debug.R
+import yuku.alkitab.model.SingleChapterVerses
 import yuku.alkitab.model.Version
+import yuku.alkitab.util.Ari
 
 /**
  * Inputs to a single verse row that don't change between recompositions.
@@ -206,48 +209,208 @@ class VerseItemComposeView @JvmOverloads constructor(
         return true
     }
 
-    @SuppressLint("StringFormatMatches", "GetContentDescriptionOverride")
+    @SuppressLint("GetContentDescriptionOverride")
     override fun getContentDescription(): CharSequence {
         val s = state ?: return ""
-        val res = StringBuilder()
-
-        val gutter = s.render.gutterVerseNumber
-        if (gutter != null) {
-            res.append(gutter).append(' ')
-        }
-        res.append(s.render.text.text)
-
-        val bookmarkCount = s.attribute.bookmarkCount
-        if (bookmarkCount == 1) {
-            res.append(' ').append(context.getString(R.string.desc_verse_attribute_one_bookmark))
-        } else if (bookmarkCount > 1) {
-            res.append(' ').append(context.getString(R.string.desc_verse_attribute_multiple_bookmarks, bookmarkCount))
-        }
-
-        val noteCount = s.attribute.noteCount
-        if (noteCount == 1) {
-            res.append(' ').append(context.getString(R.string.desc_verse_attribute_one_note))
-        } else if (noteCount > 1) {
-            res.append(' ').append(context.getString(R.string.desc_verse_attribute_multiple_notes, noteCount))
-        }
-
-        val progressMarkBits = s.attribute.progressMarkBits
-        for (presetId in 0 until AttributeView.PROGRESS_MARK_TOTAL_COUNT) {
-            if (progressMarkBits and (1 shl AttributeView.PROGRESS_MARK_BITS_START + presetId) != 0) {
-                // Captions are resolved at bind time (see VerseTextComposeHolder)
-                // so this path stays free of DB I/O.
-                s.attribute.progressMarkCaptions.getOrNull(presetId)?.let { caption ->
-                    res.append(' ').append(context.getString(R.string.desc_verse_attribute_progress_mark, caption))
-                }
-            }
-        }
-
-        return res
+        return verseItemContentDescription(context, s)
     }
 }
 
+/**
+ * TalkBack description of a verse row: gutter verse number (when present),
+ * verse text, then attribute summaries. Progress-mark captions come
+ * pre-resolved on [AttributeState.progressMarkCaptions] so this path stays
+ * free of DB I/O.
+ */
+@SuppressLint("StringFormatMatches")
+internal fun verseItemContentDescription(context: Context, s: VerseItemComposeState): CharSequence {
+    val res = StringBuilder()
+
+    val gutter = s.render.gutterVerseNumber
+    if (gutter != null) {
+        res.append(gutter).append(' ')
+    }
+    res.append(s.render.text.text)
+
+    val bookmarkCount = s.attribute.bookmarkCount
+    if (bookmarkCount == 1) {
+        res.append(' ').append(context.getString(R.string.desc_verse_attribute_one_bookmark))
+    } else if (bookmarkCount > 1) {
+        res.append(' ').append(context.getString(R.string.desc_verse_attribute_multiple_bookmarks, bookmarkCount))
+    }
+
+    val noteCount = s.attribute.noteCount
+    if (noteCount == 1) {
+        res.append(' ').append(context.getString(R.string.desc_verse_attribute_one_note))
+    } else if (noteCount > 1) {
+        res.append(' ').append(context.getString(R.string.desc_verse_attribute_multiple_notes, noteCount))
+    }
+
+    val progressMarkBits = s.attribute.progressMarkBits
+    for (presetId in 0 until AttributeView.PROGRESS_MARK_TOTAL_COUNT) {
+        if (progressMarkBits and (1 shl AttributeView.PROGRESS_MARK_BITS_START + presetId) != 0) {
+            s.attribute.progressMarkCaptions.getOrNull(presetId)?.let { caption ->
+                res.append(' ').append(context.getString(R.string.desc_verse_attribute_progress_mark, caption))
+            }
+        }
+    }
+
+    return res
+}
+
+/**
+ * Maps Android's built-in Typeface singletons to Compose's stock
+ * FontFamilies. The stock families have italic and bold variants
+ * registered, so FontStyle.Italic / FontWeight.Bold resolve to the
+ * correct glyphs (or synthesise cleanly). A raw FontFamily(Typeface)
+ * wrapper only carries the regular variant and silently renders
+ * italic upright.
+ */
+internal fun composeFontFamilyFor(tf: android.graphics.Typeface?): FontFamily = when (tf) {
+    null, android.graphics.Typeface.DEFAULT -> FontFamily.Default
+    android.graphics.Typeface.SERIF -> FontFamily.Serif
+    android.graphics.Typeface.MONOSPACE -> FontFamily.Monospace
+    android.graphics.Typeface.SANS_SERIF -> FontFamily.SansSerif
+    else -> FontFamily(ComposeTypeface(tf))
+}
+
+/** Whether the attribute column will draw at least one icon. */
+internal val AttributeState.isShowingSomething: Boolean
+    get() = bookmarkCount > 0 ||
+        noteCount > 0 ||
+        (progressMarkBits and AttributeView.PROGRESS_MARK_BIT_MASK) != 0 ||
+        hasMaps
+
+/** Icon scale for the attribute column, stepped by the effective font size in dp. */
+fun attributeViewScale(fontSizeDp: Float) = when {
+    fontSizeDp >= 13 /* 72% */ && fontSizeDp < 24 /* 133% */ -> 1f
+    fontSizeDp < 8 -> 0.5f // 0 ~ 44%
+    fontSizeDp < 18 -> 0.75f // 44% ~ 72%
+    fontSizeDp >= 36 -> 2f // 200% ~
+    else -> 1.5f // 24 to 36 // 133% ~ 200%
+}
+
+/**
+ * Builds the immutable per-row state consumed by [VerseItemComposeContent].
+ * Shared by the RecyclerView-hosted [VerseItemComposeView] rows and the fully
+ * Compose verse list so both paths render identically.
+ *
+ * @param currentPosition resolves the row's position at interaction time
+ * (a RecyclerView rebind can move a row, so the position must not be captured
+ * eagerly); returns -1 when the row is no longer attached.
+ * @param inlineLinkViewProvider supplies the View handed to
+ * [VerseInlineLinkSpan.onClick] (the row view, or the hosting Compose view).
+ */
+fun buildVerseItemComposeState(
+    context: Context,
+    data: VersesDataModel,
+    ui: VersesUiModel,
+    listeners: VersesListeners,
+    index: Int,
+    checked: Boolean,
+    currentPosition: () -> Int,
+    toggleChecked: (position: Int) -> Unit,
+    inlineLinkViewProvider: () -> android.view.View,
+): VerseItemComposeState {
+    val verse_1 = index + 1
+    val ari = Ari.encodeWithBc(data.ari_bc_, verse_1)
+    val text = data.verses_.getVerse(index)
+    val verseNumberText = data.verses_.getVerseNumberText(index)
+    val highlightInfo = data.versesAttributes.highlightInfoMap_[index]
+
+    val renderResult = VerseRendererCompose.render(
+        isVerseNumberShown = ui.isVerseNumberShown,
+        ari = ari,
+        text = text,
+        verseNumberText = verseNumberText,
+        highlightInfo = highlightInfo,
+        checked = checked,
+    )
+
+    val textSizeMult = if (data.verses_ is SingleChapterVerses.WithTextSizeMult) {
+        data.verses_.getTextSizeMult(index)
+    } else {
+        ui.textSizeMult
+    }
+
+    val applied = App.services.uiDimensions.applied()
+    val fontSizeDp = applied.fontSize2dp * textSizeMult
+    val verseNumberFontSizeDp = applied.fontSize2dp * 0.7f * textSizeMult
+    val attributeScale = attributeViewScale(applied.fontSize2dp * ui.textSizeMult)
+
+    // Pre-resolve progress-mark captions at build time so the accessibility
+    // path — which TalkBack can hit repeatedly per row — doesn't run a DB
+    // query on every read. Mirrors the values the legacy
+    // VerseItem.getContentDescription resolves inline.
+    val progressMarkBits = data.versesAttributes.progressMarkBitsMap_[index]
+    val progressMarkCaptions: List<String?> = (0 until AttributeView.PROGRESS_MARK_TOTAL_COUNT).map { presetId ->
+        if (progressMarkBits and (1 shl (AttributeView.PROGRESS_MARK_BITS_START + presetId)) == 0) {
+            null
+        } else {
+            App.services.storage.db.getProgressMarkByPresetId(presetId)?.let { progressMark ->
+                if (progressMark.caption.isNullOrEmpty()) {
+                    context.getString(AttributeView.getDefaultProgressMarkStringResource(presetId))
+                } else {
+                    progressMark.caption
+                }
+            }
+        }
+    }
+
+    return VerseItemComposeState(
+        render = renderResult,
+        fontSizeDp = fontSizeDp,
+        verseNumberFontSizeDp = verseNumberFontSizeDp,
+        fontColor = applied.fontColor,
+        verseNumberColor = applied.verseNumberColor,
+        lineSpacingMult = applied.lineSpacingMult,
+        typeface = applied.fontFace,
+        fontBold = applied.fontBold,
+        attribute = AttributeState(
+            bookmarkCount = data.versesAttributes.bookmarkCountMap_[index],
+            noteCount = data.versesAttributes.noteCountMap_[index],
+            progressMarkBits = progressMarkBits,
+            hasMaps = data.versesAttributes.hasMapsMap_[index],
+            scale = attributeScale,
+            version = data.version_,
+            versionId = data.versionId_,
+            ari = ari,
+            attributeListener = listeners.attributeListener,
+            progressMarkCaptions = progressMarkCaptions,
+        ),
+        onClick = {
+            when (ui.verseSelectionMode) {
+                VersesController.VerseSelectionMode.none -> Unit
+                VersesController.VerseSelectionMode.singleClick -> {
+                    val position = currentPosition()
+                    if (position != -1) {
+                        listeners.selectedVersesListener.onVerseSingleClick(data.getVerse_1FromPosition(position))
+                    }
+                }
+                VersesController.VerseSelectionMode.multiple -> {
+                    val position = currentPosition()
+                    if (position != -1) {
+                        toggleChecked(position)
+                    }
+                }
+            }
+        },
+        onInlineLinkClick = { type, arif ->
+            // Reuse the same factory as the legacy path so footnote / xref
+            // dialogs etc. open with identical semantics.
+            listeners.inlineLinkSpanFactory_.create(type, arif).onClick(inlineLinkViewProvider())
+        },
+        onPinDropped = { presetId ->
+            val position = currentPosition()
+            if (position != -1) {
+                listeners.pinDropListener.onPinDropped(presetId, Ari.encodeWithBc(data.ari_bc_, data.getVerse_1FromPosition(position)))
+            }
+        },
+    )
+}
+
 @Composable
-private fun VerseItemComposeContent(
+internal fun VerseItemComposeContent(
     state: VerseItemComposeState,
     checked: Boolean,
     collapsed: Boolean,
@@ -302,7 +465,7 @@ private fun VerseItemComposeContent(
     }
 }
 
-private data class LineMetrics(
+internal data class LineMetrics(
     val lineHeightSp: Float,
     val rowExtraPaddingPx: Int,
     /**
@@ -317,30 +480,45 @@ private data class LineMetrics(
 private fun rememberLineMetrics(state: VerseItemComposeState): LineMetrics {
     val density = LocalDensity.current
     return remember(state.typeface, state.fontSizeDp, state.fontBold, state.lineSpacingMult, density.density) {
-        val paint = android.text.TextPaint().apply {
-            isAntiAlias = true
-            textSize = state.fontSizeDp * density.density
-            typeface = if (state.fontBold == android.graphics.Typeface.BOLD) {
-                android.graphics.Typeface.create(state.typeface ?: android.graphics.Typeface.DEFAULT, android.graphics.Typeface.BOLD)
-            } else {
-                state.typeface ?: android.graphics.Typeface.DEFAULT
-            }
-        }
-        val fm = paint.fontMetrics
-        val naturalLineHeightPx = fm.descent - fm.ascent + fm.leading
-        val targetLineHeightPx = naturalLineHeightPx * state.lineSpacingMult
-        val rowExtraPaddingPx = (naturalLineHeightPx * (state.lineSpacingMult - 1f) + 0.5f).toInt()
-        val glyphHeightPx = fm.descent - fm.ascent
-        val gutterTopPaddingPx = if (glyphHeightPx <= 0f) 0 else {
-            ((targetLineHeightPx - glyphHeightPx) * (-fm.ascent) / glyphHeightPx + 0.5f).toInt().coerceAtLeast(0)
-        }
-        LineMetrics(
-            // density.fontScale == 1f upstream → px ↔ sp == /density.
-            lineHeightSp = targetLineHeightPx / density.density,
-            rowExtraPaddingPx = rowExtraPaddingPx,
-            gutterTopPaddingPx = gutterTopPaddingPx,
-        )
+        computeLineMetrics(state.typeface, state.fontSizeDp, state.fontBold, state.lineSpacingMult, density.density)
     }
+}
+
+/**
+ * Derives Compose line metrics from Android font metrics so text laid out with
+ * `lineHeight` + `LineHeightStyle(Proportional, Trim.None)` matches a TextView
+ * using `setLineSpacing(0, lineSpacingMult)`. The caller composes under a
+ * density with `fontScale == 1f`, so px ↔ sp conversion is `/densityFactor`.
+ */
+internal fun computeLineMetrics(
+    typeface: android.graphics.Typeface?,
+    fontSizeDp: Float,
+    fontBold: Int,
+    lineSpacingMult: Float,
+    densityFactor: Float,
+): LineMetrics {
+    val paint = android.text.TextPaint().apply {
+        isAntiAlias = true
+        textSize = fontSizeDp * densityFactor
+        this.typeface = if (fontBold == android.graphics.Typeface.BOLD) {
+            android.graphics.Typeface.create(typeface ?: android.graphics.Typeface.DEFAULT, android.graphics.Typeface.BOLD)
+        } else {
+            typeface ?: android.graphics.Typeface.DEFAULT
+        }
+    }
+    val fm = paint.fontMetrics
+    val naturalLineHeightPx = fm.descent - fm.ascent + fm.leading
+    val targetLineHeightPx = naturalLineHeightPx * lineSpacingMult
+    val rowExtraPaddingPx = (naturalLineHeightPx * (lineSpacingMult - 1f) + 0.5f).toInt()
+    val glyphHeightPx = fm.descent - fm.ascent
+    val gutterTopPaddingPx = if (glyphHeightPx <= 0f) 0 else {
+        ((targetLineHeightPx - glyphHeightPx) * (-fm.ascent) / glyphHeightPx + 0.5f).toInt().coerceAtLeast(0)
+    }
+    return LineMetrics(
+        lineHeightSp = targetLineHeightPx / densityFactor,
+        rowExtraPaddingPx = rowExtraPaddingPx,
+        gutterTopPaddingPx = gutterTopPaddingPx,
+    )
 }
 
 /**
@@ -367,20 +545,7 @@ private fun VerseTextRegion(state: VerseItemComposeState, checked: Boolean, line
         state.typeface,
         state.fontBold,
     ) {
-        // Map Android's built-in Typeface singletons to Compose's stock
-        // FontFamilies. The stock families have italic and bold variants
-        // registered, so FontStyle.Italic / FontWeight.Bold resolve to the
-        // correct glyphs (or synthesise cleanly). A raw FontFamily(Typeface)
-        // wrapper only carries the regular variant and silently renders
-        // italic upright.
-        val tf = state.typeface
-        val fontFamily: FontFamily = when (tf) {
-            null, android.graphics.Typeface.DEFAULT -> FontFamily.Default
-            android.graphics.Typeface.SERIF -> FontFamily.Serif
-            android.graphics.Typeface.MONOSPACE -> FontFamily.Monospace
-            android.graphics.Typeface.SANS_SERIF -> FontFamily.SansSerif
-            else -> FontFamily(ComposeTypeface(tf))
-        }
+        val fontFamily = composeFontFamilyFor(state.typeface)
         TextStyle(
             color = textColor,
             fontSize = state.fontSizeDp.sp,

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
@@ -41,22 +41,30 @@ import androidx.compose.ui.platform.AbstractComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.Typeface as ComposeTypeface
 import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
+import androidx.core.net.toUri
 import yuku.afw.storage.Preferences
 import yuku.alkitab.base.App
+import yuku.alkitab.base.util.AppLog
+import yuku.alkitab.base.util.safeQuery
 import yuku.alkitab.base.widget.AttributeView
+import yuku.alkitab.base.widget.DictionaryLinkInfo
 import yuku.alkitab.base.widget.LeftDrawer.PROGRESS_MARK_DRAG_MIME_TYPE
 import yuku.alkitab.base.widget.VerseInlineLinkSpan
 import yuku.alkitab.base.widget.VerseRendererCompose
@@ -109,6 +117,8 @@ data class AttributeState(
      */
     val progressMarkCaptions: List<String?>,
 )
+
+private const val TAG = "VerseItemCompose"
 
 private const val ATTENTION_DURATION_MS = 2000f
 private const val AUDIO_HIGHLIGHT_FLASH_ALPHA = 0.60f
@@ -259,6 +269,64 @@ internal fun verseItemContentDescription(context: Context, s: VerseItemComposeSt
 }
 
 /**
+ * Runs the rendered verse text through the dictionary app's analyzer content
+ * provider and wraps every recognized word in an underlined, tappable
+ * [LinkAnnotation] that opens the dictionary — the Compose counterpart of the
+ * legacy row's [yuku.alkitab.base.widget.DictionaryLinkSpan] decoration
+ * (a ClickableSpan rendered underlined in the link color, which
+ * `Appearances.applyTextAppearance` pins to the reading font color).
+ *
+ * Returns [render] unchanged when the provider is unavailable, reports
+ * nothing, or the query fails.
+ */
+internal fun addDictionaryLinks(
+    context: Context,
+    render: VerseRendererCompose.Result,
+    linkColor: Int,
+    dictionaryListener: (DictionaryLinkInfo) -> Unit,
+): VerseRendererCompose.Result {
+    // we have to exclude the verse numbers from analyze text
+    val startPos = render.startPosAfterVerseNumber
+    val analyzeString = render.text.text.substring(startPos)
+    if (analyzeString.isEmpty()) return render
+
+    val hits = mutableListOf<DictionaryLinkHit>()
+
+    val uri = "content://org.sabda.kamus.provider/analyze".toUri().buildUpon().appendQueryParameter("text", analyzeString).build()
+    try {
+        context.contentResolver.safeQuery(uri, null, null, null, null)?.use { c ->
+            val col_offset = c.getColumnIndexOrThrow("offset")
+            val col_len = c.getColumnIndexOrThrow("len")
+            val col_key = c.getColumnIndexOrThrow("key")
+
+            while (c.moveToNext()) {
+                val offset = c.getInt(col_offset)
+                val len = c.getInt(col_len)
+                val key = c.getString(col_key)
+
+                val word = analyzeString.substring(offset, offset + len)
+                hits += DictionaryLinkHit(startPos + offset, startPos + offset + len, DictionaryLinkInfo(word, key))
+            }
+        }
+    } catch (e: Exception) {
+        AppLog.e(TAG, "Error when querying dictionary content provider", e)
+        return render
+    }
+    if (hits.isEmpty()) return render
+
+    val decorated = buildAnnotatedString {
+        append(render.text)
+        for (hit in hits) {
+            addStyle(SpanStyle(color = Color(linkColor), textDecoration = TextDecoration.Underline), hit.start, hit.end)
+            addLink(LinkAnnotation.Clickable("dictionary") { dictionaryListener(hit.info) }, hit.start, hit.end)
+        }
+    }
+    return render.copy(text = decorated)
+}
+
+private class DictionaryLinkHit(val start: Int, val end: Int, val info: DictionaryLinkInfo)
+
+/**
  * Maps Android's built-in Typeface singletons to Compose's stock
  * FontFamilies. The stock families have italic and bold variants
  * registered, so FontStyle.Italic / FontWeight.Bold resolve to the
@@ -338,6 +406,19 @@ fun buildVerseItemComposeState(
     val verseNumberFontSizeDp = applied.fontSize2dp * 0.7f * textSizeMult
     val attributeScale = attributeViewScale(applied.fontSize2dp * ui.textSizeMult)
 
+    /*
+     * Dictionary mode is activated on either of these conditions:
+     * 1. user manually activate dictionary mode after selecting verses
+     * 2. automatic lookup is on and this verse is selected (checked)
+     */
+    val render = if (ari in ui.dictionaryModeAris ||
+        checked && Preferences.getBoolean(context.getString(R.string.pref_autoDictionaryAnalyze_key), context.resources.getBoolean(R.bool.pref_autoDictionaryAnalyze_default))
+    ) {
+        addDictionaryLinks(context, renderResult, applied.fontColor, listeners.dictionaryListener_)
+    } else {
+        renderResult
+    }
+
     // Pre-resolve progress-mark captions at build time so the accessibility
     // path — which TalkBack can hit repeatedly per row — doesn't run a DB
     // query on every read. Mirrors the values the legacy
@@ -358,7 +439,7 @@ fun buildVerseItemComposeState(
     }
 
     return VerseItemComposeState(
-        render = renderResult,
+        render = render,
         fontSizeDp = fontSizeDp,
         verseNumberFontSizeDp = verseNumberFontSizeDp,
         fontColor = applied.fontColor,

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
@@ -1,0 +1,1180 @@
+package yuku.alkitab.base.verses
+
+import android.content.Context
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.text.Spanned
+import android.text.style.StyleSpan
+import android.util.AttributeSet
+import android.util.SparseIntArray
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropTarget
+import androidx.compose.ui.draganddrop.mimeTypes
+import androidx.compose.ui.draganddrop.toAndroidDragEvent
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.view.updateLayoutParams
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import yuku.alkitab.base.App
+import yuku.alkitab.base.util.AppLog
+import yuku.alkitab.base.util.TargetDecoder
+import yuku.alkitab.base.verses.VersesDataModel.ItemType
+import yuku.alkitab.base.widget.AriParallelClickData
+import yuku.alkitab.base.widget.FormattedTextRenderer
+import yuku.alkitab.base.widget.LeftDrawer.PROGRESS_MARK_DRAG_MIME_TYPE
+import yuku.alkitab.base.widget.ParallelClickData
+import yuku.alkitab.base.widget.ReferenceParallelClickData
+import yuku.alkitab.util.IntArrayList
+
+private const val TAG = "VersesComposeCtl"
+
+private const val SCROLLBAR_FADE_DELAY_MS = 1000L
+private const val SCROLLBAR_FADE_DURATION_MS = 400
+private const val EMPTY_MESSAGE_TEXT_SIZE_DP = 14f
+
+/**
+ * Host view for the fully Compose-based verse list (the Verse (Compose)
+ * experimental setting). A plain [AbstractComposeView] whose content is
+ * whatever [VersesComposeControllerImpl] is currently attached; the controller
+ * owns all list state so it survives this view's composition being disposed
+ * and recreated (e.g. while the reader relocates its toolbar).
+ */
+class VersesComposeView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : AbstractComposeView(context, attrs) {
+
+    internal var controller by mutableStateOf<VersesComposeControllerImpl?>(null)
+
+    init {
+        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+    }
+
+    @Composable
+    override fun Content() {
+        controller?.ListContent()
+    }
+}
+
+/**
+ * [VersesController] implementation backed by a Compose [LazyColumn] instead
+ * of a RecyclerView. Selected when the Verse (Compose) experimental setting is
+ * enabled; the RecyclerView-based [VersesControllerImpl] remains the default.
+ *
+ * The full controller contract is honored so `IsiActivity`, the split-view
+ * manager, gestures, and audio playback drive both implementations
+ * identically:
+ * - scroll positions are anchored the same way the RecyclerView port anchors
+ *   them (a verse "at the top" sits at the view's top edge, ignoring the
+ *   scroll-past content padding, except for the very first item);
+ * - user scrolls emit [VersesController.VerseScrollListener] callbacks with
+ *   the same verse/pericope-block prop semantics, while controller-initiated
+ *   snap scrolls stay silent (mirroring RecyclerView, where only drags,
+ *   flings, and smooth scrolls produce scroll callbacks);
+ * - offscreen item heights, which RecyclerView obtains by measuring a
+ *   throwaway holder, are read from a cache of previously laid-out sizes, or
+ *   obtained by snapping the item into view first and reading its laid-out
+ *   size before applying the final offset in the same frame.
+ */
+class VersesComposeControllerImpl(
+    private val composeHost: VersesComposeView,
+    override val name: String,
+    versesDataModel: VersesDataModel = VersesDataModel.EMPTY,
+    versesUiModel: VersesUiModel = VersesUiModel.EMPTY,
+    versesListeners: VersesListeners = VersesListeners.EMPTY,
+) : VersesController {
+
+    private class DataWithVersion(val vn: Int, val data: VersesDataModel)
+
+    private data class AttentionUi(val start: Long, val verses_1: Set<Int>) {
+        companion object {
+            val NONE = AttentionUi(0L, emptySet())
+        }
+    }
+
+    internal val listState = LazyListState()
+
+    private val dataVersionNumber = AtomicInteger()
+    private var dataWithVersion by mutableStateOf(DataWithVersion(0, versesDataModel))
+    private var uiState by mutableStateOf(versesUiModel)
+    private var listenersState by mutableStateOf(versesListeners)
+
+    private var checkedPositionsState by mutableStateOf(emptySet<Int>())
+    private var attentionState by mutableStateOf(AttentionUi.NONE)
+
+    private var audioHighlightVerse1 by mutableIntStateOf(0)
+    private var audioHighlightColorState by mutableIntStateOf(0)
+
+    private val basePadding = Rect()
+    private var topInset = 0
+    private var bottomInset = 0
+    private var paddingLeftPx by mutableIntStateOf(0)
+    private var paddingTopPx by mutableIntStateOf(0)
+    private var paddingRightPx by mutableIntStateOf(0)
+    private var paddingBottomPx by mutableIntStateOf(0)
+
+    private var emptyMessageState by mutableStateOf<CharSequence?>(null)
+    // Matches the default color of EmptyableRecyclerView's Paint until
+    // setEmptyMessage supplies one.
+    private var emptyMessageColorState by mutableIntStateOf(0xff000000.toInt())
+    private var scrollbarThumbState by mutableStateOf<Drawable?>(null)
+
+    /**
+     * The data version most recently reflected by a composition. Scroll
+     * commands wait on this before touching [listState], so an index computed
+     * against fresh data is never applied while the list still shows the
+     * previous chapter (the LazyColumn equivalent of RecyclerView's
+     * pending-scroll-position-applied-on-next-layout behavior).
+     */
+    private val renderedDataVersion = mutableIntStateOf(0)
+
+    /**
+     * Non-zero while a controller-initiated snap scroll is running, so the
+     * scroll-event emitter stays silent for it. Smooth scrolls (audio
+     * highlight) intentionally do not set this: their RecyclerView counterpart
+     * also emits scroll callbacks, which keeps the split panes following the
+     * audio verse.
+     */
+    private var programmaticScrollDepth = 0
+
+    /**
+     * Laid-out item heights by position, filled as items pass through the
+     * viewport. Only valid for [cacheDataVersion]; used to estimate offscreen
+     * item heights where RecyclerView would measure a throwaway holder.
+     */
+    private val itemSizeCache = SparseIntArray()
+    private var cacheDataVersion = -1
+
+    init {
+        composeHost.controller = this
+    }
+
+    override var versesDataModel: VersesDataModel
+        get() = dataWithVersion.data
+        set(value) {
+            val vn = dataVersionNumber.incrementAndGet()
+            dataWithVersion = DataWithVersion(vn, value)
+            attentionState = AttentionUi.NONE
+        }
+
+    override var versesUiModel: VersesUiModel
+        get() = uiState
+        set(value) {
+            uiState = value
+        }
+
+    override var versesListeners: VersesListeners
+        get() = listenersState
+        set(value) {
+            listenersState = value
+        }
+
+    override fun uncheckAllVerses(callSelectedVersesListener: Boolean) {
+        checkedPositionsState = emptySet()
+
+        if (callSelectedVersesListener) {
+            listenersState.selectedVersesListener.onNoVersesSelected()
+        }
+    }
+
+    override fun checkVerses(verses_1: IntArrayList, callSelectedVersesListener: Boolean) {
+        uncheckAllVerses(false)
+
+        val data = versesDataModel
+        val newChecked = mutableSetOf<Int>()
+        var i = 0
+        val len = verses_1.size()
+        while (i < len) {
+            val verse_1 = verses_1.get(i)
+            val count = data.itemCount
+            val pos = data.getPositionIgnoringPericopeFromVerse(verse_1)
+            if (pos != -1 && pos < count) {
+                newChecked += pos
+            }
+            i++
+        }
+        checkedPositionsState = newChecked
+
+        if (callSelectedVersesListener) {
+            if (newChecked.isNotEmpty()) {
+                listenersState.selectedVersesListener.onSomeVersesSelected(getCheckedVerses_1())
+            } else {
+                listenersState.selectedVersesListener.onNoVersesSelected()
+            }
+        }
+    }
+
+    override fun getCheckedVerses_1(): IntArrayList {
+        val data = versesDataModel
+        val checkedVerses_1 = mutableSetOf<Int>()
+        for (checkedPosition in checkedPositionsState) {
+            val verse_1 = data.getVerse_1FromPosition(checkedPosition)
+            if (verse_1 >= 1) {
+                checkedVerses_1 += verse_1
+            }
+        }
+
+        val res = IntArrayList(checkedVerses_1.size)
+        for (verse_1 in checkedVerses_1.sorted()) {
+            res.add(verse_1)
+        }
+        return res
+    }
+
+    private fun toggleChecked(position: Int) {
+        val current = checkedPositionsState
+        checkedPositionsState = if (position !in current) current + position else current - position
+
+        if (checkedPositionsState.isNotEmpty()) {
+            listenersState.selectedVersesListener.onSomeVersesSelected(getCheckedVerses_1())
+        } else {
+            listenersState.selectedVersesListener.onNoVersesSelected()
+        }
+    }
+
+    // --- Scrolling ---
+
+    /**
+     * Runs a scroll operation once the composition has caught up with the data
+     * version current at call time, dropping it if the data has changed again
+     * by then (same guard as the RecyclerView implementation's posted scrolls).
+     */
+    private fun launchScroll(programmatic: Boolean = true, block: suspend (data: VersesDataModel) -> Unit) {
+        val vn = dataVersionNumber.get()
+        val scope = composeHost.findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        scope.launch {
+            snapshotFlow { renderedDataVersion.intValue }.first { it >= vn }
+            if (vn != dataVersionNumber.get()) return@launch
+            if (programmatic) programmaticScrollDepth++
+            try {
+                block(dataWithVersion.data)
+            } finally {
+                if (programmatic) programmaticScrollDepth--
+            }
+        }
+    }
+
+    /**
+     * Scroll offset that puts the item's top at the view's top edge (ignoring
+     * the scroll-past top padding), except for the very first item which sits
+     * below the padding — the same anchoring RecyclerView achieves with its
+     * `paddingNegator`.
+     */
+    private fun snapOffsetPx(position: Int): Int = if (position == 0) 0 else paddingTopPx
+
+    private fun visibleItemSizePx(position: Int): Int? =
+        listState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == position }?.size
+
+    private fun findItemSizePx(position: Int): Int? {
+        visibleItemSizePx(position)?.let { return it }
+        if (cacheDataVersion == renderedDataVersion.intValue) {
+            val cached = itemSizeCache.get(position, -1)
+            if (cached >= 0) return cached
+        }
+        return null
+    }
+
+    private fun estimatedItemSizePx(position: Int): Int {
+        findItemSizePx(position)?.let { return it }
+        val visible = listState.layoutInfo.visibleItemsInfo
+        if (visible.isNotEmpty()) return visible.sumOf { it.size } / visible.size
+        return 0
+    }
+
+    override fun scrollToTop() {
+        launchScroll { listState.scrollToItem(0) }
+    }
+
+    override fun scrollToVerse(verse_1: Int) {
+        val position = versesDataModel.getPositionOfPericopeBeginningFromVerse(verse_1)
+
+        if (position == -1) {
+            AppLog.w(TAG, "could not find verse_1=$verse_1, weird!")
+            return
+        }
+
+        launchScroll { data ->
+            if (position >= data.itemCount) return@launchScroll
+            listState.scrollToItem(position, snapOffsetPx(position))
+        }
+    }
+
+    override fun scrollToVerse(verse_1: Int, prop: Float) {
+        val position = versesDataModel.getPositionIgnoringPericopeFromVerse(verse_1)
+        if (position == -1) {
+            AppLog.d(TAG, "could not find verse_1: $verse_1")
+            return
+        }
+
+        scrollToPositionWithProp(position, prop)
+    }
+
+    override fun scrollToPericope(verse_1: Int, prop: Float) {
+        val data = versesDataModel
+        val blockStartPos = data.getPositionOfPericopeBeginningFromVerse(verse_1)
+        if (blockStartPos == -1) {
+            AppLog.d(TAG, "could not find pericope above verse_1: $verse_1")
+            return
+        }
+        val versePos = data.getPositionIgnoringPericopeFromVerse(verse_1)
+        if (blockStartPos == versePos) {
+            // No pericope above the verse on this pane — treat as a
+            // zero-height block: pin the verse top while the sender's
+            // pericope scrolls.
+            scrollToPositionWithProp(versePos, 0f)
+            return
+        }
+
+        launchScroll { latest ->
+            if (versePos >= latest.itemCount) return@launchScroll
+
+            val snapBase = if (blockStartPos == 0) 0 else paddingTopPx
+
+            var combinedHeight = 0
+            var unknown = false
+            for (p in blockStartPos until versePos) {
+                val size = findItemSizePx(p)
+                if (size == null) {
+                    unknown = true
+                    break
+                }
+                combinedHeight += size
+            }
+            if (unknown) {
+                // Snap the block into view so its items get laid out, then
+                // read the real sizes; the final snap below lands in the same
+                // frame, so no intermediate position is ever rendered.
+                listState.scrollToItem(blockStartPos, snapBase)
+                combinedHeight = 0
+                for (p in blockStartPos until versePos) {
+                    combinedHeight += visibleItemSizePx(p) ?: 0
+                }
+            }
+
+            listState.scrollToItem(blockStartPos, snapBase + (prop * combinedHeight).toInt())
+        }
+    }
+
+    private fun scrollToPositionWithProp(position: Int, prop: Float) {
+        launchScroll { data ->
+            if (position >= data.itemCount) return@launchScroll
+
+            var height = findItemSizePx(position)
+            if (height == null) {
+                listState.scrollToItem(position, paddingTopPx)
+                height = visibleItemSizePx(position) ?: return@launchScroll
+            }
+
+            listState.scrollToItem(position, paddingTopPx + (prop * height).toInt())
+        }
+    }
+
+    /**
+     * Returns -1 if there is no visible child (e.g. when split is collapsed until the height is 0).
+     */
+    private fun getPositionBasedOnScroll(): Int {
+        val first = listState.layoutInfo.visibleItemsInfo.firstOrNull() ?: return -1
+
+        val top = first.offset + paddingTopPx
+        if (top == 0) {
+            return first.index
+        }
+        val bottom = top + first.size
+        return if (bottom > 0) {
+            first.index
+        } else {
+            first.index + 1
+        }
+    }
+
+    override fun getVerse_1BasedOnScroll(): Int {
+        return versesDataModel.getVerse_1FromPosition(getPositionBasedOnScroll())
+    }
+
+    override fun pageDown(): VersesController.PressResult {
+        val info = listState.layoutInfo
+        val oldPos = info.visibleItemsInfo.firstOrNull()?.index ?: -1
+        var newPos = info.visibleItemsInfo.lastOrNull()?.index ?: -1
+
+        if (oldPos == newPos && oldPos < versesDataModel.itemCount - 1) { // in case of very long item
+            newPos = oldPos + 1
+        }
+
+        val targetPos = newPos
+        if (targetPos >= 0) {
+            launchScroll { data ->
+                if (targetPos >= data.itemCount) return@launchScroll
+                listState.scrollToItem(targetPos, snapOffsetPx(targetPos))
+            }
+        }
+
+        return VersesController.PressResult.Consumed(versesDataModel.getVerse_1FromPosition(newPos))
+    }
+
+    override fun pageUp(): VersesController.PressResult {
+        val info = listState.layoutInfo
+        val oldPos = info.visibleItemsInfo.firstOrNull()?.index ?: -1
+        val targetHeight = (info.viewportSize.height - paddingTopPx - paddingBottomPx).coerceAtLeast(0)
+
+        var totalHeight = 0
+
+        // consider how long the first child has been scrolled up
+        val firstItem = info.visibleItemsInfo.firstOrNull()
+        if (firstItem != null) {
+            totalHeight += -(firstItem.offset + paddingTopPx)
+        }
+
+        var curPos = oldPos
+        // try until totalHeight exceeds targetHeight
+        while (true) {
+            curPos--
+            if (curPos < 0) {
+                break
+            }
+
+            totalHeight += estimatedItemSizePx(curPos)
+
+            if (totalHeight > targetHeight) {
+                break
+            }
+        }
+
+        var newPos = curPos + 1
+
+        if (oldPos == newPos && oldPos > 0) { // move at least one
+            newPos = oldPos - 1
+        }
+
+        val targetPos = newPos
+        launchScroll { data ->
+            if (targetPos >= data.itemCount) return@launchScroll
+            listState.scrollToItem(targetPos, snapOffsetPx(targetPos))
+        }
+
+        return VersesController.PressResult.Consumed(versesDataModel.getVerse_1FromPosition(newPos))
+    }
+
+    override fun verseDown(): VersesController.PressResult {
+        val oldVerse_1 = getVerse_1BasedOnScroll()
+
+        val newVerse_1 = if (oldVerse_1 < versesDataModel.verses_.verseCount) {
+            oldVerse_1 + 1
+        } else {
+            oldVerse_1
+        }
+
+        scrollToVerse(newVerse_1)
+        return VersesController.PressResult.Consumed(newVerse_1)
+    }
+
+    override fun verseUp(): VersesController.PressResult {
+        val oldVerse_1 = getVerse_1BasedOnScroll()
+
+        val newVerse_1 = if (oldVerse_1 > 1) { // can still go prev
+            oldVerse_1 - 1
+        } else {
+            oldVerse_1
+        }
+
+        scrollToVerse(newVerse_1)
+        return VersesController.PressResult.Consumed(newVerse_1)
+    }
+
+    // --- View-level operations ---
+
+    override fun setViewVisibility(visibility: Int) {
+        composeHost.visibility = visibility
+    }
+
+    override fun setViewPadding(padding: Rect) {
+        basePadding.set(padding)
+        applyPadding()
+    }
+
+    override fun setViewVerticalInsets(topInset: Int, bottomInset: Int) {
+        if (this.topInset == topInset && this.bottomInset == bottomInset) return
+        this.topInset = topInset
+        this.bottomInset = bottomInset
+        applyPadding()
+    }
+
+    private fun applyPadding() {
+        val newTop = basePadding.top + topInset
+        val deltaTop = newTop - paddingTopPx
+
+        paddingLeftPx = basePadding.left
+        paddingTopPx = newTop
+        paddingRightPx = basePadding.right
+        paddingBottomPx = basePadding.bottom + bottomInset
+
+        // A LazyColumn anchors its scroll position relative to the content
+        // start, so a top-padding change would shift the verses on screen.
+        // Counter-scroll by the delta to keep the first visible verse at the
+        // same pixel position — except when the list rests at the very top,
+        // where the first verse must follow the padding into the safe area.
+        if (deltaTop != 0 && listState.canScrollBackward) {
+            launchScroll { listState.scrollBy(deltaTop.toFloat()) }
+        }
+    }
+
+    override fun setViewScrollbarThumb(thumb: Drawable) {
+        scrollbarThumbState = thumb
+    }
+
+    override fun setViewLayoutSize(width: Int, height: Int) {
+        composeHost.updateLayoutParams {
+            this.width = width
+            this.height = height
+        }
+    }
+
+    override fun setEmptyMessage(message: CharSequence?, textColor: Int) {
+        emptyMessageState = message
+        emptyMessageColorState = textColor
+    }
+
+    // --- Attention and audio highlight ---
+
+    override fun callAttentionForVerse(verse_1: Int) {
+        val pos = versesDataModel.getPositionIgnoringPericopeFromVerse(verse_1)
+        if (pos == -1) return
+
+        attentionState = AttentionUi(System.currentTimeMillis(), attentionState.verses_1 + verse_1)
+    }
+
+    override fun setAudioHighlight(verse_1: Int, color: Int) {
+        // Fast-path: this method is called every 100ms during playback
+        // (mirroring the service's position poll). Bailing out when nothing
+        // actually changed avoids restarting the highlight scroll.
+        if (audioHighlightVerse1 == verse_1 && audioHighlightColorState == color) return
+
+        audioHighlightVerse1 = verse_1
+        audioHighlightColorState = color
+        if (verse_1 == 0) return
+
+        val pos = versesDataModel.getPositionIgnoringPericopeFromVerse(verse_1)
+        if (pos == -1) return
+
+        // Smooth-scroll the highlighted verse so its top sits at the upper 10%
+        // of the viewport — keeps a thin slice of the previous verse visible
+        // for context while leaving room for upcoming verses below. Skipped
+        // when the row is already fully visible inside the viewport: yanking
+        // the page when the verse is sitting right in front of the user is
+        // more distracting than helpful.
+        launchScroll(programmatic = false) { data ->
+            if (pos >= data.itemCount) return@launchScroll
+
+            val info = listState.layoutInfo
+            val viewportHeight = info.viewportSize.height
+            if (viewportHeight <= 0) return@launchScroll
+
+            val targetTop = paddingTopPx + ((viewportHeight - paddingTopPx - paddingBottomPx) * 0.10f).toInt()
+
+            val item = info.visibleItemsInfo.firstOrNull { it.index == pos }
+            if (item != null) {
+                val topVisual = item.offset + paddingTopPx
+                val bottomVisual = topVisual + item.size
+                if (topVisual >= paddingTopPx && bottomVisual <= viewportHeight - paddingBottomPx) return@launchScroll
+                listState.animateScrollBy((topVisual - targetTop).toFloat())
+            } else {
+                listState.animateScrollToItem(pos, paddingTopPx)
+                val landed = visibleItemSizePx(pos) ?: return@launchScroll
+                // The item's top now sits at the view's top edge; nudge it
+                // down to the 10% mark (bounded by its height so a very short
+                // viewport can't scroll it back out).
+                if (landed > 0) {
+                    val topVisual = listState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == pos }
+                        ?.let { it.offset + paddingTopPx }
+                        ?: return@launchScroll
+                    val delta = topVisual - targetTop
+                    if (delta != 0) listState.animateScrollBy(delta.toFloat())
+                }
+            }
+        }
+    }
+
+    // --- Scroll event emission (split-pane sync) ---
+
+    /**
+     * Mirror of the RecyclerView scroll listener: reports the first visible
+     * verse (or the pericope-header block above it, treated as one anchor
+     * unit) and the fraction of its extent scrolled past the view's top edge.
+     */
+    private fun emitVerseScrollEvents() {
+        val data = dataWithVersion.data
+        val listeners = listenersState
+        val info = listState.layoutInfo
+        val first = info.visibleItemsInfo.firstOrNull() ?: return
+
+        var prop = 0f
+        var position = -1
+        var anchorHeight = 0
+
+        val remaining = first.offset + first.size + paddingTopPx // visual bottom; padding top is ignored
+        if (remaining >= 0) { // bottom of first child is lower than the top edge
+            position = first.index
+            anchorHeight = first.size
+            prop = if (anchorHeight > 0) 1f - remaining.toFloat() / anchorHeight else 0f
+        } else {
+            info.visibleItemsInfo.getOrNull(1)?.let { second ->
+                position = second.index
+                anchorHeight = second.size
+                prop = if (anchorHeight > 0) (-remaining).toFloat() / anchorHeight else 0f
+            }
+        }
+
+        if (position < 0) return
+
+        val verseOrPericope = data.getVerseOrPericopeFromPosition(position)
+        if (verseOrPericope > 0) {
+            listeners.verseScrollListener.onVerseScroll(false, verseOrPericope, prop)
+        } else {
+            // Contiguous pericope headers above a verse are reported
+            // as a single anchor unit so panes whose versions have
+            // different pericope counts/heights stay aligned across
+            // the whole block instead of bumping at each header.
+            var blockStartPos = position
+            while (blockStartPos > 0 &&
+                data.getItemViewType(blockStartPos - 1) == ItemType.pericope
+            ) {
+                blockStartPos--
+            }
+            val itemCount = data.itemCount
+            var versePos = position + 1
+            while (versePos < itemCount &&
+                data.getItemViewType(versePos) == ItemType.pericope
+            ) {
+                versePos++
+            }
+            if (versePos >= itemCount) return
+            val nextVerse_1 = data.getVerse_1FromPosition(versePos)
+            if (nextVerse_1 > 0) {
+                var heightsBefore = 0
+                for (p in blockStartPos until position) {
+                    heightsBefore += findItemSizePx(p) ?: 0
+                }
+                var combinedHeight = heightsBefore + anchorHeight
+                for (p in position + 1 until versePos) {
+                    combinedHeight += findItemSizePx(p) ?: 0
+                }
+
+                val scrolledOfAnchorPx = prop * anchorHeight
+                val combinedScrolledPx = heightsBefore + scrolledOfAnchorPx
+                val propCombined = if (combinedHeight > 0) combinedScrolledPx / combinedHeight else 0f
+
+                listeners.verseScrollListener.onVerseScroll(true, nextVerse_1, propCombined)
+            }
+        }
+
+        if (first.index == 0 && first.offset == 0) {
+            listeners.verseScrollListener.onScrollToTop()
+        }
+    }
+
+    // --- Composition ---
+
+    @Composable
+    internal fun ListContent() {
+        val dataW = dataWithVersion
+        val data = dataW.data
+        val ui = uiState
+        val listeners = listenersState
+
+        SideEffect {
+            renderedDataVersion.intValue = dataW.vn
+        }
+
+        // Record laid-out item sizes for offscreen-height estimates. Keyed by
+        // the rendered data version so sizes from a previous chapter never
+        // leak into the new one.
+        LaunchedEffect(Unit) {
+            snapshotFlow { listState.layoutInfo.visibleItemsInfo }.collect { visible ->
+                val vn = renderedDataVersion.intValue
+                if (cacheDataVersion != vn) {
+                    itemSizeCache.clear()
+                    cacheDataVersion = vn
+                }
+                for (item in visible) {
+                    itemSizeCache.put(item.index, item.size)
+                }
+            }
+        }
+
+        // Emit verse-scroll callbacks for user-driven scrolls (drags, flings,
+        // and smooth scrolls), skipping controller-initiated snaps.
+        LaunchedEffect(Unit) {
+            snapshotFlow {
+                val first = listState.layoutInfo.visibleItemsInfo.firstOrNull()
+                if (first == null) Long.MIN_VALUE else (first.index.toLong() shl 32) or (first.offset.toLong() and 0xffffffffL)
+            }
+                .drop(1)
+                .collect {
+                    if (!listState.isScrollInProgress) return@collect
+                    if (programmaticScrollDepth > 0) return@collect
+                    emitVerseScrollEvents()
+                }
+        }
+
+        // Strip fontScale from the density: verse text uses dp sizing (not
+        // sp), so the system font scale must not multiply on top.
+        val baseDensity = LocalDensity.current
+        val unscaledDensity = remember(baseDensity.density) {
+            Density(density = baseDensity.density, fontScale = 1f)
+        }
+
+        CompositionLocalProvider(LocalDensity provides unscaledDensity) {
+            Box(modifier = Modifier.fillMaxSize()) {
+                val contentPadding = with(unscaledDensity) {
+                    PaddingValues.Absolute(
+                        left = paddingLeftPx.toDp(),
+                        top = paddingTopPx.toDp(),
+                        right = paddingRightPx.toDp(),
+                        bottom = paddingBottomPx.toDp(),
+                    )
+                }
+
+                LazyColumn(
+                    state = listState,
+                    contentPadding = contentPadding,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verseListScrollbar(listState, scrollbarThumbState),
+                ) {
+                    items(
+                        count = data.itemCount,
+                        key = { position -> itemKey(data, position) },
+                        contentType = { position -> data.getItemViewType(position) },
+                    ) { position ->
+                        when (data.getItemViewType(position)) {
+                            ItemType.verseText -> VerseRow(data, ui, listeners, position)
+                            ItemType.pericope -> PericopeHeaderComposeItem(data, ui, listeners, position, data.getPericopeIndex(position))
+                        }
+                    }
+                }
+
+                val emptyMessage = emptyMessageState
+                if (emptyMessage != null) {
+                    BasicText(
+                        text = emptyMessage.toString(),
+                        style = TextStyle(
+                            color = Color(emptyMessageColorState),
+                            fontSize = EMPTY_MESSAGE_TEXT_SIZE_DP.sp,
+                            textAlign = TextAlign.Center,
+                        ),
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(horizontal = 16.dp),
+                    )
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun VerseRow(data: VersesDataModel, ui: VersesUiModel, listeners: VersesListeners, position: Int) {
+        val index = data.getVerse_0(position)
+        val verse_1 = index + 1
+        val checked = position in checkedPositionsState
+        val context = LocalContext.current
+
+        val state = remember(data, ui, listeners, position, checked) {
+            buildVerseItemComposeState(
+                context = context,
+                data = data,
+                ui = ui,
+                listeners = listeners,
+                index = index,
+                checked = checked,
+                currentPosition = { position },
+                toggleChecked = { pos -> toggleChecked(pos) },
+                inlineLinkViewProvider = { composeHost },
+            )
+        }
+
+        val collapsed = data.verses_.getVerse(index).isEmpty() && !state.attribute.isShowingSomething
+
+        val attention = attentionState
+        val attentionStart = if (attention.start != 0L && verse_1 in attention.verses_1) attention.start else 0L
+        val audioColor = if (verse_1 == audioHighlightVerse1) audioHighlightColorState else 0
+
+        val dragHover = remember { mutableStateOf(false) }
+        val dropTarget = remember(state) {
+            object : DragAndDropTarget {
+                override fun onEntered(event: DragAndDropEvent) {
+                    dragHover.value = true
+                }
+
+                override fun onExited(event: DragAndDropEvent) {
+                    dragHover.value = false
+                }
+
+                override fun onEnded(event: DragAndDropEvent) {
+                    dragHover.value = false
+                }
+
+                override fun onDrop(event: DragAndDropEvent): Boolean {
+                    // Refuse the drop if the payload is missing or non-numeric.
+                    val presetId = event.toAndroidDragEvent().clipData
+                        ?.getItemAt(0)?.text?.toString()?.toIntOrNull()
+                        ?: return false
+                    state.onPinDropped(presetId)
+                    return true
+                }
+            }
+        }
+
+        val description = remember(state) { verseItemContentDescription(context, state).toString() }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                // TalkBack reads the row as one unit (verse number, text, and
+                // attribute summaries), matching the View implementations, and
+                // can activate it like the legacy row's View click listener.
+                .clearAndSetSemantics {
+                    contentDescription = description
+                    onClick {
+                        state.onClick()
+                        true
+                    }
+                }
+                .dragAndDropTarget(
+                    shouldStartDragAndDrop = { event -> event.mimeTypes().contains(PROGRESS_MARK_DRAG_MIME_TYPE) },
+                    target = dropTarget,
+                )
+        ) {
+            VerseItemComposeContent(
+                state = state,
+                checked = checked,
+                collapsed = collapsed,
+                audioHighlightColor = audioColor,
+                attentionStart = attentionStart,
+                dragHover = dragHover.value,
+                // The overlay stops drawing by itself once the flash has
+                // decayed; there is no per-row state to reset here.
+                onAttentionDone = {},
+            )
+        }
+    }
+}
+
+/**
+ * Stable per-position key, using the same scheme as the RecyclerView
+ * adapter's stable ids: verses are `verse_1 * 1000`, pericope headers sit
+ * just below the following verse's key.
+ */
+private fun itemKey(data: VersesDataModel, position: Int): Long {
+    return when (data.getItemViewType(position)) {
+        ItemType.verseText -> data.getVerse_1FromPosition(position) * 1000L
+        ItemType.pericope -> {
+            when (val locateResult = data.locateVerse_1FromPosition(position)) {
+                LocateResult.EMPTY -> 1000000L + position
+                else -> locateResult.verse_1 * 1000L - locateResult.distanceToNextVerse
+            }
+        }
+    }
+}
+
+/**
+ * Compose port of the pericope header row: centered bold title, then the
+ * optional parallels line with tappable references.
+ */
+@Composable
+internal fun PericopeHeaderComposeItem(
+    data: VersesDataModel,
+    ui: VersesUiModel,
+    listeners: VersesListeners,
+    position: Int,
+    index: Int,
+) {
+    val applied = App.services.uiDimensions.applied()
+    val pericopeBlock = data.pericopeBlocks_[index]
+
+    val baseDensity = LocalDensity.current
+    val unscaledDensity = remember(baseDensity.density) {
+        Density(density = baseDensity.density, fontScale = 1f)
+    }
+
+    CompositionLocalProvider(LocalDensity provides unscaledDensity) {
+        // turn off top padding if the position == 0 OR before this is also a pericope title
+        val paddingTopPx = if (position == 0 || data.getItemViewType(position - 1) == ItemType.pericope) {
+            0
+        } else {
+            applied.pericopeSpacingTop
+        }
+        val paddingBottomPx = applied.pericopeSpacingBottom
+
+        val fontFamily = remember(applied.fontFace) { composeFontFamilyFor(applied.fontFace) }
+        val titleSizeDp = applied.fontSize2dp * ui.textSizeMult
+        val titleLineMetrics = remember(applied.fontFace, titleSizeDp, applied.lineSpacingMult, unscaledDensity.density) {
+            computeLineMetrics(applied.fontFace, titleSizeDp, android.graphics.Typeface.BOLD, applied.lineSpacingMult, unscaledDensity.density)
+        }
+
+        val titleText = remember(pericopeBlock.title) {
+            spannedToAnnotatedString(FormattedTextRenderer.render(pericopeBlock.title))
+        }
+
+        Column(
+            modifier = with(unscaledDensity) {
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = paddingTopPx.toDp(), bottom = paddingBottomPx.toDp())
+            }
+        ) {
+            BasicText(
+                text = titleText,
+                style = TextStyle(
+                    color = Color(applied.fontColor),
+                    fontSize = titleSizeDp.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = fontFamily,
+                    textAlign = TextAlign.Center,
+                    lineHeight = titleLineMetrics.lineHeightSp.sp,
+                    lineHeightStyle = LineHeightStyle(
+                        alignment = LineHeightStyle.Alignment.Proportional,
+                        trim = LineHeightStyle.Trim.Both,
+                    ),
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp),
+            )
+
+            if (pericopeBlock.parallels.isNotEmpty()) {
+                val parallelsSizeDp = titleSizeDp * 0.8235294f
+                val parallelsLineMetrics = remember(applied.fontFace, parallelsSizeDp, applied.lineSpacingMult, unscaledDensity.density) {
+                    computeLineMetrics(applied.fontFace, parallelsSizeDp, android.graphics.Typeface.NORMAL, applied.lineSpacingMult, unscaledDensity.density)
+                }
+                val parallelsText = remember(pericopeBlock, listeners) {
+                    buildParallelsAnnotatedString(pericopeBlock.parallels, listeners.parallelListener_)
+                }
+
+                BasicText(
+                    text = parallelsText,
+                    style = TextStyle(
+                        color = Color(applied.fontColor),
+                        fontSize = parallelsSizeDp.sp,
+                        fontFamily = fontFamily,
+                        textAlign = TextAlign.Center,
+                        lineHeight = parallelsLineMetrics.lineHeightSp.sp,
+                        lineHeightStyle = LineHeightStyle(
+                            alignment = LineHeightStyle.Alignment.Proportional,
+                            trim = LineHeightStyle.Trim.Both,
+                        ),
+                    ),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 12.dp),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Converts the simple formatted text produced by [FormattedTextRenderer]
+ * (italic/bold [StyleSpan]s and line breaks) into an [AnnotatedString].
+ */
+internal fun spannedToAnnotatedString(spanned: Spanned): AnnotatedString = buildAnnotatedString {
+    append(spanned.toString())
+    for (span in spanned.getSpans(0, spanned.length, StyleSpan::class.java)) {
+        val start = spanned.getSpanStart(span)
+        val end = spanned.getSpanEnd(span)
+        when (span.style) {
+            android.graphics.Typeface.ITALIC -> addStyle(SpanStyle(fontStyle = FontStyle.Italic), start, end)
+            android.graphics.Typeface.BOLD -> addStyle(SpanStyle(fontWeight = FontWeight.Bold), start, end)
+            android.graphics.Typeface.BOLD_ITALIC -> addStyle(SpanStyle(fontWeight = FontWeight.Bold, fontStyle = FontStyle.Italic), start, end)
+        }
+    }
+}
+
+/**
+ * Builds the "(Matt. 1:1; Mark 1:2; ...)" parallels line with each reference
+ * tappable, mirroring the span-based rendering of the RecyclerView pericope
+ * holder including its forced line breaks for certain parallel counts.
+ */
+internal fun buildParallelsAnnotatedString(
+    parallels: Array<String>,
+    parallelListener: (ParallelClickData) -> Unit,
+): AnnotatedString = buildAnnotatedString {
+    append("(")
+
+    val total = parallels.size
+    for (i in 0 until total) {
+        val parallel = parallels[i]
+
+        if (i > 0) {
+            // force new line for certain parallel patterns
+            if (total == 6 && i == 3 || total == 4 && i == 2 || total == 5 && i == 3) {
+                append("; \n")
+            } else {
+                append("; ")
+            }
+        }
+
+        appendParallelCompose(parallel, parallelListener)
+    }
+    append(")")
+}
+
+private fun androidx.compose.ui.text.AnnotatedString.Builder.appendParallelCompose(
+    parallel: String,
+    parallelListener: (ParallelClickData) -> Unit,
+) {
+    fun linked(): Boolean {
+        if (!parallel.startsWith("@")) {
+            return false
+        }
+
+        // look for the end
+        val targetEndPos = parallel.indexOf(' ', 1)
+        if (targetEndPos == -1) {
+            return false
+        }
+
+        val target = parallel.substring(1, targetEndPos)
+        val ariRanges = TargetDecoder.decode(target)
+        if (ariRanges.size() == 0) {
+            return false
+        }
+
+        val display = parallel.substring(targetEndPos + 1)
+
+        withLink(LinkAnnotation.Clickable("parallel") { parallelListener(AriParallelClickData(ariRanges.get(0))) }) {
+            append(display)
+        }
+        return true
+    }
+
+    if (!linked()) {
+        // fallback if the above code fails
+        withLink(LinkAnnotation.Clickable("parallel") { parallelListener(ReferenceParallelClickData(parallel)) }) {
+            append(parallel)
+        }
+    }
+}
+
+/**
+ * Fading overlay scrollbar for the verse list, drawn with the same thumb
+ * drawable the reader picks for the RecyclerView path (light/dark variants by
+ * reading-background luminance). Thumb size and position are estimated from
+ * the average laid-out item height — the standard approach for lazy lists,
+ * where total content height is unknowable without laying everything out.
+ */
+@Composable
+private fun Modifier.verseListScrollbar(listState: LazyListState, thumb: Drawable?): Modifier {
+    if (thumb == null) return this
+
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.isScrollInProgress }.collectLatest { inProgress ->
+            if (inProgress) {
+                visible = true
+            } else {
+                delay(SCROLLBAR_FADE_DELAY_MS)
+                visible = false
+            }
+        }
+    }
+    val alpha by animateFloatAsState(
+        targetValue = if (visible) 1f else 0f,
+        animationSpec = tween(durationMillis = SCROLLBAR_FADE_DURATION_MS),
+        label = "verseListScrollbarAlpha",
+    )
+
+    return drawWithContent {
+        drawContent()
+        if (alpha <= 0.01f) return@drawWithContent
+
+        val info = listState.layoutInfo
+        val items = info.visibleItemsInfo
+        if (items.isEmpty()) return@drawWithContent
+        val totalCount = info.totalItemsCount
+        if (totalCount == 0) return@drawWithContent
+
+        val avg = items.sumOf { it.size }.toFloat() / items.size
+        if (avg <= 0f) return@drawWithContent
+
+        val contentHeight = avg * totalCount + info.beforeContentPadding + info.afterContentPadding
+        val viewportHeight = size.height
+        if (contentHeight <= viewportHeight) return@drawWithContent
+
+        val minThumbHeight = 32.dp.toPx()
+        val thumbHeight = (viewportHeight * viewportHeight / contentHeight).coerceAtLeast(minThumbHeight)
+
+        val first = items.first()
+        val scrolledPx = (first.index * avg - first.offset).coerceAtLeast(0f)
+        val maxScrollPx = (contentHeight - viewportHeight).coerceAtLeast(1f)
+        val fraction = (scrolledPx / maxScrollPx).coerceIn(0f, 1f)
+        val thumbTop = fraction * (viewportHeight - thumbHeight)
+
+        val thumbWidth = if (thumb.intrinsicWidth > 0) thumb.intrinsicWidth.toFloat() else 4.dp.toPx()
+
+        drawIntoCanvas { canvas ->
+            thumb.alpha = (alpha * 255f).toInt().coerceIn(0, 255)
+            thumb.setBounds(
+                (size.width - thumbWidth).toInt(),
+                thumbTop.toInt(),
+                size.width.toInt(),
+                (thumbTop + thumbHeight).toInt(),
+            )
+            thumb.draw(canvas.nativeCanvas)
+        }
+    }
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
@@ -3,10 +3,13 @@ package yuku.alkitab.base.verses
 import android.content.Context
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
+import android.os.Parcelable
 import android.text.Spanned
 import android.text.style.StyleSpan
 import android.util.AttributeSet
 import android.util.SparseIntArray
+import android.view.AbsSavedState
+import android.view.ViewGroup
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.draganddrop.dragAndDropTarget
@@ -52,12 +55,14 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
@@ -109,6 +114,20 @@ class VersesComposeView @JvmOverloads constructor(
     @Composable
     override fun Content() {
         controller?.ListContent()
+    }
+
+    /**
+     * This pane keeps the view id of the RecyclerView it replaces (the
+     * reader's inset listeners and layout assertions look the pane up by id),
+     * so a saved hierarchy state written by the RecyclerView implementation
+     * can arrive here under the same id after the Verse (Compose) setting
+     * changes mid-lifecycle (its restart-triggered `recreate()` saves the old
+     * hierarchy's state). Any state stored under this id is ignored instead
+     * of being force-cast: the reader restores its reading position itself,
+     * from the ari it keeps in the activity instance state.
+     */
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        super.onRestoreInstanceState(AbsSavedState.EMPTY_STATE)
     }
 }
 
@@ -579,9 +598,23 @@ class VersesComposeControllerImpl(
 
     override fun setViewLayoutSize(width: Int, height: Int) {
         composeHost.updateLayoutParams {
-            this.width = width
-            this.height = height
+            this.width = coerceValidLayoutDimension(width)
+            this.height = coerceValidLayoutDimension(height)
         }
+    }
+
+    /**
+     * A negative dimension that is not MATCH_PARENT/WRAP_CONTENT would fall
+     * through every branch of `ViewGroup.getChildMeasureSpec` and measure the
+     * pane with an UNSPECIFIED (infinite) constraint — which a vertically
+     * scrollable LazyColumn rejects with an exception, where a RecyclerView
+     * would silently measure its whole content. Treat such values as 0.
+     */
+    private fun coerceValidLayoutDimension(value: Int): Int = when {
+        value >= 0 -> value
+        value == ViewGroup.LayoutParams.MATCH_PARENT -> value
+        value == ViewGroup.LayoutParams.WRAP_CONTENT -> value
+        else -> 0
     }
 
     override fun setEmptyMessage(message: CharSequence?, textColor: Int) {
@@ -1073,6 +1106,14 @@ internal fun buildParallelsAnnotatedString(
     append(")")
 }
 
+/**
+ * The legacy [yuku.alkitab.base.widget.ParallelSpan] is a plain ClickableSpan,
+ * so parallels render underlined (in the link color, which the pericope text
+ * appearance pins to the font color). The underline is carried here by the
+ * link's own styles.
+ */
+private val parallelLinkStyles = TextLinkStyles(style = SpanStyle(textDecoration = TextDecoration.Underline))
+
 private fun androidx.compose.ui.text.AnnotatedString.Builder.appendParallelCompose(
     parallel: String,
     parallelListener: (ParallelClickData) -> Unit,
@@ -1096,7 +1137,7 @@ private fun androidx.compose.ui.text.AnnotatedString.Builder.appendParallelCompo
 
         val display = parallel.substring(targetEndPos + 1)
 
-        withLink(LinkAnnotation.Clickable("parallel") { parallelListener(AriParallelClickData(ariRanges.get(0))) }) {
+        withLink(LinkAnnotation.Clickable("parallel", parallelLinkStyles) { parallelListener(AriParallelClickData(ariRanges.get(0))) }) {
             append(display)
         }
         return true
@@ -1104,7 +1145,7 @@ private fun androidx.compose.ui.text.AnnotatedString.Builder.appendParallelCompo
 
     if (!linked()) {
         // fallback if the above code fails
-        withLink(LinkAnnotation.Clickable("parallel") { parallelListener(ReferenceParallelClickData(parallel)) }) {
+        withLink(LinkAnnotation.Clickable("parallel", parallelLinkStyles) { parallelListener(ReferenceParallelClickData(parallel)) }) {
             append(parallel)
         }
     }

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
@@ -94,11 +94,9 @@ private const val SCROLLBAR_FADE_DURATION_MS = 400
 private const val EMPTY_MESSAGE_TEXT_SIZE_DP = 14f
 
 /**
- * Host view for the fully Compose-based verse list (the Verse (Compose)
- * experimental setting). A plain [AbstractComposeView] whose content is
- * whatever [VersesComposeControllerImpl] is currently attached; the controller
- * owns all list state so it survives this view's composition being disposed
- * and recreated (e.g. while the reader relocates its toolbar).
+ * Host view for the fully Compose-based verse list. The attached
+ * [VersesComposeControllerImpl] owns all list state, so it survives this view's
+ * composition being disposed and recreated.
  */
 class VersesComposeView @JvmOverloads constructor(
     context: Context,
@@ -117,14 +115,11 @@ class VersesComposeView @JvmOverloads constructor(
     }
 
     /**
-     * This pane keeps the view id of the RecyclerView it replaces (the
-     * reader's inset listeners and layout assertions look the pane up by id),
-     * so a saved hierarchy state written by the RecyclerView implementation
-     * can arrive here under the same id after the Verse (Compose) setting
-     * changes mid-lifecycle (its restart-triggered `recreate()` saves the old
-     * hierarchy's state). Any state stored under this id is ignored instead
-     * of being force-cast: the reader restores its reading position itself,
-     * from the ari it keeps in the activity instance state.
+     * This pane shares its view id with the RecyclerView implementation, so a
+     * hierarchy state saved by that implementation can be restored into this
+     * view when the Verse (Compose) setting changes mid-lifecycle. Such state
+     * is dropped rather than force-cast; the reader restores its reading
+     * position itself, from the ari in the activity instance state.
      */
     override fun onRestoreInstanceState(state: Parcelable?) {
         super.onRestoreInstanceState(AbsSavedState.EMPTY_STATE)
@@ -138,18 +133,7 @@ class VersesComposeView @JvmOverloads constructor(
  *
  * The full controller contract is honored so `IsiActivity`, the split-view
  * manager, gestures, and audio playback drive both implementations
- * identically:
- * - scroll positions are anchored the same way the RecyclerView port anchors
- *   them (a verse "at the top" sits at the view's top edge, ignoring the
- *   scroll-past content padding, except for the very first item);
- * - user scrolls emit [VersesController.VerseScrollListener] callbacks with
- *   the same verse/pericope-block prop semantics, while controller-initiated
- *   snap scrolls stay silent (mirroring RecyclerView, where only drags,
- *   flings, and smooth scrolls produce scroll callbacks);
- * - offscreen item heights, which RecyclerView obtains by measuring a
- *   throwaway holder, are read from a cache of previously laid-out sizes, or
- *   obtained by snapping the item into view first and reading its laid-out
- *   size before applying the final offset in the same frame.
+ * identically.
  */
 class VersesComposeControllerImpl(
     private val composeHost: VersesComposeView,
@@ -189,8 +173,7 @@ class VersesComposeControllerImpl(
     private var paddingBottomPx by mutableIntStateOf(0)
 
     private var emptyMessageState by mutableStateOf<CharSequence?>(null)
-    // Matches the default color of EmptyableRecyclerView's Paint until
-    // setEmptyMessage supplies one.
+    // Default color until setEmptyMessage supplies one.
     private var emptyMessageColorState by mutableIntStateOf(0xff000000.toInt())
     private var scrollbarThumbState by mutableStateOf<Drawable?>(null)
 
@@ -198,24 +181,22 @@ class VersesComposeControllerImpl(
      * The data version most recently reflected by a composition. Scroll
      * commands wait on this before touching [listState], so an index computed
      * against fresh data is never applied while the list still shows the
-     * previous chapter (the LazyColumn equivalent of RecyclerView's
-     * pending-scroll-position-applied-on-next-layout behavior).
+     * previous chapter.
      */
     private val renderedDataVersion = mutableIntStateOf(0)
 
     /**
      * Non-zero while a controller-initiated snap scroll is running, so the
      * scroll-event emitter stays silent for it. Smooth scrolls (audio
-     * highlight) intentionally do not set this: their RecyclerView counterpart
-     * also emits scroll callbacks, which keeps the split panes following the
-     * audio verse.
+     * highlight) intentionally do not set this, so the split panes keep
+     * following the audio verse.
      */
     private var programmaticScrollDepth = 0
 
     /**
      * Laid-out item heights by position, filled as items pass through the
-     * viewport. Only valid for [cacheDataVersion]; used to estimate offscreen
-     * item heights where RecyclerView would measure a throwaway holder.
+     * viewport. Only valid for [cacheDataVersion]; used to estimate the height
+     * of offscreen items.
      */
     private val itemSizeCache = SparseIntArray()
     private var cacheDataVersion = -1
@@ -312,7 +293,7 @@ class VersesComposeControllerImpl(
     /**
      * Runs a scroll operation once the composition has caught up with the data
      * version current at call time, dropping it if the data has changed again
-     * by then (same guard as the RecyclerView implementation's posted scrolls).
+     * by then.
      */
     private fun launchScroll(programmatic: Boolean = true, block: suspend (data: VersesDataModel) -> Unit) {
         val vn = dataVersionNumber.get()
@@ -332,8 +313,7 @@ class VersesComposeControllerImpl(
     /**
      * Scroll offset that puts the item's top at the view's top edge (ignoring
      * the scroll-past top padding), except for the very first item which sits
-     * below the padding — the same anchoring RecyclerView achieves with its
-     * `paddingNegator`.
+     * below the padding.
      */
     private fun snapOffsetPx(position: Int): Int = if (position == 0) 0 else paddingTopPx
 
@@ -416,9 +396,9 @@ class VersesComposeControllerImpl(
                 combinedHeight += size
             }
             if (unknown) {
-                // Snap the block into view so its items get laid out, then
-                // read the real sizes; the final snap below lands in the same
-                // frame, so no intermediate position is ever rendered.
+                // Snap the block into view so its items get laid out and their
+                // real sizes can be read; the final snap below lands in the
+                // same frame, so no intermediate position is ever rendered.
                 listState.scrollToItem(blockStartPos, snapBase)
                 combinedHeight = 0
                 for (p in blockStartPos until versePos) {
@@ -604,11 +584,10 @@ class VersesComposeControllerImpl(
     }
 
     /**
-     * A negative dimension that is not MATCH_PARENT/WRAP_CONTENT would fall
-     * through every branch of `ViewGroup.getChildMeasureSpec` and measure the
-     * pane with an UNSPECIFIED (infinite) constraint — which a vertically
-     * scrollable LazyColumn rejects with an exception, where a RecyclerView
-     * would silently measure its whole content. Treat such values as 0.
+     * A negative dimension that is not MATCH_PARENT/WRAP_CONTENT falls through
+     * every branch of `ViewGroup.getChildMeasureSpec` and measures the pane
+     * with an UNSPECIFIED (infinite) constraint, which a vertically scrollable
+     * LazyColumn rejects with an exception. Treat such values as 0.
      */
     private fun coerceValidLayoutDimension(value: Int): Int = when {
         value >= 0 -> value
@@ -632,9 +611,8 @@ class VersesComposeControllerImpl(
     }
 
     override fun setAudioHighlight(verse_1: Int, color: Int) {
-        // Fast-path: this method is called every 100ms during playback
-        // (mirroring the service's position poll). Bailing out when nothing
-        // actually changed avoids restarting the highlight scroll.
+        // Called every 100ms during playback, so bail out when nothing changed
+        // to avoid restarting the highlight scroll.
         if (audioHighlightVerse1 == verse_1 && audioHighlightColorState == color) return
 
         audioHighlightVerse1 = verse_1
@@ -645,11 +623,7 @@ class VersesComposeControllerImpl(
         if (pos == -1) return
 
         // Smooth-scroll the highlighted verse so its top sits at the upper 10%
-        // of the viewport — keeps a thin slice of the previous verse visible
-        // for context while leaving room for upcoming verses below. Skipped
-        // when the row is already fully visible inside the viewport: yanking
-        // the page when the verse is sitting right in front of the user is
-        // more distracting than helpful.
+        // of the viewport, unless the row is already fully visible.
         launchScroll(programmatic = false) { data ->
             if (pos >= data.itemCount) return@launchScroll
 
@@ -668,9 +642,8 @@ class VersesComposeControllerImpl(
             } else {
                 listState.animateScrollToItem(pos, paddingTopPx)
                 val landed = visibleItemSizePx(pos) ?: return@launchScroll
-                // The item's top now sits at the view's top edge; nudge it
-                // down to the 10% mark (bounded by its height so a very short
-                // viewport can't scroll it back out).
+                // The item's top now sits at the view's top edge; nudge it down
+                // to the 10% mark.
                 if (landed > 0) {
                     val topVisual = listState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == pos }
                         ?.let { it.offset + paddingTopPx }
@@ -685,9 +658,9 @@ class VersesComposeControllerImpl(
     // --- Scroll event emission (split-pane sync) ---
 
     /**
-     * Mirror of the RecyclerView scroll listener: reports the first visible
-     * verse (or the pericope-header block above it, treated as one anchor
-     * unit) and the fraction of its extent scrolled past the view's top edge.
+     * Reports the first visible verse (or the pericope-header block above it,
+     * treated as one anchor unit) and the fraction of its extent scrolled past
+     * the view's top edge.
      */
     private fun emitVerseScrollEvents() {
         val data = dataWithVersion.data
@@ -718,10 +691,9 @@ class VersesComposeControllerImpl(
         if (verseOrPericope > 0) {
             listeners.verseScrollListener.onVerseScroll(false, verseOrPericope, prop)
         } else {
-            // Contiguous pericope headers above a verse are reported
-            // as a single anchor unit so panes whose versions have
-            // different pericope counts/heights stay aligned across
-            // the whole block instead of bumping at each header.
+            // Contiguous pericope headers above a verse are reported as a
+            // single anchor unit, so panes whose versions have different
+            // pericope counts stay aligned across the whole block.
             var blockStartPos = position
             while (blockStartPos > 0 &&
                 data.getItemViewType(blockStartPos - 1) == ItemType.pericope
@@ -773,9 +745,8 @@ class VersesComposeControllerImpl(
             renderedDataVersion.intValue = dataW.vn
         }
 
-        // Record laid-out item sizes for offscreen-height estimates. Keyed by
-        // the rendered data version so sizes from a previous chapter never
-        // leak into the new one.
+        // Record laid-out item sizes for offscreen-height estimates, keyed by
+        // data version so sizes from another chapter never leak in.
         LaunchedEffect(Unit) {
             snapshotFlow { listState.layoutInfo.visibleItemsInfo }.collect { visible ->
                 val vn = renderedDataVersion.intValue
@@ -804,8 +775,8 @@ class VersesComposeControllerImpl(
                 }
         }
 
-        // Strip fontScale from the density: verse text uses dp sizing (not
-        // sp), so the system font scale must not multiply on top.
+        // Verse text uses dp sizing, so the system font scale must not
+        // multiply on top of it.
         val baseDensity = LocalDensity.current
         val unscaledDensity = remember(baseDensity.density) {
             Density(density = baseDensity.density, fontScale = 1f)
@@ -917,9 +888,8 @@ class VersesComposeControllerImpl(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                // TalkBack reads the row as one unit (verse number, text, and
-                // attribute summaries), matching the View implementations, and
-                // can activate it like the legacy row's View click listener.
+                // TalkBack reads the row as one unit: verse number, text, and
+                // attribute summaries.
                 .clearAndSetSemantics {
                     contentDescription = description
                     onClick {
@@ -939,8 +909,7 @@ class VersesComposeControllerImpl(
                 audioHighlightColor = audioColor,
                 attentionStart = attentionStart,
                 dragHover = dragHover.value,
-                // The overlay stops drawing by itself once the flash has
-                // decayed; there is no per-row state to reset here.
+                // The overlay stops drawing by itself once the flash decays.
                 onAttentionDone = {},
             )
         }
@@ -1079,8 +1048,7 @@ internal fun spannedToAnnotatedString(spanned: Spanned): AnnotatedString = build
 
 /**
  * Builds the "(Matt. 1:1; Mark 1:2; ...)" parallels line with each reference
- * tappable, mirroring the span-based rendering of the RecyclerView pericope
- * holder including its forced line breaks for certain parallel counts.
+ * tappable.
  */
 internal fun buildParallelsAnnotatedString(
     parallels: Array<String>,
@@ -1107,10 +1075,8 @@ internal fun buildParallelsAnnotatedString(
 }
 
 /**
- * The legacy [yuku.alkitab.base.widget.ParallelSpan] is a plain ClickableSpan,
- * so parallels render underlined (in the link color, which the pericope text
- * appearance pins to the font color). The underline is carried here by the
- * link's own styles.
+ * Parallels render underlined, like the ClickableSpan-based
+ * [yuku.alkitab.base.widget.ParallelSpan].
  */
 private val parallelLinkStyles = TextLinkStyles(style = SpanStyle(textDecoration = TextDecoration.Underline))
 
@@ -1152,11 +1118,10 @@ private fun androidx.compose.ui.text.AnnotatedString.Builder.appendParallelCompo
 }
 
 /**
- * Fading overlay scrollbar for the verse list, drawn with the same thumb
- * drawable the reader picks for the RecyclerView path (light/dark variants by
- * reading-background luminance). Thumb size and position are estimated from
- * the average laid-out item height — the standard approach for lazy lists,
- * where total content height is unknowable without laying everything out.
+ * Fading overlay scrollbar for the verse list, drawn with the thumb drawable
+ * the reader supplies. Thumb size and position are estimated from the average
+ * laid-out item height, since the total content height of a lazy list is
+ * unknowable without laying everything out.
  */
 @Composable
 private fun Modifier.verseListScrollbar(listState: LazyListState, thumb: Drawable?): Modifier {

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesControllerImpl.kt
@@ -34,7 +34,6 @@ import yuku.alkitab.base.widget.PericopeHeaderItem
 import yuku.alkitab.base.widget.ReferenceParallelClickData
 import yuku.alkitab.base.widget.ScrollbarSetter.setVerticalThumb
 import yuku.alkitab.base.widget.VerseRenderer
-import yuku.alkitab.base.widget.VerseRendererCompose
 import yuku.alkitab.debug.R
 import yuku.alkitab.model.SingleChapterVerses
 import yuku.alkitab.util.Ari
@@ -825,110 +824,23 @@ class VerseTextComposeHolder(private val view: VerseItemComposeView) : ItemHolde
         index: Int,
     ) {
         val verse_1 = index + 1
-        val ari = Ari.encodeWithBc(data.ari_bc_, verse_1)
         val text = data.verses_.getVerse(index)
-        val verseNumberText = data.verses_.getVerseNumberText(index)
-        val highlightInfo = data.versesAttributes.highlightInfoMap_[index]
 
-        val renderResult = VerseRendererCompose.render(
-            isVerseNumberShown = ui.isVerseNumberShown,
-            ari = ari,
-            text = text,
-            verseNumberText = verseNumberText,
-            highlightInfo = highlightInfo,
+        val state = buildVerseItemComposeState(
+            context = view.context,
+            data = data,
+            ui = ui,
+            listeners = listeners,
+            index = index,
             checked = checked,
+            currentPosition = { bindingAdapterPosition },
+            toggleChecked = toggleChecked,
+            inlineLinkViewProvider = { view },
         )
-
-        val textSizeMult = if (data.verses_ is SingleChapterVerses.WithTextSizeMult) {
-            data.verses_.getTextSizeMult(index)
-        } else {
-            ui.textSizeMult
-        }
-
-        val applied = App.services.uiDimensions.applied()
-        val fontSizeDp = applied.fontSize2dp * textSizeMult
-        val verseNumberFontSizeDp = applied.fontSize2dp * 0.7f * textSizeMult
-        val attributeScale = scaleForAttributeView(applied.fontSize2dp * ui.textSizeMult)
-
-        // Pre-resolve progress-mark captions at bind time so the
-        // accessibility path (getContentDescription) doesn't run a DB query
-        // on every TalkBack read. Mirrors the values the legacy
-        // VerseItem.getContentDescription resolves inline.
-        val progressMarkBits = data.versesAttributes.progressMarkBitsMap_[index]
-        val progressMarkCaptions: List<String?> = (0 until yuku.alkitab.base.widget.AttributeView.PROGRESS_MARK_TOTAL_COUNT).map { presetId ->
-            if (progressMarkBits and (1 shl (yuku.alkitab.base.widget.AttributeView.PROGRESS_MARK_BITS_START + presetId)) == 0) {
-                null
-            } else {
-                App.services.storage.db.getProgressMarkByPresetId(presetId)?.let { progressMark ->
-                    if (progressMark.caption.isNullOrEmpty()) {
-                        view.context.getString(yuku.alkitab.base.widget.AttributeView.getDefaultProgressMarkStringResource(presetId))
-                    } else {
-                        progressMark.caption
-                    }
-                }
-            }
-        }
-
-        val state = VerseItemComposeState(
-            render = renderResult,
-            fontSizeDp = fontSizeDp,
-            verseNumberFontSizeDp = verseNumberFontSizeDp,
-            fontColor = applied.fontColor,
-            verseNumberColor = applied.verseNumberColor,
-            lineSpacingMult = applied.lineSpacingMult,
-            typeface = applied.fontFace,
-            fontBold = applied.fontBold,
-            attribute = AttributeState(
-                bookmarkCount = data.versesAttributes.bookmarkCountMap_[index],
-                noteCount = data.versesAttributes.noteCountMap_[index],
-                progressMarkBits = progressMarkBits,
-                hasMaps = data.versesAttributes.hasMapsMap_[index],
-                scale = attributeScale,
-                version = data.version_,
-                versionId = data.versionId_,
-                ari = ari,
-                attributeListener = listeners.attributeListener,
-                progressMarkCaptions = progressMarkCaptions,
-            ),
-            onClick = {
-                when (ui.verseSelectionMode) {
-                    VersesController.VerseSelectionMode.none -> Unit
-                    VersesController.VerseSelectionMode.singleClick -> {
-                        val adapterPosition = bindingAdapterPosition
-                        if (adapterPosition != -1) {
-                            listeners.selectedVersesListener.onVerseSingleClick(data.getVerse_1FromPosition(adapterPosition))
-                        }
-                    }
-                    VersesController.VerseSelectionMode.multiple -> {
-                        val adapterPosition = bindingAdapterPosition
-                        if (adapterPosition != -1) {
-                            toggleChecked(adapterPosition)
-                        }
-                    }
-                }
-            },
-            onInlineLinkClick = { type, arif ->
-                // Reuse the same factory as the legacy path so footnote / xref
-                // dialogs etc. open with identical semantics.
-                listeners.inlineLinkSpanFactory_.create(type, arif).onClick(view)
-            },
-            onPinDropped = { presetId ->
-                val adapterPosition = bindingAdapterPosition
-                if (adapterPosition != -1) {
-                    listeners.pinDropListener.onPinDropped(presetId, Ari.encodeWithBc(data.ari_bc_, data.getVerse_1FromPosition(adapterPosition)))
-                }
-            },
-        )
-
-        val attr = state.attribute
-        val attributeShowingSomething = attr.bookmarkCount > 0 ||
-            attr.noteCount > 0 ||
-            (attr.progressMarkBits and yuku.alkitab.base.widget.AttributeView.PROGRESS_MARK_BIT_MASK) != 0 ||
-            attr.hasMaps
 
         view.bind(state)
         view.checked = checked
-        view.collapsed = text.isEmpty() && !attributeShowingSomething
+        view.collapsed = text.isEmpty() && !state.attribute.isShowingSomething
 
         // Attention: same logic as VerseTextHolder.
         if (attention.hasAny() && verse_1 in attention.verses_1) {
@@ -939,14 +851,6 @@ class VerseTextComposeHolder(private val view: VerseItemComposeView) : ItemHolde
 
         // Audio highlight: same poke-on-rebind as VerseTextHolder.
         view.audioHighlightColor = if (verse_1 == audioHighlight.verse_1) audioHighlight.color else 0
-    }
-
-    private fun scaleForAttributeView(fontSizeDp: Float) = when {
-        fontSizeDp >= 13 && fontSizeDp < 24 -> 1f
-        fontSizeDp < 8 -> 0.5f
-        fontSizeDp < 18 -> 0.75f
-        fontSizeDp >= 36 -> 2f
-        else -> 1.5f
     }
 }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
@@ -316,7 +316,12 @@ class SplitViewManager(
             splitRoot.orientation = LinearLayout.VERTICAL
 
             val totalHeight = splitRoot.height
-            val masterHeight = ((totalHeight - splitHandleThickness) * prop).toInt()
+            // splitRoot may not have been laid out yet (height 0, e.g. when the
+            // split is restored during activity creation); without the clamp
+            // the master pane would get a negative height, which measures as an
+            // UNSPECIFIED (infinite) constraint. The global-layout listener
+            // redistributes the sizes once the real dimensions are known.
+            val masterHeight = ((totalHeight - splitHandleThickness) * prop).toInt().coerceAtLeast(0)
 
             run {
                 // divide the screen space
@@ -334,7 +339,7 @@ class SplitViewManager(
             splitRoot.orientation = LinearLayout.HORIZONTAL
 
             val totalWidth = splitRoot.width
-            val masterWidth = ((totalWidth - splitHandleThickness) * prop).toInt()
+            val masterWidth = ((totalWidth - splitHandleThickness) * prop).toInt().coerceAtLeast(0)
 
             run {
                 // divide the screen space

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
@@ -316,11 +316,10 @@ class SplitViewManager(
             splitRoot.orientation = LinearLayout.VERTICAL
 
             val totalHeight = splitRoot.height
-            // splitRoot may not have been laid out yet (height 0, e.g. when the
-            // split is restored during activity creation); without the clamp
-            // the master pane would get a negative height, which measures as an
-            // UNSPECIFIED (infinite) constraint. The global-layout listener
-            // redistributes the sizes once the real dimensions are known.
+            // splitRoot may not have been laid out yet (height 0, e.g. when
+            // the split is restored during activity creation). A negative pane
+            // height measures as an UNSPECIFIED (infinite) constraint; the
+            // global-layout listener redistributes the real sizes later.
             val masterHeight = ((totalHeight - splitHandleThickness) * prop).toInt().coerceAtLeast(0)
 
             run {

--- a/Alkitab/src/main/res/values-in/pref_labels.xml
+++ b/Alkitab/src/main/res/values-in/pref_labels.xml
@@ -30,7 +30,7 @@
     <string name="pref_experimental">Fitur eksperimental</string>
     <string name="pref_experimental_warning">Mungkin belum stabil. Matikan jika bermasalah.</string>
     <string name="pref_useComposeVerseItem_title">Tampilan ayat (Compose)</string>
-    <string name="pref_useComposeVerseItem_summary">Tampilkan tiap ayat dengan implementasi Jetpack Compose yang baru, bukan tampilan lama. Buka sebuah pasal untuk melihat perubahannya.</string>
+    <string name="pref_useComposeVerseItem_summary">Tampilkan teks Alkitab dengan daftar ayat yang sepenuhnya berbasis Jetpack Compose, bukan tampilan lama. Berlaku setelah layar pembacaan dibuka kembali.</string>
     <string name="pref_useComposeGoto_title">Navigasi (Compose)</string>
     <string name="pref_useComposeGoto_summary">Tampilkan layar Navigasi versi Jetpack Compose yang baru, bukan implementasi lama dengan tab.</string>
     <string name="pref_useComposeSong_title">Lirik lagu (Compose)</string>

--- a/Alkitab/src/main/res/values/pref_labels.xml
+++ b/Alkitab/src/main/res/values/pref_labels.xml
@@ -32,8 +32,8 @@
 
     <string name="pref_experimental">Experimental features</string>
     <string name="pref_experimental_warning">May be unstable. Disable if you hit issues.</string>
-    <string name="pref_useComposeVerseItem_title">Verse items (Compose)</string>
-    <string name="pref_useComposeVerseItem_summary">Render each verse with the new Jetpack Compose implementation instead of the legacy custom view. Open a chapter to see the change.</string>
+    <string name="pref_useComposeVerseItem_title">Verse (Compose)</string>
+    <string name="pref_useComposeVerseItem_summary">Show the Bible text with the new, fully Jetpack Compose-based verse list instead of the legacy views. Takes effect when the reader screen is reopened.</string>
     <string name="pref_useComposeGoto_title">Navigation (Compose)</string>
     <string name="pref_useComposeGoto_summary">Show the new Jetpack Compose Navigation screen instead of the legacy tab-based implementation.</string>
     <string name="pref_useComposeSong_title">Song lyrics (Compose)</string>

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/ReaderSideBySideSnapshotTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/ReaderSideBySideSnapshotTest.kt
@@ -1,0 +1,450 @@
+package yuku.alkitab.base.verses
+
+import android.app.Activity
+import android.content.pm.ProviderInfo
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color as AndroidColor
+import android.graphics.Typeface
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.appcompat.app.AppCompatActivity
+import androidx.test.core.app.ApplicationProvider
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.Base64
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import yuku.afw.App as AfwApp
+import yuku.alkitab.base.S
+import yuku.alkitab.base.widget.AttributeView
+import yuku.alkitab.base.widget.LabeledSplitHandleButton
+import yuku.alkitab.base.widget.SplitHandleButton
+import yuku.alkitab.base.widget.TwofingerLinearLayout
+import yuku.alkitab.debug.R
+import yuku.alkitab.model.PericopeBlock
+import yuku.alkitab.model.SingleChapterVerses
+import yuku.alkitab.util.Ari
+import yuku.alkitab.util.IntArrayList
+
+/**
+ * Side-by-side screenshot report comparing the legacy RecyclerView verse
+ * pipeline with the fully Compose one, at the pane level (whole lists rather
+ * than single rows): pericope header with parallels, every attribute icon
+ * type, dictionary-mode word underlines, a selected verse, and the complete
+ * split layout (vertical and horizontal) around the shared
+ * [LabeledSplitHandleButton].
+ *
+ * Like [VerseItemSideBySideSnapshotTest], this is a report generator for
+ * human inspection, not a pixel-diff: it writes PNGs plus a self-contained
+ * `index.html` (images embedded as data URIs) under
+ * `Alkitab/build/snapshots/reader-side-by-side/`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = AfwApp::class, sdk = [34], qualifiers = "w360dp-h640dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class ReaderSideBySideSnapshotTest {
+
+    private val PANE_WIDTH_PX = 360
+    private val PANE_HEIGHT_PX = 380
+    private val SPLIT_WIDTH_PX = 360
+    private val SPLIT_HEIGHT_PX = 640
+
+    private class FakeVerses(private val texts: List<String>) : SingleChapterVerses {
+        override val verseCount: Int get() = texts.size
+        override fun getVerse(verse_0: Int): String = texts[verse_0]
+    }
+
+    private class Case(
+        val name: String,
+        val description: String,
+        val data: VersesDataModel,
+        val checkedVerses: List<Int> = emptyList(),
+        val dictionaryAris: Set<Int> = emptySet(),
+    )
+
+    @Before
+    fun setUp() {
+        AfwApp.initWithAppContext(ApplicationProvider.getApplicationContext())
+
+        val prefContext = ApplicationProvider.getApplicationContext<android.content.Context>()
+        yuku.afw.storage.Preferences.setInt(
+            prefContext.getString(R.string.pref_selectedVerseBgColor_key),
+            0xfffff59d.toInt(),
+        )
+
+        Robolectric.buildContentProvider(FakeDictionaryProvider::class.java).create(
+            ProviderInfo().apply { authority = "org.sabda.kamus.provider" }
+        )
+
+        val dims = S.CalculatedDimensions().apply {
+            fontSize2dp = 17f
+            fontFace = Typeface.DEFAULT
+            fontBold = Typeface.NORMAL
+            fontColor = 0xff202020.toInt()
+            fontRedColor = 0xffcc0000.toInt()
+            verseNumberColor = 0xff445566.toInt()
+            backgroundColor = 0xffffffff.toInt()
+            lineSpacingMult = 1.15f
+            indentParagraphFirst = 38
+            indentParagraphRest = 5
+            indentSpacing1 = 22
+            indentSpacing2 = 38
+            indentSpacing3 = 54
+            indentSpacing4 = 70
+            indentSpacingExtra = 6
+            pericopeSpacingTop = 14
+            pericopeSpacingBottom = 4
+        }
+        S.applied()
+        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
+        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
+        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, dims)
+    }
+
+    private fun idleLoopers() {
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun buildActivity(): AppCompatActivity {
+        val activity = Robolectric.buildActivity(AppCompatActivity::class.java).setup().get()
+        activity.setTheme(androidx.appcompat.R.style.Theme_AppCompat)
+        return activity
+    }
+
+    private val ariBc = Ari.encode(1, 2, 0)
+
+    private fun ariOfVerse(verse_1: Int) = Ari.encodeWithBc(ariBc, verse_1)
+
+    private fun dataModel(
+        verses: List<String>,
+        pericopeBeforeVerse_1: Int? = null,
+        attributes: (VersesAttributes) -> Unit = {},
+    ): VersesDataModel {
+        val versesAttributes = VersesAttributes.createEmpty(verses.size)
+        attributes(versesAttributes)
+        return VersesDataModel(
+            ari_bc_ = ariBc,
+            verses_ = FakeVerses(verses),
+            pericopeBlockCount_ = if (pericopeBeforeVerse_1 != null) 1 else 0,
+            pericopeAris_ = if (pericopeBeforeVerse_1 != null) intArrayOf(ariOfVerse(pericopeBeforeVerse_1)) else IntArray(0),
+            pericopeBlocks_ = if (pericopeBeforeVerse_1 != null) {
+                listOf(PericopeBlock().apply {
+                    title = "@@The @9Creation@7 of the World"
+                    parallels = arrayOf("@a:${Ari.encode(19, 8, 1)} Psalm 8:1", "John 1:1-3")
+                })
+            } else {
+                emptyList()
+            },
+            versesAttributes = versesAttributes,
+        )
+    }
+
+    private fun buildCases(): List<Case> {
+        val pericopeData = dataModel(
+            verses = listOf(
+                "In the beginning God created the heavens and the earth.",
+                "Now the earth was formless and empty, and darkness was over the surface of the deep.",
+            ),
+            pericopeBeforeVerse_1 = 1,
+        )
+
+        val attributesData = dataModel(
+            verses = listOf(
+                "This verse has two bookmarks attached to it.",
+                "This verse has three notes attached to it.",
+                "This verse has two progress-mark pins on it.",
+                "This verse has a maps indicator on it.",
+                "This verse has no attributes at all.",
+            ),
+        ) { attr ->
+            attr.bookmarkCountMap_[0] = 2
+            attr.noteCountMap_[1] = 3
+            attr.progressMarkBitsMap_[2] =
+                (1 shl AttributeView.PROGRESS_MARK_BITS_START) or (1 shl (AttributeView.PROGRESS_MARK_BITS_START + 1))
+            attr.hasMapsMap_[3] = true
+        }
+
+        val dictionaryData = dataModel(
+            verses = listOf(
+                "In the beginning God created the heavens; created them all.",
+                "And everything created was seen to be good.",
+            ),
+        )
+
+        val selectedData = dataModel(
+            verses = listOf(
+                "The first verse is not selected.",
+                "The second verse is the selected one, shown with the selection background.",
+                "The third verse is not selected either.",
+            ),
+        )
+
+        return listOf(
+            Case(
+                name = "pericope-and-parallels",
+                description = "Pericope header: bold centered title with italic segment, plus underlined tappable parallels (one ari target, one plain reference).",
+                data = pericopeData,
+            ),
+            Case(
+                name = "attributes",
+                description = "Attribute icons: bookmark with count 2, note with count 3, two progress-mark pins, maps indicator.",
+                data = attributesData,
+            ),
+            Case(
+                name = "dictionary-underline",
+                description = "Dictionary mode: every occurrence of the word 'created' is underlined per-word.",
+                data = dictionaryData,
+                dictionaryAris = setOf(ariOfVerse(1), ariOfVerse(2)),
+            ),
+            Case(
+                name = "selected-verse",
+                description = "Verse 2 selected (checked): selection background and overridden text color.",
+                data = selectedData,
+                checkedVerses = listOf(2),
+            ),
+        )
+    }
+
+    private fun splitData() = dataModel(
+        verses = List(10) { "Verse ${it + 1} of the split-view chapter, with enough words to wrap onto more than one line." },
+        pericopeBeforeVerse_1 = 1,
+    )
+
+    // --- Legacy (RecyclerView) rendering ---
+
+    private fun renderLegacyPane(case: Case, width: Int, height: Int): Bitmap {
+        val activity = buildActivity()
+        val rv = EmptyableRecyclerView(activity)
+        val controller = VersesControllerImpl(rv, "legacy")
+        configureController(controller, case)
+        return measureAndDraw(rv, width, height)
+    }
+
+    // --- Compose rendering ---
+
+    private fun renderComposePane(case: Case, width: Int, height: Int): Bitmap {
+        val activity = buildActivity()
+        val view = VersesComposeView(activity)
+        val controller = VersesComposeControllerImpl(view, "compose")
+        configureController(controller, case)
+        activity.setContentView(view, ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+        pumpCompose(view, width, height) { controller.listState.layoutInfo.visibleItemsInfo.isNotEmpty() }
+        return measureAndDraw(view, width, height)
+    }
+
+    private fun configureController(controller: VersesController, case: Case) {
+        controller.versesDataModel = case.data
+        controller.versesUiModel = VersesUiModel.EMPTY.copy(
+            isVerseNumberShown = true,
+            dictionaryModeAris = case.dictionaryAris,
+        )
+        if (case.checkedVerses.isNotEmpty()) {
+            val list = IntArrayList()
+            for (v in case.checkedVerses) list.add(v)
+            controller.checkVerses(list, callSelectedVersesListener = false)
+        }
+    }
+
+    private fun pumpCompose(view: View, width: Int, height: Int, composed: () -> Boolean) {
+        var rounds = 0
+        while (true) {
+            idleLoopers()
+            view.measure(
+                View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY),
+            )
+            view.layout(0, 0, width, height)
+            idleLoopers()
+            rounds++
+            if (composed()) return
+            assertTrue("compose pane never composed its items", rounds < 10)
+        }
+    }
+
+    // --- Split layout rendering ---
+
+    private fun renderSplit(vertical: Boolean, compose: Boolean): Bitmap {
+        val activity = buildActivity()
+        val handleThickness = activity.resources.getDimensionPixelSize(R.dimen.split_handle_thickness)
+
+        val splitRoot = TwofingerLinearLayout(activity)
+        splitRoot.orientation = if (vertical) LinearLayout.VERTICAL else LinearLayout.HORIZONTAL
+
+        val handle = LabeledSplitHandleButton(activity, null)
+        handle.orientation = if (vertical) SplitHandleButton.Orientation.vertical else SplitHandleButton.Orientation.horizontal
+        handle.setLabel1("▲ KJV")
+        handle.setLabel2("TB ▼")
+
+        val case = Case("split", "", splitData())
+
+        val pane0Params: LinearLayout.LayoutParams
+        val handleParams: LinearLayout.LayoutParams
+        val pane1Params: LinearLayout.LayoutParams
+        if (vertical) {
+            pane0Params = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, (SPLIT_HEIGHT_PX - handleThickness) / 2)
+            handleParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, handleThickness)
+            pane1Params = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+        } else {
+            pane0Params = LinearLayout.LayoutParams((SPLIT_WIDTH_PX - handleThickness) / 2, ViewGroup.LayoutParams.MATCH_PARENT)
+            handleParams = LinearLayout.LayoutParams(handleThickness, ViewGroup.LayoutParams.MATCH_PARENT)
+            pane1Params = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+        }
+
+        val composeControllers = mutableListOf<VersesComposeControllerImpl>()
+        if (compose) {
+            val pane0 = VersesComposeView(activity)
+            val pane1 = VersesComposeView(activity)
+            val c0 = VersesComposeControllerImpl(pane0, "split0")
+            val c1 = VersesComposeControllerImpl(pane1, "split1")
+            configureController(c0, case)
+            configureController(c1, case)
+            composeControllers += c0
+            composeControllers += c1
+            splitRoot.addView(pane0, pane0Params)
+            splitRoot.addView(handle, handleParams)
+            splitRoot.addView(pane1, pane1Params)
+        } else {
+            val pane0 = EmptyableRecyclerView(activity)
+            val pane1 = EmptyableRecyclerView(activity)
+            configureController(VersesControllerImpl(pane0, "split0"), case)
+            configureController(VersesControllerImpl(pane1, "split1"), case)
+            splitRoot.addView(pane0, pane0Params)
+            splitRoot.addView(handle, handleParams)
+            splitRoot.addView(pane1, pane1Params)
+        }
+
+        activity.setContentView(splitRoot, ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+        if (compose) {
+            pumpCompose(splitRoot, SPLIT_WIDTH_PX, SPLIT_HEIGHT_PX) {
+                composeControllers.all { it.listState.layoutInfo.visibleItemsInfo.isNotEmpty() }
+            }
+        } else {
+            idleLoopers()
+        }
+        return measureAndDraw(splitRoot, SPLIT_WIDTH_PX, SPLIT_HEIGHT_PX)
+    }
+
+    // --- Bitmap + report plumbing ---
+
+    private fun measureAndDraw(view: View, width: Int, height: Int): Bitmap {
+        view.measure(
+            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY),
+        )
+        view.layout(0, 0, width, height)
+        idleLoopers()
+        view.measure(
+            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY),
+        )
+        view.layout(0, 0, width, height)
+
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(AndroidColor.WHITE)
+        view.draw(canvas)
+        return bitmap
+    }
+
+    private fun toDataUri(bitmap: Bitmap): String {
+        val out = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        return "data:image/png;base64," + Base64.getEncoder().encodeToString(out.toByteArray())
+    }
+
+    private fun savePng(dir: File, name: String, bitmap: Bitmap) {
+        File(dir, name).outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+    }
+
+    private fun resolveSnapshotDir(): File {
+        val override = System.getenv("READER_SIDE_BY_SIDE_SNAPSHOT_DIR")
+        return if (override != null) File(override) else File("build/snapshots/reader-side-by-side")
+    }
+
+    @Test
+    fun `produce side-by-side pane and split-layout snapshots for the legacy and Compose verse pipelines`() {
+        val outputDir = resolveSnapshotDir()
+        outputDir.mkdirs()
+
+        class Row(val name: String, val description: String, val legacy: Bitmap, val compose: Bitmap)
+
+        val rows = mutableListOf<Row>()
+
+        for (case in buildCases()) {
+            FakeDictionaryProvider.lastAnalyzeText = null
+            val legacy = renderLegacyPane(case, PANE_WIDTH_PX, PANE_HEIGHT_PX)
+            val compose = renderComposePane(case, PANE_WIDTH_PX, PANE_HEIGHT_PX)
+            rows += Row(case.name, case.description, legacy, compose)
+        }
+
+        rows += Row(
+            "split-vertical",
+            "Top-bottom split: two panes around the shared LabeledSplitHandleButton (labels + rotate button).",
+            renderSplit(vertical = true, compose = false),
+            renderSplit(vertical = true, compose = true),
+        )
+        rows += Row(
+            "split-horizontal",
+            "Side-by-side split: two panes around the vertical split handle.",
+            renderSplit(vertical = false, compose = false),
+            renderSplit(vertical = false, compose = true),
+        )
+
+        val html = StringBuilder()
+        html.append(
+            """
+            <!doctype html>
+            <html><head><meta charset="utf-8"/><title>Reader: legacy vs Compose</title>
+            <style>
+            body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 24px; }
+            table { border-collapse: collapse; }
+            td, th { vertical-align: top; padding: 8px 12px; border-bottom: 1px solid #ddd; }
+            th { text-align: left; background: #f4f4f4; position: sticky; top: 0; }
+            td.label { width: 280px; }
+            td.label .name { font-weight: 600; }
+            td.label p { margin: 4px 0 0; color: #444; font-size: 13px; }
+            img { display: block; max-width: 400px; image-rendering: pixelated; border: 1px solid #eee; }
+            </style></head>
+            <body>
+            <h1>Reader pipelines: legacy (RecyclerView) vs Verse (Compose)</h1>
+            <p>Whole-pane and split-layout renders from identical data. Compare the two columns row by row.</p>
+            <table>
+              <thead><tr><th>Case</th><th>Legacy</th><th>Compose</th></tr></thead>
+              <tbody>
+            """.trimIndent()
+        )
+
+        for (row in rows) {
+            savePng(outputDir, "${row.name}-legacy.png", row.legacy)
+            savePng(outputDir, "${row.name}-compose.png", row.compose)
+            html.append(
+                "<tr>" +
+                    "<td class=\"label\"><div class=\"name\">${escapeHtml(row.name)}</div><p>${escapeHtml(row.description)}</p></td>" +
+                    "<td><img src=\"${toDataUri(row.legacy)}\"/></td>" +
+                    "<td><img src=\"${toDataUri(row.compose)}\"/></td>" +
+                    "</tr>\n"
+            )
+        }
+
+        html.append("</tbody></table></body></html>")
+
+        val indexFile = File(outputDir, "index.html")
+        indexFile.writeText(html.toString())
+
+        println("Reader side-by-side report written to: ${indexFile.absolutePath}")
+        assertTrue("index.html should exist", indexFile.exists())
+    }
+
+    private fun escapeHtml(s: String): String =
+        s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;")
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemComposeDictionaryTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemComposeDictionaryTest.kt
@@ -1,0 +1,198 @@
+package yuku.alkitab.base.verses
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.ProviderInfo
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.graphics.Typeface
+import android.net.Uri
+import android.view.View
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import yuku.afw.App as AfwApp
+import yuku.alkitab.base.S
+import yuku.alkitab.base.widget.DictionaryLinkInfo
+import yuku.alkitab.debug.R
+import yuku.alkitab.model.SingleChapterVerses
+import yuku.alkitab.util.Ari
+
+/**
+ * Fake analyzer for the dictionary app's content provider: recognizes every
+ * occurrence of the word "created" in the analyzed text.
+ */
+class FakeDictionaryProvider : ContentProvider() {
+    override fun onCreate(): Boolean = true
+
+    override fun query(uri: Uri, projection: Array<String>?, selection: String?, selectionArgs: Array<String>?, sortOrder: String?): Cursor {
+        val text = uri.getQueryParameter("text").orEmpty()
+        lastAnalyzeText = text
+
+        val cursor = MatrixCursor(arrayOf("offset", "len", "key"))
+        var index = text.indexOf(RECOGNIZED_WORD)
+        while (index >= 0) {
+            cursor.addRow(arrayOf<Any>(index, RECOGNIZED_WORD.length, "key_$RECOGNIZED_WORD"))
+            index = text.indexOf(RECOGNIZED_WORD, index + 1)
+        }
+        return cursor
+    }
+
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+    override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    companion object {
+        const val RECOGNIZED_WORD = "created"
+        var lastAnalyzeText: String? = null
+    }
+}
+
+/**
+ * Tests for the dictionary-mode word links on the Compose verse row state:
+ * words reported by the analyzer content provider become underlined,
+ * tappable link ranges that call the dictionary listener, mirroring the
+ * legacy DictionaryLinkSpan behavior.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = AfwApp::class, sdk = [34])
+class VerseItemComposeDictionaryTest {
+
+    private class FakeVerses(private val texts: List<String>) : SingleChapterVerses {
+        override val verseCount: Int get() = texts.size
+        override fun getVerse(verse_0: Int): String = texts[verse_0]
+    }
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        AfwApp.initWithAppContext(context)
+
+        FakeDictionaryProvider.lastAnalyzeText = null
+
+        val dims = S.CalculatedDimensions().apply {
+            fontSize2dp = 17f
+            fontFace = Typeface.DEFAULT
+            fontBold = Typeface.NORMAL
+            fontColor = 0xff202020.toInt()
+            fontRedColor = 0xffcc0000.toInt()
+            verseNumberColor = 0xff445566.toInt()
+            lineSpacingMult = 1.15f
+        }
+        S.applied()
+        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
+        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
+        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, dims)
+    }
+
+    private fun registerDictionaryProvider() {
+        Robolectric.buildContentProvider(FakeDictionaryProvider::class.java).create(
+            ProviderInfo().apply { authority = "org.sabda.kamus.provider" }
+        )
+    }
+
+    private val verseText = "In the beginning God created the heavens; created them all."
+
+    private fun buildState(
+        dictionaryMode: Boolean,
+        checked: Boolean = false,
+        clicked: MutableList<DictionaryLinkInfo> = mutableListOf(),
+    ): VerseItemComposeState {
+        val data = VersesDataModel(
+            ari_bc_ = Ari.encode(1, 2, 0),
+            verses_ = FakeVerses(listOf(verseText)),
+        )
+        val ari = Ari.encodeWithBc(data.ari_bc_, 1)
+        val ui = VersesUiModel.EMPTY.copy(
+            isVerseNumberShown = true,
+            dictionaryModeAris = if (dictionaryMode) setOf(ari) else emptySet(),
+        )
+        val listeners = VersesListeners.EMPTY.copy(
+            dictionaryListener_ = { info -> clicked.add(info) },
+        )
+        return buildVerseItemComposeState(
+            context = context,
+            data = data,
+            ui = ui,
+            listeners = listeners,
+            index = 0,
+            checked = checked,
+            currentPosition = { 0 },
+            toggleChecked = {},
+            inlineLinkViewProvider = { View(context) },
+        )
+    }
+
+    @Test
+    fun `dictionary mode analyzes the text after the verse number and links every recognized word`() {
+        registerDictionaryProvider()
+        val clicked = mutableListOf<DictionaryLinkInfo>()
+        val state = buildState(dictionaryMode = true, clicked = clicked)
+
+        val startPos = state.render.startPosAfterVerseNumber
+        val fullText = state.render.text.text
+
+        // The analyzer must have received the verse text without the
+        // verse-number prefix.
+        assertTrue(startPos > 0)
+        assertEquals(fullText.substring(startPos), FakeDictionaryProvider.lastAnalyzeText)
+
+        val links = state.render.text.getLinkAnnotations(0, fullText.length)
+        assertEquals(2, links.size)
+        for (link in links) {
+            assertEquals(FakeDictionaryProvider.RECOGNIZED_WORD, fullText.substring(link.start, link.end))
+        }
+
+        // Each linked word range is underlined, like the legacy ClickableSpan.
+        val underlined = state.render.text.spanStyles.filter { it.item.textDecoration == TextDecoration.Underline }
+        assertEquals(2, underlined.size)
+        assertEquals(links.map { it.start to it.end }.toSet(), underlined.map { it.start to it.end }.toSet())
+
+        // Tapping a link reports the word and the analyzer's key.
+        val first = links.minByOrNull { it.start }!!.item as LinkAnnotation.Clickable
+        first.linkInteractionListener!!.onClick(first)
+        assertEquals(1, clicked.size)
+        assertEquals(FakeDictionaryProvider.RECOGNIZED_WORD, clicked[0].orig_text)
+        assertEquals("key_${FakeDictionaryProvider.RECOGNIZED_WORD}", clicked[0].key)
+    }
+
+    @Test
+    fun `without dictionary mode the verse text carries no dictionary links`() {
+        registerDictionaryProvider()
+        val state = buildState(dictionaryMode = false)
+
+        assertTrue(state.render.text.getLinkAnnotations(0, state.render.text.length).isEmpty())
+    }
+
+    @Test
+    fun `automatic lookup analyzes a checked verse even without dictionary mode`() {
+        registerDictionaryProvider()
+        yuku.afw.storage.Preferences.setBoolean(context.getString(R.string.pref_autoDictionaryAnalyze_key), true)
+        try {
+            val state = buildState(dictionaryMode = false, checked = true)
+            assertEquals(2, state.render.text.getLinkAnnotations(0, state.render.text.length).size)
+        } finally {
+            yuku.afw.storage.Preferences.remove(context.getString(R.string.pref_autoDictionaryAnalyze_key))
+        }
+    }
+
+    @Test
+    fun `a missing dictionary provider leaves the rendered text untouched`() {
+        // No provider registered for the authority: safeQuery returns null
+        // and the render result must pass through unchanged.
+        val state = buildState(dictionaryMode = true)
+        assertTrue(state.render.text.getLinkAnnotations(0, state.render.text.length).isEmpty())
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VersesComposeControllerImplTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VersesComposeControllerImplTest.kt
@@ -1,9 +1,14 @@
 package yuku.alkitab.base.verses
 
+import android.os.Parcelable
 import android.text.SpannableStringBuilder
 import android.text.style.StyleSpan
+import android.util.SparseArray
+import android.view.View
+import android.view.ViewGroup
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.font.FontStyle
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -162,6 +167,61 @@ class VersesComposeControllerImplTest {
     }
 
     @Test
+    fun `setViewLayoutSize clamps invalid negative dimensions that would otherwise measure as infinite constraints`() {
+        val controller = VersesComposeControllerImpl(view, "test")
+        view.layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+
+        // The split manager can compute a negative pane height before the
+        // split root is laid out; it must never reach the LayoutParams.
+        controller.setViewLayoutSize(ViewGroup.LayoutParams.MATCH_PARENT, -12)
+        assertEquals(ViewGroup.LayoutParams.MATCH_PARENT, view.layoutParams.width)
+        assertEquals(0, view.layoutParams.height)
+
+        // The special LayoutParams constants and real pixel sizes pass through.
+        controller.setViewLayoutSize(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        assertEquals(ViewGroup.LayoutParams.WRAP_CONTENT, view.layoutParams.height)
+        controller.setViewLayoutSize(150, 320)
+        assertEquals(150, view.layoutParams.width)
+        assertEquals(320, view.layoutParams.height)
+    }
+
+    @Test
+    fun `restoring a RecyclerView saved state into the Compose pane under the same view id does not throw`() {
+        // The Verse (Compose) setting toggles which view type sits under the
+        // pane's id; a restart triggered by the toggle saves the outgoing
+        // RecyclerView hierarchy and restores it into the Compose pane.
+        val paneId = View.generateViewId()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val recyclerView = EmptyableRecyclerView(context)
+        recyclerView.id = paneId
+        recyclerView.layoutManager = LinearLayoutManager(context)
+        val container = SparseArray<Parcelable>()
+        recyclerView.saveHierarchyState(container)
+        assertNotNull(container.get(paneId))
+
+        val composeView = VersesComposeView(context)
+        composeView.id = paneId
+        composeView.restoreHierarchyState(container)
+    }
+
+    @Test
+    fun `restoring a Compose pane saved state into a RecyclerView under the same view id does not throw`() {
+        val paneId = View.generateViewId()
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+
+        val composeView = VersesComposeView(context)
+        composeView.id = paneId
+        val container = SparseArray<Parcelable>()
+        composeView.saveHierarchyState(container)
+
+        val recyclerView = EmptyableRecyclerView(context)
+        recyclerView.id = paneId
+        recyclerView.layoutManager = LinearLayoutManager(context)
+        recyclerView.restoreHierarchyState(container)
+    }
+
+    @Test
     fun `spannedToAnnotatedString maps italic StyleSpans to Compose italic ranges`() {
         val rendered = FormattedTextRenderer.render("@@Before @9italic part@7 after")
         assertTrue(rendered.getSpans(0, rendered.length, StyleSpan::class.java).isNotEmpty())
@@ -196,6 +256,15 @@ class VersesComposeControllerImplTest {
         assertEquals(2, links.size)
         assertEquals("Matthew 1:1", annotated.text.substring(links[0].start, links[0].end))
         assertEquals("Mark 2:2", annotated.text.substring(links[1].start, links[1].end))
+
+        // Underlined like the legacy ClickableSpan-based ParallelSpan.
+        for (link in links) {
+            val clickable = link.item as LinkAnnotation.Clickable
+            assertEquals(
+                androidx.compose.ui.text.style.TextDecoration.Underline,
+                clickable.styles?.style?.textDecoration,
+            )
+        }
 
         // Tapping the second link reports a reference-based parallel.
         val link = links[1].item as LinkAnnotation.Clickable

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VersesComposeControllerImplTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VersesComposeControllerImplTest.kt
@@ -1,0 +1,236 @@
+package yuku.alkitab.base.verses
+
+import android.text.SpannableStringBuilder
+import android.text.style.StyleSpan
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.font.FontStyle
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import yuku.alkitab.base.widget.AriParallelClickData
+import yuku.alkitab.base.widget.FormattedTextRenderer
+import yuku.alkitab.base.widget.ParallelClickData
+import yuku.alkitab.base.widget.ReferenceParallelClickData
+import yuku.alkitab.model.SingleChapterVerses
+import yuku.alkitab.util.Ari
+import yuku.alkitab.util.IntArrayList
+
+/**
+ * Tests for the fully Compose-based verses controller, exercising the parts
+ * of the [VersesController] contract that don't require a running composition
+ * (verse checking, listener callbacks, scroll queries against an un-composed
+ * list) plus the pure text-conversion helpers used by the Compose pericope
+ * header.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class VersesComposeControllerImplTest {
+
+    private class FakeVerses(private val texts: List<String>) : SingleChapterVerses {
+        override val verseCount: Int get() = texts.size
+        override fun getVerse(verse_0: Int): String = texts[verse_0]
+    }
+
+    private lateinit var view: VersesComposeView
+
+    private fun dataModel(verseCount: Int): VersesDataModel {
+        val verses = FakeVerses(List(verseCount) { "Verse ${it + 1}" })
+        return VersesDataModel(
+            ari_bc_ = Ari.encode(1, 2, 0),
+            verses_ = verses,
+        )
+    }
+
+    @Before
+    fun setUp() {
+        view = VersesComposeView(ApplicationProvider.getApplicationContext())
+    }
+
+    @Test
+    fun `checkVerses marks the requested verses and reports them ascending through getCheckedVerses_1`() {
+        val controller = VersesComposeControllerImpl(view, "test")
+        controller.versesDataModel = dataModel(10)
+
+        val toCheck = IntArrayList()
+        toCheck.add(7)
+        toCheck.add(2)
+        toCheck.add(5)
+        controller.checkVerses(toCheck, callSelectedVersesListener = false)
+
+        val checked = controller.getCheckedVerses_1()
+        assertEquals(3, checked.size())
+        assertEquals(2, checked.get(0))
+        assertEquals(5, checked.get(1))
+        assertEquals(7, checked.get(2))
+    }
+
+    @Test
+    fun `checkVerses ignores verse numbers outside the chapter`() {
+        val controller = VersesComposeControllerImpl(view, "test")
+        controller.versesDataModel = dataModel(5)
+
+        val toCheck = IntArrayList()
+        toCheck.add(3)
+        toCheck.add(99)
+        controller.checkVerses(toCheck, callSelectedVersesListener = false)
+
+        val checked = controller.getCheckedVerses_1()
+        assertEquals(1, checked.size())
+        assertEquals(3, checked.get(0))
+    }
+
+    @Test
+    fun `checkVerses with callSelectedVersesListener notifies onSomeVersesSelected and uncheckAllVerses notifies onNoVersesSelected`() {
+        var someSelected: IntArrayList? = null
+        var noneSelectedCalled = false
+        val listeners = VersesListeners.EMPTY.copy(
+            selectedVersesListener = object : VersesController.SelectedVersesListener() {
+                override fun onSomeVersesSelected(verses_1: IntArrayList) {
+                    someSelected = verses_1
+                }
+
+                override fun onNoVersesSelected() {
+                    noneSelectedCalled = true
+                }
+            }
+        )
+        val controller = VersesComposeControllerImpl(view, "test", versesListeners = listeners)
+        controller.versesDataModel = dataModel(10)
+
+        val toCheck = IntArrayList()
+        toCheck.add(4)
+        controller.checkVerses(toCheck, callSelectedVersesListener = true)
+
+        val reported = someSelected
+        assertNotNull(reported)
+        assertEquals(1, reported!!.size())
+        assertEquals(4, reported.get(0))
+        assertFalse(noneSelectedCalled)
+
+        controller.uncheckAllVerses(callSelectedVersesListener = true)
+        assertTrue(noneSelectedCalled)
+        assertEquals(0, controller.getCheckedVerses_1().size())
+    }
+
+    @Test
+    fun `getVerse_1BasedOnScroll returns 0 when the list has never been laid out`() {
+        val controller = VersesComposeControllerImpl(view, "test")
+        controller.versesDataModel = dataModel(10)
+
+        assertEquals(0, controller.getVerse_1BasedOnScroll())
+    }
+
+    @Test
+    fun `scroll requests and highlights on an un-composed list do not throw`() {
+        val controller = VersesComposeControllerImpl(view, "test")
+        controller.versesDataModel = dataModel(10)
+
+        // The view is not attached to a lifecycle, so these must no-op safely.
+        controller.scrollToTop()
+        controller.scrollToVerse(5)
+        controller.scrollToVerse(5, 0.5f)
+        controller.scrollToPericope(5, 0.5f)
+        controller.callAttentionForVerse(3)
+        controller.setAudioHighlight(2, 0x40ff0000)
+        controller.setAudioHighlight(0, 0)
+
+        val down = controller.pageDown()
+        assertTrue(down is VersesController.PressResult.Consumed)
+        val up = controller.pageUp()
+        assertTrue(up is VersesController.PressResult.Consumed)
+    }
+
+    @Test
+    fun `verseDown and verseUp stay within chapter bounds`() {
+        val controller = VersesComposeControllerImpl(view, "test")
+        controller.versesDataModel = dataModel(3)
+
+        // Un-composed list scrolls report verse 0, so verseDown moves to 1.
+        val down = controller.pageDown()
+        assertTrue(down is VersesController.PressResult.Consumed)
+
+        val result = controller.verseDown()
+        assertTrue(result is VersesController.PressResult.Consumed)
+        assertEquals(1, (result as VersesController.PressResult.Consumed).targetVerse_1)
+    }
+
+    @Test
+    fun `spannedToAnnotatedString maps italic StyleSpans to Compose italic ranges`() {
+        val rendered = FormattedTextRenderer.render("@@Before @9italic part@7 after")
+        assertTrue(rendered.getSpans(0, rendered.length, StyleSpan::class.java).isNotEmpty())
+
+        val annotated = spannedToAnnotatedString(rendered)
+        assertEquals("Before italic part after", annotated.text)
+
+        val italicRanges = annotated.spanStyles.filter { it.item.fontStyle == FontStyle.Italic }
+        assertEquals(1, italicRanges.size)
+        val range = italicRanges[0]
+        assertEquals("italic part", annotated.text.substring(range.start, range.end))
+    }
+
+    @Test
+    fun `spannedToAnnotatedString of a plain title has no styles`() {
+        val annotated = spannedToAnnotatedString(SpannableStringBuilder("Plain title"))
+        assertEquals("Plain title", annotated.text)
+        assertTrue(annotated.spanStyles.isEmpty())
+    }
+
+    @Test
+    fun `buildParallelsAnnotatedString wraps every parallel in a clickable link and separates them`() {
+        val clicked = mutableListOf<ParallelClickData>()
+        val annotated = buildParallelsAnnotatedString(
+            arrayOf("Matthew 1:1", "Mark 2:2"),
+            { data -> clicked.add(data) },
+        )
+
+        assertEquals("(Matthew 1:1; Mark 2:2)", annotated.text)
+
+        val links = annotated.getLinkAnnotations(0, annotated.text.length)
+        assertEquals(2, links.size)
+        assertEquals("Matthew 1:1", annotated.text.substring(links[0].start, links[0].end))
+        assertEquals("Mark 2:2", annotated.text.substring(links[1].start, links[1].end))
+
+        // Tapping the second link reports a reference-based parallel.
+        val link = links[1].item as LinkAnnotation.Clickable
+        link.linkInteractionListener!!.onClick(link)
+        assertEquals(1, clicked.size)
+        assertTrue(clicked[0] is ReferenceParallelClickData)
+        assertEquals("Mark 2:2", (clicked[0] as ReferenceParallelClickData).reference)
+    }
+
+    @Test
+    fun `buildParallelsAnnotatedString decodes @-encoded targets into ari click data`() {
+        val clicked = mutableListOf<ParallelClickData>()
+        // "@" target syntax: encoded target, space, display text. The "a:"
+        // target type carries a raw ari decoded by TargetDecoder.
+        val annotated = buildParallelsAnnotatedString(
+            arrayOf("@a:${Ari.encode(0, 1, 1)} Gen. 1:1"),
+            { data -> clicked.add(data) },
+        )
+
+        assertEquals("(Gen. 1:1)", annotated.text)
+        val links = annotated.getLinkAnnotations(0, annotated.text.length)
+        assertEquals(1, links.size)
+
+        val link = links[0].item as LinkAnnotation.Clickable
+        link.linkInteractionListener!!.onClick(link)
+        assertEquals(1, clicked.size)
+        assertTrue(clicked[0] is AriParallelClickData)
+    }
+
+    @Test
+    fun `buildParallelsAnnotatedString forces line breaks for the 4-parallel pattern`() {
+        val annotated = buildParallelsAnnotatedString(
+            arrayOf("A 1", "B 2", "C 3", "D 4"),
+            {},
+        )
+        assertEquals("(A 1; B 2; \nC 3; D 4)", annotated.text)
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VersesComposeListCompositionTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VersesComposeListCompositionTest.kt
@@ -1,0 +1,304 @@
+package yuku.alkitab.base.verses
+
+import android.graphics.Typeface
+import android.graphics.Rect
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import yuku.afw.App as AfwApp
+import yuku.alkitab.base.S
+import yuku.alkitab.debug.R
+import yuku.alkitab.model.PericopeBlock
+import yuku.alkitab.model.SingleChapterVerses
+import yuku.alkitab.util.Ari
+
+/**
+ * Composition-level tests for [VersesComposeControllerImpl]: the LazyColumn
+ * content (verse rows and pericope headers) is actually composed, measured,
+ * and laid out inside a Robolectric activity, then the controller's scroll
+ * contract is exercised against the live layout.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = AfwApp::class, sdk = [34], qualifiers = "w360dp-h640dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class VersesComposeListCompositionTest {
+
+    private val VIEWPORT_WIDTH_PX = 360
+    private val VIEWPORT_HEIGHT_PX = 640
+
+    private class FakeVerses(private val texts: List<String>) : SingleChapterVerses {
+        override val verseCount: Int get() = texts.size
+        override fun getVerse(verse_0: Int): String = texts[verse_0]
+    }
+
+    @Before
+    fun setUp() {
+        AfwApp.initWithAppContext(ApplicationProvider.getApplicationContext())
+
+        val prefContext = ApplicationProvider.getApplicationContext<android.content.Context>()
+        yuku.afw.storage.Preferences.setInt(
+            prefContext.getString(R.string.pref_selectedVerseBgColor_key),
+            0xfffff59d.toInt(),
+        )
+
+        // Deterministic dimensions so the render pipeline never consults real
+        // preferences/resources (mirrors VerseItemSideBySideSnapshotTest).
+        val dims = S.CalculatedDimensions().apply {
+            fontSize2dp = 17f
+            fontFace = Typeface.DEFAULT
+            fontBold = Typeface.NORMAL
+            fontColor = 0xff202020.toInt()
+            fontRedColor = 0xffcc0000.toInt()
+            verseNumberColor = 0xff445566.toInt()
+            backgroundColor = 0xffffffff.toInt()
+            lineSpacingMult = 1.15f
+            indentParagraphFirst = 38
+            indentParagraphRest = 5
+            indentSpacing1 = 22
+            indentSpacing2 = 38
+            indentSpacing3 = 54
+            indentSpacing4 = 70
+            indentSpacingExtra = 6
+            pericopeSpacingTop = 14
+            pericopeSpacingBottom = 4
+        }
+        S.applied()
+        overrideAppliedDimensions(dims)
+    }
+
+    private fun overrideAppliedDimensions(d: S.CalculatedDimensions) {
+        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
+        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
+        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, d)
+    }
+
+    private fun idleLoopers() {
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    /**
+     * A chapter of [verseCount] verses with a pericope header before verse 5
+     * (when the chapter is long enough), so both item types get composed.
+     */
+    private fun dataModel(verseCount: Int): VersesDataModel {
+        // Several lines per verse so a 60-verse chapter is many viewports
+        // tall; mid-chapter verses can then really be scrolled to the top
+        // instead of clamping at the end of the content.
+        val filler = "and more words to push the verse onto several lines ".repeat(3)
+        val verses = FakeVerses(List(verseCount) { "Verse ${it + 1} $filler." })
+        val withPericope = verseCount >= 5
+        return VersesDataModel(
+            ari_bc_ = Ari.encode(1, 2, 0),
+            verses_ = verses,
+            pericopeBlockCount_ = if (withPericope) 1 else 0,
+            pericopeAris_ = if (withPericope) intArrayOf(Ari.encode(1, 2, 5)) else IntArray(0),
+            pericopeBlocks_ = if (withPericope) {
+                listOf(PericopeBlock().apply {
+                    title = "@@A @9formatted@7 pericope title"
+                    parallels = arrayOf("Matthew 1:1", "Mark 2:2")
+                })
+            } else {
+                emptyList()
+            },
+        )
+    }
+
+    private class Harness(
+        val controller: VersesComposeControllerImpl,
+        val view: VersesComposeView,
+    )
+
+    /**
+     * Builds the controller with its data already set BEFORE the view
+     * attaches, so the chapter renders in the attach-time initial composition
+     * and scrolls compose new rows inside the measure pass (LazyLayout
+     * subcomposition). This keeps the tests independent of Robolectric's
+     * recomposition frame clock, which only reliably ticks for the first
+     * activity of a test sandbox — production recomposition paths are
+     * exercised by the sandbox-isolated data-change test below.
+     */
+    private fun composeList(verseCount: Int): Harness {
+        val activity = Robolectric.buildActivity(AppCompatActivity::class.java).setup().get()
+        activity.setTheme(androidx.appcompat.R.style.Theme_AppCompat)
+
+        val view = VersesComposeView(activity)
+        val controller = VersesComposeControllerImpl(view, "test")
+        controller.versesDataModel = dataModel(verseCount)
+        activity.setContentView(
+            view,
+            ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT),
+        )
+
+        val harness = Harness(controller, view)
+        var rounds = 0
+        while (harness.controller.listState.layoutInfo.visibleItemsInfo.isEmpty()) {
+            pumpLayout(harness)
+            rounds++
+            assertTrue("list never composed any items", rounds < 10)
+        }
+        return harness
+    }
+
+    private fun pumpLayout(harness: Harness) {
+        // Two rounds of apply-notification + measure/idle so recomposition →
+        // scroll-command → forced remeasure chains fully settle before
+        // assertions.
+        repeat(2) {
+            idleLoopers()
+            harness.view.measure(
+                View.MeasureSpec.makeMeasureSpec(VIEWPORT_WIDTH_PX, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(VIEWPORT_HEIGHT_PX, View.MeasureSpec.EXACTLY),
+            )
+            harness.view.layout(0, 0, VIEWPORT_WIDTH_PX, VIEWPORT_HEIGHT_PX)
+            idleLoopers()
+        }
+    }
+
+    @Test
+    fun `composing a chapter with verses and a pericope header lays out items and reports verse 1 at the top`() {
+        val harness = composeList(30)
+
+        val info = harness.controller.listState.layoutInfo
+        assertTrue("expected laid-out items, got none", info.visibleItemsInfo.isNotEmpty())
+        // 30 verses + 1 pericope header
+        assertEquals(31, info.totalItemsCount)
+
+        assertEquals(1, harness.controller.getVerse_1BasedOnScroll())
+    }
+
+    @Test
+    fun `scrollToVerse snaps a mid-chapter verse to the top of the viewport`() {
+        val harness = composeList(60)
+
+        harness.controller.scrollToVerse(40)
+        pumpLayout(harness)
+
+        assertEquals(40, harness.controller.getVerse_1BasedOnScroll())
+    }
+
+    @Test
+    fun `scrollToVerse on a verse with a pericope header above scrolls to the header keeping the verse next`() {
+        val harness = composeList(60)
+
+        // Verse 5 has the pericope header directly above it; scrollToVerse
+        // must land on the header, and the verse-based-on-scroll resolves
+        // through the header to verse 5.
+        harness.controller.scrollToVerse(5)
+        pumpLayout(harness)
+
+        assertEquals(5, harness.controller.getVerse_1BasedOnScroll())
+        val firstVisible = harness.controller.listState.layoutInfo.visibleItemsInfo.first()
+        assertEquals(ItemTypeOf(harness.controller.versesDataModel, firstVisible.index), VersesDataModel.ItemType.pericope)
+    }
+
+    @Test
+    fun `scrollToVerse with prop offsets the verse by the requested fraction of its height`() {
+        val harness = composeList(60)
+
+        harness.controller.scrollToVerse(30, 0.5f)
+        pumpLayout(harness)
+
+        val data = harness.controller.versesDataModel
+        val pos = data.getPositionIgnoringPericopeFromVerse(30)
+        val item = harness.controller.listState.layoutInfo.visibleItemsInfo.first { it.index == pos }
+        // Half the verse's height is scrolled past the top edge (offset is
+        // relative to the content start; there is no content padding here).
+        assertEquals(-(item.size / 2).toFloat(), item.offset.toFloat(), 1.5f)
+    }
+
+    @Test
+    // Runs on its own sdk so it gets a fresh Robolectric sandbox whose
+    // recomposition frame clock works: this test is the one that depends on a
+    // recomposition (data set while the view is already attached).
+    @Config(sdk = [33])
+    fun `a scroll requested together with a data change applies to the new chapter's positions`() {
+        val harness = composeList(10)
+
+        harness.controller.versesDataModel = dataModel(60)
+        harness.controller.scrollToVerse(50)
+        pumpLayout(harness)
+        // A second pump lets the post-recomposition scroll command land in
+        // case the first pass only recomposed the new chapter.
+        pumpLayout(harness)
+
+        assertEquals(50, harness.controller.getVerse_1BasedOnScroll())
+    }
+
+    @Test
+    fun `pageDown advances the top verse and reports the new target`() {
+        val harness = composeList(60)
+
+        val result = harness.controller.pageDown()
+        assertTrue(result is VersesController.PressResult.Consumed)
+        pumpLayout(harness)
+
+        val topVerseAfter = harness.controller.getVerse_1BasedOnScroll()
+        assertTrue("expected pageDown to move past verse 1, still at $topVerseAfter", topVerseAfter > 1)
+        assertEquals((result as VersesController.PressResult.Consumed).targetVerse_1, topVerseAfter)
+    }
+
+    @Test
+    fun `verseDown then verseUp returns to the same top verse`() {
+        val harness = composeList(60)
+
+        harness.controller.scrollToVerse(20)
+        pumpLayout(harness)
+        assertEquals(20, harness.controller.getVerse_1BasedOnScroll())
+
+        harness.controller.verseDown()
+        pumpLayout(harness)
+        assertEquals(21, harness.controller.getVerse_1BasedOnScroll())
+
+        harness.controller.verseUp()
+        pumpLayout(harness)
+        assertEquals(20, harness.controller.getVerse_1BasedOnScroll())
+    }
+
+    @Test
+    fun `padding changes and audio highlight on a composed list do not disturb the top-of-list anchor`() {
+        val harness = composeList(30)
+
+        harness.controller.setViewPadding(Rect(10, 20, 10, 20))
+        pumpLayout(harness)
+        // At the very top, the first verse follows the padding into place and
+        // the reported top verse stays 1.
+        assertEquals(1, harness.controller.getVerse_1BasedOnScroll())
+
+        harness.controller.setAudioHighlight(2, 0x40ff0000)
+        pumpLayout(harness)
+        harness.controller.setAudioHighlight(0, 0)
+        pumpLayout(harness)
+        assertEquals(1, harness.controller.getVerse_1BasedOnScroll())
+    }
+
+    @Test
+    fun `checked verses survive a data reload via checkVerses round trip`() {
+        val harness = composeList(30)
+
+        val toCheck = yuku.alkitab.util.IntArrayList()
+        toCheck.add(3)
+        toCheck.add(8)
+        harness.controller.checkVerses(toCheck, callSelectedVersesListener = false)
+        pumpLayout(harness)
+
+        val checked = harness.controller.getCheckedVerses_1()
+        assertEquals(2, checked.size())
+        assertEquals(3, checked.get(0))
+        assertEquals(8, checked.get(1))
+    }
+
+    private fun ItemTypeOf(data: VersesDataModel, position: Int): VersesDataModel.ItemType =
+        data.getItemViewType(position)
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,13 @@ S.activeVersion() → MVersion → Version (abstract)
   → VerseItem (custom RelativeLayout with highlight/selection drawing)
 ```
 
+With the "Verse (Compose)" experimental setting enabled, `IsiActivity` swaps the
+two RecyclerViews for `VersesComposeView`s driven by `VersesComposeControllerImpl`
+(a LazyColumn-based implementation of the same `VersesController` interface):
+`VerseRendererCompose` renders verse text to an `AnnotatedString`, rows reuse
+`VerseItemComposeContent`, and pericope headers are composed natively. Dialogs
+(`VersesDialog`, `XrefDialog`) always use the RecyclerView pipeline.
+
 ### ARI (Alkitab Resource Identifier)
 
 The fundamental addressing scheme — a 24-bit integer encoding book, chapter, and verse:

--- a/docs/tech-debt-remediation.md
+++ b/docs/tech-debt-remediation.md
@@ -63,6 +63,7 @@ This document is an index over the prioritized remediation plan for each tech de
 
 - [REM-21: Migrate Song Storage from Parcelable to JSON](tech-debt-remediation/REM-21-song-json-storage.md) ✅ **2.8** — app-side done; backend redirect branching and `kidung-data` authoring are out of scope (separate repos).
 - [REM-22: Introduce Jetpack Compose for New Screens](tech-debt-remediation/REM-22-jetpack-compose.md) — **2.6** (kicked off; the Goto Compose port is currently gated behind an experimental flag with the legacy screen as default)
+- [REM-45: Migrate the IsiActivity Shell to Compose (Staged)](tech-debt-remediation/REM-45-isiactivity-compose-shell.md) — **2.2** (planned; gated on the Verse (Compose) experimental verse list being promoted to default — see the staged plan for the ordering rationale)
 - [REM-44: Make the Daily-Verse Widget's Version Fallback Explicit](tech-debt-remediation/REM-44-widget-version-fallback.md) — **2.6** (2026-07 audit)
 - [REM-42: Bounded Eviction for the Version Cache](tech-debt-remediation/REM-42-version-cache-eviction.md) — **2.4** (2026-07 audit)
 - [REM-43: Surface or Resolve Cross-Device Sync Conflicts](tech-debt-remediation/REM-43-sync-conflict-handling.md) — **2.4** (long-standing last-write-wins limitation)
@@ -109,6 +110,7 @@ This document is an index over the prioritized remediation plan for each tech de
 | [REM-44](tech-debt-remediation/REM-44-widget-version-fallback.md) | Explicit widget version fallback (2026-07 audit) | **2.6** | 4 |
 | [REM-42](tech-debt-remediation/REM-42-version-cache-eviction.md) | Bounded version-cache eviction (2026-07 audit) | **2.4** | 4 |
 | [REM-43](tech-debt-remediation/REM-43-sync-conflict-handling.md) | Surface/resolve sync conflicts | **2.4** | 4 |
+| [REM-45](tech-debt-remediation/REM-45-isiactivity-compose-shell.md) | IsiActivity Compose shell (staged; gated on Verse (Compose) default) | **2.2** | 4 |
 
 ## Suggested Execution Order
 

--- a/docs/tech-debt-remediation/REM-22-jetpack-compose.md
+++ b/docs/tech-debt-remediation/REM-22-jetpack-compose.md
@@ -11,11 +11,12 @@
 - `BibleAppTheme` (dynamic color on Android 12+) introduced under `yuku.alkitab.base.compose`.
 - `GotoActivity` and the three goto tabs (Dialer / Direct / Grid) implemented as Composables under `compose/goto/` (including the app's first `ViewModel`, `GotoViewModel`). Public API on `GotoActivity` (`createIntent` / `obtainResult` / `Result`) is preserved so call sites in `IsiActivity` keep working unchanged. The legacy View-based screens were later restored as the default (PR #212) and the Compose path is opt-in via `ExperimentalFlags.useComposeGoto()` — both implementations currently coexist inside `GotoActivity`.
 - The iOS-style color picker added in [REM-20](REM-20-ambilwarna-replacement.md) is also a Compose surface (`IosColorPicker` + `ColorPickerDialog`) hosted inside a `ModalBottomSheet`.
+- The reader's verse content view has a fully Compose-based implementation (2026-08): `VersesComposeControllerImpl` + `VersesComposeView` (LazyColumn) implement the complete `VersesController` contract and replace the two reader RecyclerViews when the Verse (Compose) experimental setting is on; verse rows and pericope headers render via `VerseRendererCompose` / `VerseItemComposeContent`, including dictionary-mode word links. The RecyclerView pipeline remains the default and always serves `VersesDialog`/`XrefDialog`.
 
 **Remaining steps:**
 1. Continue with simpler screens: `AboutActivity.kt` (Kotlin, View-based with custom animations), `HelpActivity.java` (Java, WebView-based — convert to Kotlin first)
 2. Gradually migrate: `SettingsActivity` → Compose Preference screens
-3. Do NOT migrate `IsiActivity` verse rendering — too complex and performance-critical for initial Compose adoption
+3. Reader (`IsiActivity`): verse rendering is covered by the experimental Compose verse list above; the rest of the reader shell (split container/handle, gestures, toolbar/action mode, floater, drawer) is tracked as a staged plan in [REM-45](REM-45-isiactivity-compose-shell.md), gated on the Compose verse list being promoted to default first
 
 **Difficulty:** Hard (ongoing effort over months). Risk: Compose interop with existing View-based code requires careful fragment/activity management.
 

--- a/docs/tech-debt-remediation/REM-45-isiactivity-compose-shell.md
+++ b/docs/tech-debt-remediation/REM-45-isiactivity-compose-shell.md
@@ -1,0 +1,88 @@
+# REM-45: Migrate the IsiActivity Shell to Compose (Staged)
+
+**Status:** Planned — gated on the Verse (Compose) experimental verse list being promoted to default (see stage 0/1 below).
+**Addresses:** General modernization; completes the reader's Compose migration beyond the verse content view
+**Module:** UI (reader)
+**BRICE:** B=2 R=1 I=1 C=2 E=5 → **2.2**
+**Phase:** 4 — Long-term / Major Refactors
+
+## Background
+
+The verse content view already has a fully Compose-based implementation behind the
+"Verse (Compose)" experimental setting (2026-08): `VersesComposeControllerImpl` +
+`VersesComposeView` implement the whole `VersesController` contract over a
+`LazyColumn`, swapped in place of the two `EmptyableRecyclerView` panes. The rest
+of the reader — the split container and handle, gestures, toolbar/action mode,
+back/forward panel, floater, drawer — is still View-based, connected through the
+interfaces extracted in REM-06/07/08 (`ReaderGestureHost`, `VerseActionModeHost`,
+`SplitViewHost`/`SplitViewActions`).
+
+This mixed state is *not* itself debt: View/Compose interop is the supported
+migration strategy, and the existing seams are exactly what makes the remaining
+migration cheap. The reason to stage the rest carefully is structural:
+
+- **Dual verse pipelines force the container to stay a ViewGroup.** While the
+  RecyclerView verse list is the default and the Compose list is an experiment,
+  `TwofingerLinearLayout` must be able to host either pane type. Making the
+  container Compose first would push the *default* RecyclerView path into
+  `AndroidView` wrappers — destabilizing production to serve an experiment.
+  The container can only be composified after the Compose verse list becomes
+  the default and the RecyclerView verse pipeline is retired.
+- **The split trio is tightly coupled.** `SplitViewManager`,
+  `LabeledSplitHandleButton`, and `TwofingerLinearLayout` share view-level pixel
+  math (explicit `LayoutParams` sizing during handle drags, orientation
+  switching, a global-layout listener) and View touch-interception semantics
+  (one-finger chapter swipe, two-finger scale/drag over the scrolling panes).
+  A Compose port is a redesign (fraction-based layout + custom gesture
+  arbitration over two `LazyColumn`s), not a translation.
+- **The toolbar drags the action mode with it.** The verse selection UI is an
+  AppCompat `ActionMode` (`VerseActionModeController`) rendered into the
+  toolbar chrome; a Compose toolbar means rebuilding that whole surface.
+
+## Staged plan
+
+1. **Stage 0 — bake the Compose verse list (prerequisite, not this task).**
+   Gather feedback on the experimental setting; verify split-scroll sync feel,
+   fling behavior, TalkBack, drag-and-drop across devices. Exit criterion for
+   moving on: the Compose verse list is promoted to the default.
+2. **Stage 1 — retire the RecyclerView verse pipeline in the reader.** Remove
+   the `IsiActivity` flag branch and the RecyclerView-based reader panes
+   (`VersesDialog`/`XrefDialog` keep `VersesControllerImpl` until ported
+   separately). One verse pipeline in the reader unlocks every later stage.
+3. **Stage 2 — split container, handle, and reader gestures as one project.**
+   Replace `TwofingerLinearLayout` + `LabeledSplitHandleButton` with a Compose
+   split layout; rework `SplitViewManager` to a fraction-based model; port
+   `ReaderGestureHandler`'s one-finger swipe and two-finger scale/drag into
+   Compose pointer input with explicit arbitration against the pane scrolling.
+   Highest-risk stage; needs its own test plan (gesture + split proportion
+   persistence + inset behavior).
+4. **Stage 3 — small overlays, opportunistically.** The back/forward panel
+   (`BackForwardListController`'s two buttons) is a trivial conversion; the
+   `Floater` (custom-drawn drag target fed by `ReaderGestureHandler`) is a
+   moderate one. Either can also be folded into stage 2 if convenient.
+5. **Stage 4 — toolbar and verse action mode.** Replace the AppCompat toolbar
+   (Goto button, prev/next chapter, version button, audio slot) and rebuild the
+   selection action surface currently provided by `startSupportActionMode` /
+   `VerseActionModeController`. Largest user-visible surface; last on purpose.
+6. **Stage 5 — left drawer.** `LeftDrawer` works fine via interop today
+   (including the progress-pin `startDragAndDrop` source feeding the Compose
+   drop targets); port it only once the rest of the shell is Compose.
+
+## Risks
+
+- Stage 2 touches scroll-sync and gesture behavior that users feel immediately;
+  regressions there are worse than keeping Views longer. Do not combine it with
+  unrelated reader changes.
+- Edge-to-edge inset handling in `IsiActivity.setupSafeAreaInsets` is
+  View-listener-based and was tuned per-edge (toolbar location, audio bar,
+  stacked split); each stage that absorbs a view must re-verify cutout/fullscreen
+  behavior.
+- `TextAppearancePanel` overlays and `FancyShowCaseView` tips attach to the View
+  hierarchy; they need interop hosts (or their own ports) as the shell shrinks.
+
+**Difficulty:** Hard (multi-sprint, sequential). Each stage should land
+independently shippable, with the previous stage settled first.
+
+---
+
+[← Back to remediation index](../tech-debt-remediation.md)


### PR DESCRIPTION
## Summary

When the **Verse (Compose)** experimental setting is enabled, `IsiActivity` now replaces its verse content view — the two `EmptyableRecyclerView` panes — with fully Compose-based lists. Each pane becomes a `VersesComposeView` (an `AbstractComposeView`) hosting a `LazyColumn`, driven by the new `VersesComposeControllerImpl`, which implements the complete `VersesController` contract. Because the swap happens behind that interface and the replacement views keep the same view ids, child indices, and layout params, `SplitViewManager`, the two-finger/swipe gesture container, the inset listeners, the action mode, and audio playback all work unchanged on either pipeline. With the setting off (the default), nothing changes; `VersesDialog`/`XrefDialog` always keep the RecyclerView pipeline.

## What the Compose controller mirrors from the RecyclerView implementation

- **Scroll anchoring**: `scrollToVerse`/`scrollToPericope`/`scrollToVerse(prop)` anchor a verse's top at the view's top edge (ignoring scroll-past padding, except for the first item), matching the RecyclerView `paddingNegator` behavior. Offscreen item heights — which RecyclerView gets by measuring a throwaway holder — are read from a cache of laid-out sizes, or by snapping the item into view and applying the final offset in the same frame.
- **Split-pane sync**: user drags/flings emit the same `VerseScrollListener` verse and pericope-block prop callbacks (contiguous headers treated as one anchor unit); controller-initiated snap scrolls stay silent, so panes never feed back into each other.
- **Data-change safety**: scroll commands wait until the composition reflects the data version they were computed against (the LazyColumn equivalent of RecyclerView's pending-scroll-applied-on-next-layout), and are dropped if the data changes again first.
- **Verse rows**: reuse `VerseItemComposeContent` (the row UI of the existing Compose verse-item experiment) through a shared `buildVerseItemComposeState()` extracted from the RecyclerView holder, so both paths build identical row state — including checked overlays, highlights, inline footnote/xref links, attribute icons, attention flash, and audio-highlight overlays.
- **Dictionary mode**: words reported by the dictionary app's analyzer content provider become underlined, tappable `LinkAnnotation`s routed through the existing dictionary listener — the Compose counterpart of `DictionaryLinkSpan`, honoring both manual dictionary mode and the checked-verse automatic-lookup preference. Since the state builder is shared, the RecyclerView-hosted Compose rows gain this too.
- **Pericope headers**: composed natively — centered bold title via `FormattedTextRenderer` converted to an `AnnotatedString`, and tappable parallels via `LinkAnnotation` with the same forced line-break patterns.
- **Everything else**: page/verse volume navigation, insets and preference padding (with pixel-position compensation when top padding changes mid-list), the empty message overlay, a fading overlay scrollbar drawn with the theme-picked thumb drawable, progress-pin drag-and-drop (`Modifier.dragAndDropTarget`), audio highlight with smooth scroll into the upper 10% of the viewport, and TalkBack row descriptions plus a semantic click action.

Toggling the setting now emits `needsRestart` (the same mechanism `DisplayFragment` uses) since the reader builds its content view once at creation; the preference strings were updated accordingly (EN + IN).

## Tests

- `VersesComposeControllerImplTest` — verse checking/listener contract, un-composed-list safety, and the pericope text converters (italic spans, clickable parallels, `@`-target decoding, forced line breaks).
- `VersesComposeListCompositionTest` — Robolectric composition tests that actually lay out the LazyColumn and verify: items + pericope header compose, `scrollToVerse` (plain, prop-offset, and pericope-anchored), `pageDown`, `verseDown`/`verseUp` round trip, padding changes, and the scroll-with-data-change version gate.
- `VerseItemComposeDictionaryTest` — a fake analyzer content provider verifies the analyzed text excludes the verse-number prefix, every recognized word gets an underlined link at the right range, taps deliver the word + key to the dictionary listener, the checked + automatic-lookup path, and that a missing provider leaves the text untouched.
- Full `testPlainDebugUnitTest` + `testPlainReleaseUnitTest` suites and `assemblePlainDebug` are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LSJ5rLw67fJKm7UYLdGHK