### PR TITLE
Refetch past the HTTP cache when an audio payload fails to parse

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioHttp.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioHttp.kt
@@ -3,6 +3,7 @@ package yuku.alkitab.base.audio
 import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import okhttp3.CacheControl
 import okhttp3.Request
 import yuku.alkitab.base.connection.Connections
 import yuku.alkitab.base.util.AppLog
@@ -19,6 +20,17 @@ internal fun interface AudioHttp {
      * Never throws.
      */
     suspend fun getBody(url: String): String?
+
+    /**
+     * Like [getBody], but instructs the HTTP layer to bypass its cache and
+     * fetch [url] from the network. Callers use this when a body fails to
+     * parse: the bytes may be a corrupted entry served from the disk cache,
+     * and a network fetch both yields the origin's current payload and
+     * replaces the cached entry — otherwise the corruption would be pinned
+     * for the entry's whole freshness lifetime. The default delegates to
+     * [getBody], which is correct for implementations without a cache.
+     */
+    suspend fun getBodyRevalidating(url: String): String? = getBody(url)
 }
 
 /**
@@ -30,8 +42,19 @@ internal object OkHttpAudioHttp : AudioHttp {
 
     private const val TAG = "OkHttpAudioHttp"
 
-    override suspend fun getBody(url: String): String? = withContext(Dispatchers.IO) {
-        val request = Request.Builder().url(url).build()
+    override suspend fun getBody(url: String): String? = execute(url, cacheControl = null)
+
+    // FORCE_NETWORK (the `no-cache` request directive) makes OkHttp skip the
+    // cache lookup and issue an unconditional request, whose response then
+    // overwrites the cached entry.
+    override suspend fun getBodyRevalidating(url: String): String? =
+        execute(url, cacheControl = CacheControl.FORCE_NETWORK)
+
+    private suspend fun execute(url: String, cacheControl: CacheControl?): String? = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url(url)
+            .apply { if (cacheControl != null) cacheControl(cacheControl) }
+            .build()
         try {
             Connections.okHttp.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioSetsRepository.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioSetsRepository.kt
@@ -123,13 +123,25 @@ object AudioSetsRepository {
     private suspend fun fetchSets(versionId: String): AudioSets {
         val presetName = presetNameResolver.presetNameFor(versionId)
             ?: return emptySets("")
-        val body = http.getBody(BuildConfig.SERVER_HOST + SETS_PATH + presetName)
+        val url = BuildConfig.SERVER_HOST + SETS_PATH + presetName
+        val body = http.getBody(url)
             ?: return emptySets(presetName)
+        parseSets(body)?.let { return it }
+        // The unparseable bytes may be a corrupted entry served from the HTTP
+        // disk cache; fetch once past the cache — replacing the entry — and
+        // give the fresh payload a parse.
+        AppLog.w(TAG, "audio sets for $presetName did not parse; refetching past the HTTP cache")
+        val fresh = http.getBodyRevalidating(url)
+            ?: return emptySets(presetName)
+        return parseSets(fresh) ?: emptySets(presetName)
+    }
+
+    private fun parseSets(body: String): AudioSets? {
         return try {
             json.decodeFromString(AudioSets.serializer(), body)
         } catch (e: SerializationException) {
-            AppLog.w(TAG, "audio sets JSON did not parse for $presetName: ${e.message}")
-            emptySets(presetName)
+            AppLog.w(TAG, "audio sets JSON did not parse: ${e.message}")
+            null
         }
     }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioRepository.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioRepository.kt
@@ -58,6 +58,16 @@ object BibleAudioRepository {
         val template = set.timingUrlTemplate ?: return null
         val url = expandTemplate(template, bookId, chapter_1)
         val body = http.getBody(url) ?: return null
+        parseTiming(body, url)?.let { return it }
+        // The unparseable bytes may be a corrupted entry served from the HTTP
+        // disk cache; fetch once past the cache — replacing the entry — and
+        // give the fresh payload a parse.
+        AppLog.w(TAG, "timing did not parse for $url; refetching past the HTTP cache")
+        val fresh = http.getBodyRevalidating(url) ?: return null
+        return parseTiming(fresh, url)
+    }
+
+    private fun parseTiming(body: String, url: String): ChapterTiming? {
         return try {
             json.decodeFromString(ChapterTiming.serializer(), body)
         } catch (e: SerializationException) {

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioSetsRepositoryTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioSetsRepositoryTest.kt
@@ -194,10 +194,40 @@ class AudioSetsRepositoryTest {
     }
 
     @Test
-    fun `an unparseable body resolves to an empty set list`() = runBlocking {
-        AudioSetsRepository.http = FakeHttp { "{ this is not json" }
+    fun `an unparseable body resolves to an empty set list after both fetch attempts`() = runBlocking {
+        val http = FakeHttp { "{ this is not json" }
+        AudioSetsRepository.http = http
         val sets = AudioSetsRepository.setsFor("preset/in-tb")
         assertTrue(sets.sets.isEmpty())
+        assertEquals(
+            "a parse failure triggers one revalidating refetch (the fake's default delegates to getBody)",
+            2,
+            http.calls.get(),
+        )
+    }
+
+    @Test
+    fun `a corrupt cached body is refetched past the HTTP cache and the fresh payload is used`() = runBlocking {
+        // getBody plays the disk cache serving corrupted bytes; the
+        // revalidating fetch plays the network serving the real payload.
+        val http = object : AudioHttp {
+            var plainCalls = 0
+            var revalidatingCalls = 0
+            override suspend fun getBody(url: String): String? {
+                plainCalls++
+                return "{ corrupt bytes from the disk cache"
+            }
+            override suspend fun getBodyRevalidating(url: String): String? {
+                revalidatingCalls++
+                return IN_TB_SETS_JSON
+            }
+        }
+        AudioSetsRepository.http = http
+
+        val sets = AudioSetsRepository.setsFor("preset/in-tb")
+        assertEquals(listOf("alkitabsuara", "davar"), sets.sets.map { it.audioId })
+        assertEquals(1, http.plainCalls)
+        assertEquals(1, http.revalidatingCalls)
     }
 
     @Test

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/BibleAudioRepositoryTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/BibleAudioRepositoryTest.kt
@@ -169,6 +169,21 @@ class BibleAudioRepositoryTest {
     }
 
     @Test
+    fun `fetchTiming refetches past the HTTP cache when the first body is corrupt`() = runBlocking {
+        // getBody plays the disk cache serving corrupted bytes; the
+        // revalidating fetch plays the network serving the real payload.
+        BibleAudioRepository.http = object : AudioHttp {
+            override suspend fun getBody(url: String): String? = "{ corrupt bytes from the disk cache"
+            override suspend fun getBodyRevalidating(url: String): String? =
+                """{"schema":2,"preset":"in-tb","audioId":"alkitabsuara","book_1":1,"chapter_1":1,"durationMs":1000,"verses":[{"verse_1":1,"startMs":0,"endMs":1000}]}"""
+        }
+        val timing = BibleAudioRepository.fetchTiming("preset/in-tb", "alkitabsuara", bookId = 0, chapter_1 = 1)
+        assertNotNull(timing)
+        assertEquals(1, timing!!.verses.size)
+        assertEquals(1_000L, timing.durationMs)
+    }
+
+    @Test
     fun `fetchTiming returns null when a required timing field is missing`() = runBlocking {
         // durationMs absent — must fail the parse, not default to zero.
         BibleAudioRepository.http = FakeHttp {

--- a/docs/features/audio-bible/backend-contract.md
+++ b/docs/features/audio-bible/backend-contract.md
@@ -154,7 +154,7 @@ Caching: `ETag` + `Cache-Control: public, max-age=604800`.
 | `200` with `verses: []` | Play without verse highlight; disable verse-skip |
 | `404` on `/audio/file/…` | Error icon on the bar's play button; tap retries |
 | `502` / `503` with `Retry-After` | Treat as temporarily unavailable; no retry loop (only the play button's explicit tap-to-retry re-queries) |
-| Network or parse failure | Empty set list; icon stays hidden rather than showing a dead button |
+| Network or parse failure | Empty set list; icon stays hidden rather than showing a dead button. A parse failure refetches once with `no-cache` first, in case the corrupt bytes were a cached entry |
 
 The app ships **no bundled fallback**. Per-version availability can't be usefully
 baked into the APK, so these endpoints must be live in production before the

--- a/docs/features/audio-bible/multi-audio-sets-design.md
+++ b/docs/features/audio-bible/multi-audio-sets-design.md
@@ -135,7 +135,10 @@ object AudioSetsRepository {
   drops a cached answer and queries again.
 - **Disk cache** is the existing 50 MB OkHttp cache on `Connections.okHttp`,
   honoring the backend's `Cache-Control`. No new file, no bundled asset, no
-  hand-rolled ETag bookkeeping.
+  hand-rolled ETag bookkeeping. A body that fails to parse is refetched once
+  with `no-cache` (same for timing payloads): the bytes may be a corrupted
+  cached entry, and the network response replaces it instead of leaving the
+  corruption pinned for its whole freshness lifetime.
 - **`Prefkey.audioCatalog_etag` is deleted.** It exists only to drive the
   manual `If-None-Match` on the catalog fetch; OkHttp does conditional revalidation
   itself.


### PR DESCRIPTION
Follow-up to #258. A `/audio/sets` or `/audio/timing` body that fails to parse may be a corrupted entry served from the OkHttp disk cache. Without a bypass, every retry re-reads the same bytes until the entry's freshness expires — `max-age=86400` (24 h) for sets, `max-age=604800` (7 days) for timing — because the play-button retry only clears the in-memory layer, and the re-issued GET is satisfied from disk while fresh. Timing is the worst case: a corrupt timing payload isn't surfaced as an error at all (it just disables highlight), so it would silently stay broken for that chapter for up to a week.

## What changed

- On a parse failure, `AudioSetsRepository.fetchSets` and `BibleAudioRepository.fetchTiming` refetch the URL once with `Cache-Control: no-cache` and parse that instead. The unconditional network response both yields the origin's current payload and **replaces the cached entry**, so the corruption cannot outlive a single fetch cycle — self-healing with no user action, and no behavior change when the origin itself is serving garbage (still resolves as empty/null).
- `AudioHttp` gains `getBodyRevalidating(url)` with a default implementation delegating to `getBody`, keeping lambda-based test fakes source-compatible. `OkHttpAudioHttp` overrides it with `CacheControl.FORCE_NETWORK`.
- Truncated downloads are unaffected (they surface as transport failures and OkHttp never commits partial cache entries), so the extra request only fires on the rare complete-but-invalid payload.
- `multi-audio-sets-design.md` (§4 disk-cache bullet) and `backend-contract.md` (error table) note the behavior.

## Testing

- `AudioSetsRepositoryTest`: a corrupt first body followed by a clean revalidating fetch resolves the real set list (one call to each path); a body that is corrupt on both attempts resolves to an empty set list after exactly two fetch attempts.
- `BibleAudioRepositoryTest`: a corrupt first timing body followed by a clean revalidating fetch parses; the existing failure cases are unchanged.

Verified locally: `./gradlew assemblePlainDebug` builds and `./gradlew testPlainDebugUnitTest` passes — 616 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KukitVY1dPCq6tNbWQWhYH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KukitVY1dPCq6tNbWQWhYH)_