### PR TITLE
Fix MonotonicFrameClock crash when the audio highlight scrolls an offscreen verse into view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Android Studio
 !/.idea/
 .gradle
+.kotlin
 /local.properties
 /.idea/workspace.xml
 /.idea/tasks.xml

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MonotonicFrameClock
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -45,6 +46,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.platform.AndroidUiDispatcher
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -92,6 +94,17 @@ private const val TAG = "VersesComposeCtl"
 private const val SCROLLBAR_FADE_DELAY_MS = 1000L
 private const val SCROLLBAR_FADE_DURATION_MS = 400
 private const val EMPTY_MESSAGE_TEXT_SIZE_DP = 14f
+
+/**
+ * The Choreographer-backed frame clock that Compose UI itself runs on. Needed
+ * to drive animations from coroutines that are not launched from a composition
+ * (which would carry a clock in their context already).
+ */
+private val uiFrameClock: MonotonicFrameClock by lazy {
+    checkNotNull(AndroidUiDispatcher.Main[MonotonicFrameClock]) {
+        "AndroidUiDispatcher.Main carries no MonotonicFrameClock"
+    }
+}
 
 /**
  * Host view for the fully Compose-based verse list. The attached
@@ -294,11 +307,16 @@ class VersesComposeControllerImpl(
      * Runs a scroll operation once the composition has caught up with the data
      * version current at call time, dropping it if the data has changed again
      * by then.
+     *
+     * The coroutine runs on the host view's lifecycle scope, which carries no
+     * [MonotonicFrameClock]; the Choreographer-backed one is added because
+     * animated scrolls suspend on `withFrameNanos` and throw without a clock in
+     * context.
      */
     private fun launchScroll(programmatic: Boolean = true, block: suspend (data: VersesDataModel) -> Unit) {
         val vn = dataVersionNumber.get()
         val scope = composeHost.findViewTreeLifecycleOwner()?.lifecycleScope ?: return
-        scope.launch {
+        scope.launch(uiFrameClock) {
             snapshotFlow { renderedDataVersion.intValue }.first { it >= vn }
             if (vn != dataVersionNumber.get()) return@launch
             if (programmatic) programmaticScrollDepth++

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VersesComposeListCompositionTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VersesComposeListCompositionTest.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.test.core.app.ApplicationProvider
+import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -166,6 +167,35 @@ class VersesComposeListCompositionTest {
         }
     }
 
+    /**
+     * Like [pumpLayout], but advances the clock so Choreographer frame
+     * callbacks — and with them the frame clock that Compose animations
+     * suspend on — actually fire.
+     */
+    private fun pumpFrames(harness: Harness, frames: Int = 60) {
+        repeat(frames) {
+            Shadows.shadowOf(Looper.getMainLooper()).idleFor(20, TimeUnit.MILLISECONDS)
+            harness.view.measure(
+                View.MeasureSpec.makeMeasureSpec(VIEWPORT_WIDTH_PX, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(VIEWPORT_HEIGHT_PX, View.MeasureSpec.EXACTLY),
+            )
+            harness.view.layout(0, 0, VIEWPORT_WIDTH_PX, VIEWPORT_HEIGHT_PX)
+        }
+    }
+
+    /** Runs [block] with every uncaught exception collected instead of merely logged. */
+    private fun collectingUncaughtExceptions(block: () -> Unit): List<Throwable> {
+        val caught = mutableListOf<Throwable>()
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { _, e -> caught += e }
+        try {
+            block()
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previous)
+        }
+        return caught
+    }
+
     @Test
     fun `composing a chapter with verses and a pericope header lays out items and reports verse 1 at the top`() {
         val harness = composeList(30)
@@ -281,6 +311,29 @@ class VersesComposeListCompositionTest {
         harness.controller.setAudioHighlight(0, 0)
         pumpLayout(harness)
         assertEquals(1, harness.controller.getVerse_1BasedOnScroll())
+    }
+
+    @Test
+    // Own sdk for a fresh Robolectric sandbox, so the Choreographer this test
+    // drives is the one the frame clock posts its callbacks to.
+    @Config(sdk = [32])
+    fun `audio highlight on an offscreen verse smooth-scrolls it into view`() {
+        val harness = composeList(60)
+
+        // The animated scroll suspends on the frame clock, which the scroll
+        // coroutine's context must carry — it is launched from the host view's
+        // lifecycle scope, not from a composition.
+        val caught = collectingUncaughtExceptions {
+            harness.controller.setAudioHighlight(30, 0x40ff0000)
+            pumpFrames(harness)
+        }
+        assertEquals("scroll coroutine failed: ${caught.firstOrNull()}", emptyList<Throwable>(), caught)
+
+        val pos = harness.controller.versesDataModel.getPositionIgnoringPericopeFromVerse(30)
+        val item = harness.controller.listState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == pos }
+        assertTrue("verse 30 was never scrolled into view", item != null)
+        // Landed near the upper 10% of the viewport, as setAudioHighlight aims for.
+        assertEquals((VIEWPORT_HEIGHT_PX * 0.10f), item!!.offset.toFloat(), 8f)
     }
 
     @Test


### PR DESCRIPTION
## The crash

```
Fatal Exception: java.lang.IllegalStateException: A MonotonicFrameClock is not available in this
CoroutineContext. Callers should supply an appropriate MonotonicFrameClock using withContext.
  at androidx.compose.foundation.gestures.ScrollExtensionsKt.animateScrollBy
  at yuku.alkitab.base.verses.VersesComposeControllerImpl$setAudioHighlight$1.invokeSuspend
  at yuku.alkitab.base.verses.VersesComposeControllerImpl$launchScroll$1.invokeSuspend
  at yuku.alkitab.base.audio.HighlightTracker.update
  at yuku.alkitab.base.audio.BibleAudioService$startPositionPolling$1.invokeSuspend
```

## Cause

`VersesComposeControllerImpl.launchScroll` runs its scroll block on the host view's
`lifecycleScope` — i.e. `Dispatchers.Main.immediate` — whose context carries no
`MonotonicFrameClock`. A coroutine launched from a composition (`rememberCoroutineScope`,
`LaunchedEffect`) gets one for free; this one does not.

Every other caller of `launchScroll` performs a *snap* scroll (`scrollToItem` / `scrollBy`),
which never touches the clock, so the gap went unnoticed. `setAudioHighlight` is the sole
caller that *animates*: `animateScrollBy` and `animateScrollToItem` suspend on
`withFrameNanos`, which throws when no clock is in context.

The result: during audio playback, the moment `HighlightTracker` advanced the highlight to a
verse that was not already fully visible, the animated scroll threw on the main thread and
killed the app. A highlighted verse that was already onscreen took the early return above the
animate call, which is why playback only crashed on verse transitions that needed a scroll.

## The fix

Add the Choreographer-backed frame clock that Compose UI itself runs on — the one carried by
`AndroidUiDispatcher.Main` — to the coroutine context used by `launchScroll`.

Only the clock element is added; the dispatcher is deliberately left as `Main.immediate` so the
dispatch timing of every existing snap-scroll path is untouched. Frame callbacks are delivered
by the Choreographer independently of the dispatcher, so the animation runs correctly.

## Tests

Added `audio highlight on an offscreen verse smooth-scrolls it into view` to
`VersesComposeListCompositionTest`, which composes a 60-verse chapter, highlights verse 30
while it is offscreen, and drives real frames. It asserts both that the scroll coroutine raised
no uncaught exception and that verse 30 landed at the upper 10% of the viewport that
`setAudioHighlight` aims for. The existing audio-highlight test only highlighted an already
visible verse, so it took the early return and never reached the animate call.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rpm6ohYfBDKyGECNZR8P5F)_