### PR TITLE
Keep the split handle drag out of the system navigation gesture areas

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/LeftDrawer.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/LeftDrawer.java
@@ -150,6 +150,16 @@ public abstract class LeftDrawer extends NestedScrollView {
 		drawerLayout.closeDrawer(GravityCompat.START);
 	}
 
+	/**
+	 * Turns the edge swipe that opens this drawer on or off. Callers that own a
+	 * competing horizontal drag near the left edge — the split handle parked
+	 * there — switch it off for the duration of their drag, so the touch does
+	 * not also peek the drawer open.
+	 */
+	public void setEdgeSwipeEnabled(boolean enabled) {
+		drawerLayout.setDrawerLockMode(enabled ? DrawerLayout.LOCK_MODE_UNLOCKED : DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
+	}
+
 	void bHelp_click() {
 		activity.startActivity(AboutActivity.createIntent());
 	}

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitHandleButton.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitHandleButton.java
@@ -1,6 +1,7 @@
 package yuku.alkitab.base.widget;
 
 import android.content.Context;
+import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import static android.view.MotionEvent.ACTION_CANCEL;
@@ -8,6 +9,9 @@ import static android.view.MotionEvent.ACTION_DOWN;
 import static android.view.MotionEvent.ACTION_MOVE;
 import static android.view.MotionEvent.ACTION_UP;
 import androidx.appcompat.widget.AppCompatButton;
+import androidx.core.view.ViewCompat;
+import java.util.Collections;
+import java.util.List;
 
 public class SplitHandleButton extends AppCompatButton {
     public interface SplitHandleButtonListener {
@@ -50,6 +54,22 @@ public class SplitHandleButton extends AppCompatButton {
 
     public void setOrientation(final Orientation orientation) {
         this.orientation = orientation;
+    }
+
+    @Override
+    protected void onLayout(final boolean changed, final int left, final int top, final int right, final int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+
+        // A handle parked against a screen edge overlaps the system's back-gesture
+        // area, where a drag that starts on the bar would be swallowed by the
+        // system instead of resizing the panes. Claiming the bar's own bounds
+        // keeps such a drag with us. The system caps exclusions at 200dp per
+        // edge and honors the rects nearest the bottom, so on a full-height bar
+        // only its lower part is guaranteed. The mandatory gesture area at the
+        // window bottom cannot be claimed at all; the split manager instead
+        // keeps the bar out of it.
+        final List<Rect> exclusion = Collections.singletonList(new Rect(0, 0, right - left, bottom - top));
+        ViewCompat.setSystemGestureExclusionRects(this, exclusion);
     }
 
     @Override

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
@@ -26,17 +26,27 @@ private const val TAG = "SplitViewManager"
 
 /**
  * Master-pane heights that keep the stacked split's handle clear of the
- * system's mandatory gesture areas at the window top and bottom.
+ * system's mandatory gesture areas.
  *
  * Touches starting inside those areas are claimed by the system (home / app
  * switch, notification shade). Unlike the back-gesture areas along the left
  * and right edges, they cannot be excluded, so a handle parked there could be
  * pressed but never dragged back.
  */
-internal fun masterHeightRange(rootHeight: Int, handleThickness: Int, mandatoryInsetTop: Int, mandatoryInsetBottom: Int): IntRange {
-    val max = (rootHeight - handleThickness - mandatoryInsetBottom).coerceAtLeast(0)
-    return mandatoryInsetTop.coerceAtMost(max)..max
+internal fun masterHeightRange(rootHeight: Int, handleThickness: Int, reservedTop: Int, reservedBottom: Int): IntRange {
+    val max = (rootHeight - handleThickness - reservedBottom).coerceAtLeast(0)
+    return reservedTop.coerceAtMost(max)..max
 }
+
+/**
+ * How much of the window top the stacked split's handle has to stay below.
+ *
+ * While the status bar is showing it occupies the top gesture area, so the
+ * handle may sit flush against the window top. In fullscreen there is no bar
+ * over that area and a drag starting there is taken by the system instead.
+ */
+internal fun reservedTopForHandle(mandatoryInsetTop: Int, statusBarVisible: Boolean): Int =
+    if (statusBarVisible) 0 else mandatoryInsetTop
 
 /**
  * Container for the secondary ("split 1") version metadata. Kept as a single
@@ -105,6 +115,7 @@ class SplitViewManager(
             val splitRoot = host.splitRoot
             val splitHandleButton = host.splitHandleButton
             splitRoot.setOnefingerEnabled(false)
+            host.leftDrawer.setEdgeSwipeEnabled(false)
 
             if (splitHandleButton.orientation == SplitHandleButton.Orientation.vertical) {
                 first = splitHandleButton.top
@@ -137,6 +148,7 @@ class SplitViewManager(
 
         override fun onHandleDragStop() {
             host.splitRoot.setOnefingerEnabled(true)
+            host.leftDrawer.setEdgeSwipeEnabled(true)
 
             if (prop != Float.MIN_VALUE) {
                 Preferences.setFloat(Prefkey.lastSplitProp, prop)
@@ -374,10 +386,15 @@ class SplitViewManager(
     }
 
     private fun masterHeightRange(rootHeight: Int, handleThickness: Int): IntRange {
-        val insets = ViewCompat.getRootWindowInsets(host.splitRoot)
-            ?.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())
-            ?: Insets.NONE
-        return masterHeightRange(rootHeight, handleThickness, insets.top, insets.bottom)
+        val rootInsets = ViewCompat.getRootWindowInsets(host.splitRoot)
+        val mandatory = rootInsets?.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures()) ?: Insets.NONE
+        val statusBarVisible = rootInsets?.isVisible(WindowInsetsCompat.Type.statusBars()) ?: true
+        return masterHeightRange(
+            rootHeight,
+            handleThickness,
+            reservedTopForHandle(mandatory.top, statusBarVisible),
+            mandatory.bottom,
+        )
     }
 
     private fun closeSplitDisplay() {

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
@@ -5,6 +5,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.LinearLayout
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
@@ -20,6 +23,20 @@ import yuku.alkitab.debug.R
 import yuku.alkitab.model.Version
 
 private const val TAG = "SplitViewManager"
+
+/**
+ * Master-pane heights that keep the stacked split's handle clear of the
+ * system's mandatory gesture areas at the window top and bottom.
+ *
+ * Touches starting inside those areas are claimed by the system (home / app
+ * switch, notification shade). Unlike the back-gesture areas along the left
+ * and right edges, they cannot be excluded, so a handle parked there could be
+ * pressed but never dragged back.
+ */
+internal fun masterHeightRange(rootHeight: Int, handleThickness: Int, mandatoryInsetTop: Int, mandatoryInsetBottom: Int): IntRange {
+    val max = (rootHeight - handleThickness - mandatoryInsetBottom).coerceAtLeast(0)
+    return mandatoryInsetTop.coerceAtMost(max)..max
+}
 
 /**
  * Container for the secondary ("split 1") version metadata. Kept as a single
@@ -113,9 +130,9 @@ class SplitViewManager(
         override fun onHandleDragMoveY(dySinceLast: Float, dySinceStart: Float) {
             val newH = (first + dySinceStart).toInt()
             val maxH = root - handle
-            val height = if (newH < 0) 0 else if (newH > maxH) maxH else newH
+            val height = newH.coerceIn(masterHeightRange(root, handle))
             host.lsSplit0.setViewLayoutSize(ViewGroup.LayoutParams.MATCH_PARENT, height)
-            prop = height.toFloat() / maxH
+            prop = if (maxH > 0) height.toFloat() / maxH else 0f
         }
 
         override fun onHandleDragStop() {
@@ -320,7 +337,8 @@ class SplitViewManager(
             // the split is restored during activity creation). A negative pane
             // height measures as an UNSPECIFIED (infinite) constraint; the
             // global-layout listener redistributes the real sizes later.
-            val masterHeight = ((totalHeight - splitHandleThickness) * prop).toInt().coerceAtLeast(0)
+            val masterHeight = ((totalHeight - splitHandleThickness) * prop).toInt()
+                .coerceIn(masterHeightRange(totalHeight, splitHandleThickness))
 
             run {
                 // divide the screen space
@@ -353,6 +371,13 @@ class SplitViewManager(
                 height = ViewGroup.LayoutParams.MATCH_PARENT
             }
         }
+    }
+
+    private fun masterHeightRange(rootHeight: Int, handleThickness: Int): IntRange {
+        val insets = ViewCompat.getRootWindowInsets(host.splitRoot)
+            ?.getInsets(WindowInsetsCompat.Type.mandatorySystemGestures())
+            ?: Insets.NONE
+        return masterHeightRange(rootHeight, handleThickness, insets.top, insets.bottom)
     }
 
     private fun closeSplitDisplay() {

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/SplitHandleGestureTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/SplitHandleGestureTest.kt
@@ -13,7 +13,8 @@ import org.robolectric.annotation.Config
  * dragged near a window edge: the back gesture along the left and right edges,
  * and the home / app-switch gesture along the bottom. The back-gesture areas
  * are handed to the handle through a system gesture exclusion rect; the bottom
- * area cannot be excluded, so the handle's travel is bounded instead.
+ * area cannot be excluded, so the handle's travel is bounded instead. The top
+ * is only bounded in fullscreen, where no status bar covers the gesture area.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
@@ -57,23 +58,35 @@ class SplitHandleGestureTest {
         // 1920 tall root, 24px handle, 48px gesture bar at the bottom: the
         // master pane can grow until the handle's bottom edge reaches the
         // gesture area, not until it reaches the window bottom.
-        val range = masterHeightRange(rootHeight = 1920, handleThickness = 24, mandatoryInsetTop = 0, mandatoryInsetBottom = 48)
+        val range = masterHeightRange(rootHeight = 1920, handleThickness = 24, reservedTop = 0, reservedBottom = 48)
 
         assertEquals(0, range.first)
         assertEquals(1848, range.last)
     }
 
     @Test
-    fun `the stacked split starts below the top mandatory gesture area`() {
-        val range = masterHeightRange(rootHeight = 1920, handleThickness = 24, mandatoryInsetTop = 72, mandatoryInsetBottom = 48)
+    fun `the handle reaches the window top while the status bar is showing`() {
+        val reservedTop = reservedTopForHandle(mandatoryInsetTop = 72, statusBarVisible = true)
+        val range = masterHeightRange(rootHeight = 1920, handleThickness = 24, reservedTop = reservedTop, reservedBottom = 48)
 
+        assertEquals(0, reservedTop)
+        assertEquals(0, range.first)
+        assertEquals(1848, range.last)
+    }
+
+    @Test
+    fun `in fullscreen the handle stays below the top mandatory gesture area`() {
+        val reservedTop = reservedTopForHandle(mandatoryInsetTop = 72, statusBarVisible = false)
+        val range = masterHeightRange(rootHeight = 1920, handleThickness = 24, reservedTop = reservedTop, reservedBottom = 48)
+
+        assertEquals(72, reservedTop)
         assertEquals(72, range.first)
         assertEquals(1848, range.last)
     }
 
     @Test
     fun `without mandatory gesture insets the handle can travel the whole root`() {
-        val range = masterHeightRange(rootHeight = 1920, handleThickness = 24, mandatoryInsetTop = 0, mandatoryInsetBottom = 0)
+        val range = masterHeightRange(rootHeight = 1920, handleThickness = 24, reservedTop = 0, reservedBottom = 0)
 
         assertEquals(0, range.first)
         assertEquals(1896, range.last)
@@ -83,7 +96,7 @@ class SplitHandleGestureTest {
     fun `a root smaller than the reserved areas still yields a usable range`() {
         // Before the split root is laid out its height is 0; the range must
         // stay non-empty so coerceIn does not throw.
-        val range = masterHeightRange(rootHeight = 0, handleThickness = 24, mandatoryInsetTop = 72, mandatoryInsetBottom = 48)
+        val range = masterHeightRange(rootHeight = 0, handleThickness = 24, reservedTop = 72, reservedBottom = 48)
 
         assertEquals(0, range.first)
         assertEquals(0, range.last)

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/SplitHandleGestureTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/SplitHandleGestureTest.kt
@@ -1,0 +1,92 @@
+package yuku.alkitab.base.widget
+
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The split handle competes with the system navigation gestures when it is
+ * dragged near a window edge: the back gesture along the left and right edges,
+ * and the home / app-switch gesture along the bottom. The back-gesture areas
+ * are handed to the handle through a system gesture exclusion rect; the bottom
+ * area cannot be excluded, so the handle's travel is bounded instead.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class SplitHandleGestureTest {
+
+    private fun handle(width: Int, height: Int): SplitHandleButton {
+        val button = LabeledSplitHandleButton(ApplicationProvider.getApplicationContext(), null)
+        button.measure(
+            View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY),
+        )
+        button.layout(0, 0, width, height)
+        return button
+    }
+
+    @Test
+    fun `the handle claims its own bounds from the system gesture areas once laid out`() {
+        val button = handle(24, 800)
+
+        val rects = button.systemGestureExclusionRects
+        assertEquals(1, rects.size)
+        assertEquals(0, rects[0].left)
+        assertEquals(0, rects[0].top)
+        assertEquals(24, rects[0].right)
+        assertEquals(800, rects[0].bottom)
+    }
+
+    @Test
+    fun `the exclusion rect follows the handle when it is laid out at a new size`() {
+        val button = handle(24, 800)
+        button.layout(0, 0, 1080, 24)
+
+        val rects = button.systemGestureExclusionRects
+        assertEquals(1, rects.size)
+        assertEquals(1080, rects[0].right)
+        assertEquals(24, rects[0].bottom)
+    }
+
+    @Test
+    fun `the stacked split stops short of the bottom mandatory gesture area`() {
+        // 1920 tall root, 24px handle, 48px gesture bar at the bottom: the
+        // master pane can grow until the handle's bottom edge reaches the
+        // gesture area, not until it reaches the window bottom.
+        val range = masterHeightRange(rootHeight = 1920, handleThickness = 24, mandatoryInsetTop = 0, mandatoryInsetBottom = 48)
+
+        assertEquals(0, range.first)
+        assertEquals(1848, range.last)
+    }
+
+    @Test
+    fun `the stacked split starts below the top mandatory gesture area`() {
+        val range = masterHeightRange(rootHeight = 1920, handleThickness = 24, mandatoryInsetTop = 72, mandatoryInsetBottom = 48)
+
+        assertEquals(72, range.first)
+        assertEquals(1848, range.last)
+    }
+
+    @Test
+    fun `without mandatory gesture insets the handle can travel the whole root`() {
+        val range = masterHeightRange(rootHeight = 1920, handleThickness = 24, mandatoryInsetTop = 0, mandatoryInsetBottom = 0)
+
+        assertEquals(0, range.first)
+        assertEquals(1896, range.last)
+    }
+
+    @Test
+    fun `a root smaller than the reserved areas still yields a usable range`() {
+        // Before the split root is laid out its height is 0; the range must
+        // stay non-empty so coerceIn does not throw.
+        val range = masterHeightRange(rootHeight = 0, handleThickness = 24, mandatoryInsetTop = 72, mandatoryInsetBottom = 48)
+
+        assertEquals(0, range.first)
+        assertEquals(0, range.last)
+        assertEquals(0, 0.coerceIn(range))
+    }
+}


### PR DESCRIPTION
## Problem

When the split handle is parked against a window edge, it overlaps areas that other gesture handlers own, so a drag that starts on the bar is taken by something else instead of resizing the panes:

- **Side-by-side split at the left/right edge** — the handle lights up on touch-down, but dragging toward the center runs the system back gesture.
- **Side-by-side split at the left edge** — the same touch also sits in the left drawer's edge-swipe area, so the drawer peeks open.
- **Stacked split over the bottom gesture bar** — the handle lights up, but moving the finger up triggers the app switcher.

For the system gestures the handle receives `ACTION_DOWN` (hence the pressed state), then `ACTION_CANCEL` once the system claims the stream. There is no API to reclaim a touch after the system has begun interpreting it — `requestDisallowInterceptTouchEvent` only affects parent views, not the system's edge detector — so those conflicts have to be declared ahead of time.

## Fix

**Back-gesture areas (left/right edges).** `SplitHandleButton` publishes its own bounds as a system gesture exclusion rect on every layout, so touches starting on the bar stay with the app. The system caps exclusions at 200dp per edge and honors the rects nearest the bottom of the screen, so on a full-height side-by-side bar the lower part is what's guaranteed — that's an OS limit, not something an app can raise.

**Mandatory gesture area (window bottom).** Exclusion rects are ignored there by design, so nothing can hand those touches back. Instead, `SplitViewManager` bounds the stacked split's travel by the mandatory system gesture insets — both while dragging and when the saved proportion is restored — so the handle can never come to rest inside the area where it could be pressed but not dragged back.

The window top is treated differently: while the status bar is showing it covers that gesture area and the handle may sit flush against the top, so the bound applies only in fullscreen.

**Left drawer edge swipe.** The drawer's edge swipe is switched off for the duration of a handle drag (`DrawerLayout.LOCK_MODE_LOCKED_CLOSED`, restored on drag stop), which also suppresses the delayed peek that an edge touch schedules. This sits next to the existing `setOnefingerEnabled(false)` that already silences the reader's own swipe gestures during a drag.

All of this lives in the shared View layer, so it applies to the RecyclerView and Verse (Compose) verse lists alike.

## Tests

`SplitHandleGestureTest` (new): the handle publishes its bounds as an exclusion rect once laid out and updates them when re-laid out at a new size; the stacked-split range stops short of the bottom mandatory area, reaches the window top while the status bar is showing, stays below the top mandatory area in fullscreen, spans the whole root when no mandatory insets are reported, and stays non-empty when the split root has not been laid out yet.

`assemblePlainDebug`, `testPlainDebugUnitTest`, and `testPlainReleaseUnitTest` are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LSJ5rLw67fJKm7UYLdGHK