### PR TITLE
Fix play-from-verse starting at the chapter top, and gate it on verse timing

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -182,7 +182,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     // --- VerseActionModeActions overrides ---
     override fun uncheckAllVersesSplit0() { lsSplit0.uncheckAllVerses(true) }
     override fun onActionModeDestroyed() { actionMode = null }
-    override fun isAudioAvailableForVerseAction(): Boolean = audioBinder.isAvailable
+    override fun isAudioAvailableForVerseAction(): Boolean = audioBinder.isPlayFromVerseAvailable
     override fun playAudioFromVerse(verse_1: Int) { audioBinder.showFromVerse(verse_1) }
 
     // --- ReaderGestureActions overrides (state is read via ReaderGestureHost below) ---

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
@@ -149,10 +149,14 @@ class AudioBarController(
     private var selectedSource: AudioSourceOption? = null
 
     /**
-     * 1-based verse the next [buildRequest] should seek to, or `0` for the
-     * chapter start. Set by [showFromVerse] and consumed (reset to `0`) the
-     * moment [buildRequest] reads it, so neighbor/auto-advance loads always
-     * start at the beginning.
+     * 1-based verse the next chapter load should seek to, or `0` for the
+     * chapter start. Set by [showFromVerse] (and by [pickSet] when switching
+     * recordings mid-verse) and cleared by [dispatchLoad] only once a request
+     * actually reaches the service — a request built while the service is
+     * still connecting is dropped and rebuilt later from this same field, so
+     * clearing it any earlier would lose the requested verse. Chapter-follow
+     * loads ([onChapterChanged]) reset it explicitly so browsing always starts
+     * at the beginning.
      */
     private var startVerse1 = 0
 
@@ -168,6 +172,19 @@ class AudioBarController(
      */
     val isAvailable: Boolean
         get() = host?.audioAvailableSources()?.isNotEmpty() == true
+
+    /**
+     * Whether the "play audio from this verse" verse action should be offered:
+     * at least one visible version has a recording with verse timing that
+     * covers the book being read. Without timing there is no verse position to
+     * seek to, so the action could only start at the chapter top. Same
+     * non-blocking cache peek as [isAvailable].
+     */
+    val isPlayFromVerseAvailable: Boolean
+        get() {
+            val host = this.host ?: return false
+            return hasPlayableOption(buildSetGroups(host, timedOnly = true))
+        }
 
     /** True while the audio bar is on screen — drives the toolbar audio-icon variant. */
     val isBarVisible: Boolean
@@ -303,6 +320,8 @@ class AudioBarController(
         lastServiceBookId = sourceBook.bookId
         lastServiceChapter1 = availableChapter
 
+        // Chapter browsing supersedes any not-yet-delivered play-from-verse target.
+        startVerse1 = 0
         val request = BibleAudioService.AudioRequest(
             versionId = source.versionId,
             audioId = source.audioId,
@@ -312,7 +331,7 @@ class AudioBarController(
             displaySubtitle = displaySubtitle(source),
             startVerse_1 = 0,
         )
-        service?.loadChapter(request) ?: run { pendingLoad = host }
+        dispatchLoad(host, request)
     }
 
     /**
@@ -329,15 +348,25 @@ class AudioBarController(
     }
 
     /**
-     * Opens the bar and starts playback seeked to [verse_1] (1-based). If the
-     * bar is already showing the same chapter, just seeks rather than reloading
-     * the MP3. Falls back to a normal start-at-0 load when the selected version
-     * has no timing for that verse (handled service-side).
+     * Opens the bar and starts playback seeked to [verse_1] (1-based) — the
+     * "play audio from this verse" verse action.
+     *
+     * - Session already on the reader's chapter with a recording that has
+     *   timing (or whose timing is still unresolved): plain seek, no reload.
+     * - No session, and every recording that would play has timing: the normal
+     *   [show] flow (direct start, or the split-view source picker), carrying
+     *   the start verse.
+     * - Otherwise the recording that would play is known to lack timing — a
+     *   verse seek in it cannot resolve — so the recording sheet opens listing
+     *   only recordings with timing (grouped per version, like the bar's
+     *   recording chip), and the pick starts playback at the verse.
      */
     fun showFromVerse(verse_1: Int) {
         val host = this.host ?: return
         val svc = service
-        if (requestedVisible && svc != null &&
+        val sessionOnTimedSet = requestedVisible && selectedSource != null &&
+            selectedSet()?.hasTiming != false
+        if (sessionOnTimedSet && svc != null &&
             host.audioCurrentBook().bookId == lastServiceBookId &&
             host.audioCurrentChapter1() == lastServiceChapter1
         ) {
@@ -345,7 +374,35 @@ class AudioBarController(
             return
         }
         startVerse1 = verse_1
-        show()
+
+        if (sessionOnTimedSet) {
+            // Session on a chapter other than the reader's (or the service is
+            // still connecting): reload the reader's chapter at the verse.
+            startSession(host)
+            return
+        }
+
+        if (!requestedVisible) {
+            val sources = host.audioAvailableSources()
+            if (sources.isNotEmpty() && sources.all { resolvedSet(it)?.hasTiming == true }) {
+                show()
+                return
+            }
+        }
+
+        val groups = buildSetGroups(host, timedOnly = true)
+        if (groups.isEmpty()) {
+            // The verse action is hidden when no timed recording is visible;
+            // guard against a set list refreshed between menu prep and tap.
+            AppLog.w(TAG, "showFromVerse: no recording with timing on screen")
+            startVerse1 = 0
+            if (!requestedVisible) show()
+            return
+        }
+        requestedVisible = true
+        ensureComposeContent()
+        _uiState.update { it.copy(setGroups = groups) }
+        host.audioBarVisibilityChanged(true)
     }
 
     fun show() {
@@ -359,6 +416,7 @@ class AudioBarController(
                 // Should be unreachable — menu icon is hidden when no source has audio.
                 AppLog.w(TAG, "show() called with no audio sources visible")
                 requestedVisible = false
+                startVerse1 = 0
             }
             1 -> {
                 selectedSource = sources[0]
@@ -377,13 +435,15 @@ class AudioBarController(
 
     /** Binds the service and fires the first loadChapter once [selectedSource] is set. */
     private fun startSession(host: Host) {
+        requestedVisible = true
+        ensureComposeContent()
         ensureBound()
         _uiState.update {
-            it.copy(visible = true, preparing = service == null, pickerOptions = null)
+            it.copy(visible = true, preparing = service == null, pickerOptions = null, setGroups = null)
         }
         host.audioBarVisibilityChanged(true)
         val request = buildRequest(host) ?: return
-        service?.loadChapter(request) ?: run { pendingLoad = host }
+        dispatchLoad(host, request)
     }
 
     fun hide() {
@@ -487,8 +547,6 @@ class AudioBarController(
         val sourceBook = host.audioBookInVersion(source.versionId, readerBook.bookId)
             ?: return null
         val availableChapter = chapter1.coerceIn(1, sourceBook.chapter_count)
-        val sv = startVerse1
-        startVerse1 = 0
         return BibleAudioService.AudioRequest(
             versionId = source.versionId,
             audioId = source.audioId,
@@ -496,20 +554,39 @@ class AudioBarController(
             chapter_1 = availableChapter,
             displayTitle = "${sourceBook.shortName} $availableChapter",
             displaySubtitle = displaySubtitle(source),
-            startVerse_1 = sv,
+            startVerse_1 = startVerse1,
         )
     }
+
+    /**
+     * Hands [request] to the service, or queues a rebuild for when the service
+     * connects. [startVerse1] is cleared only when the request is actually
+     * delivered: the queued path rebuilds the request in [projectToUi] via
+     * [buildRequest], which must still see the requested start verse — this is
+     * what makes "play audio from this verse" survive the initial service
+     * binding instead of degrading to a chapter-top start.
+     */
+    private fun dispatchLoad(host: Host, request: BibleAudioService.AudioRequest) {
+        val svc = service
+        if (svc == null) {
+            pendingLoad = host
+            return
+        }
+        svc.loadChapter(request)
+        startVerse1 = 0
+    }
+
+    /** The [AudioSet] behind [option], or null while its version's set list is unresolved. */
+    private fun resolvedSet(option: AudioSourceOption): AudioSet? =
+        AudioSetsRepository.cachedSetsFor(option.versionId)
+            ?.sets?.firstOrNull { it.audioId == option.audioId }
 
     /**
      * The recording selected for the current session, resolved against the
      * cached set list. Null while nothing is selected or the cache is cold
      * (e.g. right after process death).
      */
-    private fun selectedSet(): AudioSet? {
-        val source = selectedSource ?: return null
-        return AudioSetsRepository.cachedSetsFor(source.versionId)
-            ?.sets?.firstOrNull { it.audioId == source.audioId }
-    }
+    private fun selectedSet(): AudioSet? = selectedSource?.let(::resolvedSet)
 
     /** Set list of the selected source's version, or null while unresolved. */
     private fun setsOfSelectedVersion(): List<AudioSet>? {
@@ -551,12 +628,19 @@ class AudioBarController(
                 _uiState.update { it.copy(showSpeedSheet = false) }
             }
             AudioBarCommand.OpenSetSheet -> {
-                val groups = buildSetGroups(host)
+                val groups = buildSetGroups(host, timedOnly = false)
                 if (groups.isEmpty()) return
                 _uiState.update { it.copy(setGroups = groups) }
             }
             AudioBarCommand.DismissSetSheet -> {
-                _uiState.update { it.copy(setGroups = null) }
+                if (selectedSource == null) {
+                    // The play-from-verse picker was dismissed before any
+                    // session existed — nothing to keep on screen.
+                    hide()
+                } else {
+                    startVerse1 = 0
+                    _uiState.update { it.copy(setGroups = null) }
+                }
             }
             is AudioBarCommand.PickSet -> pickSet(host, cmd.versionId, cmd.audioId)
             AudioBarCommand.Retry -> retryLoad(host)
@@ -588,29 +672,23 @@ class AudioBarController(
      * The recording-picker sheet's content: one group per visible version
      * whose set list has resolved non-empty — two groups in split view when
      * both sides have audio. Rows for sets (or versions) that don't cover the
-     * book being read are listed but disabled.
+     * book being read are listed but disabled. With [timedOnly], recordings
+     * without verse timing are dropped entirely (the play-from-verse picker —
+     * an untimed recording cannot serve a verse seek, so listing it disabled
+     * would only advertise a dead end).
      */
-    private fun buildSetGroups(host: Host): List<AudioSetGroup> {
-        val source = selectedSource ?: return emptyList()
+    private fun buildSetGroups(host: Host, timedOnly: Boolean): List<AudioSetGroup> {
         val currentBookId = host.audioCurrentBook().bookId
-        return host.audioVisibleVersionIds().distinct().mapNotNull { versionId ->
-            val sets = AudioSetsRepository.cachedSetsFor(versionId)?.sets
-            if (sets.isNullOrEmpty()) return@mapNotNull null
-            val versionName = host.audioVersionShortName(versionId) ?: return@mapNotNull null
-            val bookInVersion = host.audioBookInVersion(versionId, currentBookId) != null
-            AudioSetGroup(
-                versionId = versionId,
-                versionName = versionName,
-                options = sets.map { set ->
-                    AudioSetOption(
-                        audioId = set.audioId,
-                        title = set.title,
-                        selected = versionId == source.versionId && set.audioId == source.audioId,
-                        coversCurrentBook = bookInVersion && set.coversBook(currentBookId),
-                    )
-                },
-            )
-        }
+        return buildSetGroups(
+            versionIds = host.audioVisibleVersionIds().distinct(),
+            currentBookId = currentBookId,
+            selectedVersionId = selectedSource?.versionId,
+            selectedAudioId = selectedSource?.audioId,
+            timedOnly = timedOnly,
+            setsOf = { versionId -> AudioSetsRepository.cachedSetsFor(versionId)?.sets },
+            versionNameOf = host::audioVersionShortName,
+            versionHasBook = { versionId -> host.audioBookInVersion(versionId, currentBookId) != null },
+        )
     }
 
     /**
@@ -618,33 +696,44 @@ class AudioBarController(
      * the other split's version (the sheet lists both in split view, so this
      * is also the mid-session way to move audio across the splits). Persists
      * the per-version choice, then reloads the current chapter in the new
-     * recording — seeking to the start of the verse that was playing when the
-     * incoming recording has timing (a non-zero playing verse implies the
-     * outgoing one did), and to the chapter start otherwise. Timing differs
-     * per recording, so a millisecond-preserving switch would land in an
-     * arbitrary place.
+     * recording. The start verse: a pending play-from-verse target wins, then
+     * continuity with the verse that was playing; a recording without timing
+     * always starts at the chapter top. Timing differs per recording, so a
+     * millisecond-preserving switch would land in an arbitrary place.
+     *
+     * Also serves the play-from-verse picker's pick, including before any
+     * session exists ([selectedSource] still null) — [startSession] then
+     * binds the service and shows the bar.
      */
     private fun pickSet(host: Host, versionId: String, audioId: String) {
-        val source = selectedSource ?: return
-        if (versionId == source.versionId && audioId == source.audioId) {
+        val source = selectedSource
+        if (source != null && versionId == source.versionId && audioId == source.audioId) {
             _uiState.update { it.copy(setGroups = null) }
+            // Re-picked the recording already playing while a play-from-verse
+            // target is pending: a seek does the job.
+            val sv = startVerse1
+            if (sv > 0) {
+                startVerse1 = 0
+                service?.seekToVerse(sv)
+            }
             return
         }
         val newSet = AudioSetsRepository.cachedSetsFor(versionId)?.sets
             ?.firstOrNull { it.audioId == audioId } ?: return
         val versionName = host.audioVersionShortName(versionId) ?: return
         AudioSetSelections.store(versionId, newSet.audioId)
-        val playingVerse = _uiState.value.verse_1
-        startVerse1 = if (newSet.hasTiming && playingVerse > 0) playingVerse else 0
+        startVerse1 = startVerseForSetSwitch(
+            newSetHasTiming = newSet.hasTiming,
+            pendingStartVerse1 = startVerse1,
+            playingVerse1 = _uiState.value.verse_1,
+        )
         selectedSource = AudioSourceOption(
             versionId = versionId,
             shortName = versionName,
             audioId = newSet.audioId,
             title = newSet.title,
         )
-        _uiState.update { it.copy(setGroups = null) }
-        val request = buildRequest(host) ?: return
-        service?.loadChapter(request) ?: run { pendingLoad = host }
+        startSession(host)
     }
 
     /**
@@ -658,7 +747,7 @@ class AudioBarController(
         val source = selectedSource ?: return
         val request = buildRequest(host) ?: return
         AudioSetsRepository.invalidate(source.versionId)
-        service?.loadChapter(request) ?: run { pendingLoad = host }
+        dispatchLoad(host, request)
     }
 
     private fun projectToUi(state: PlaybackState) {
@@ -705,8 +794,8 @@ class AudioBarController(
         // queued load avoids that flicker.
         val isPending = pendingLoad != null
         pendingLoad?.let { ph ->
-            buildRequest(ph)?.let { req -> service?.loadChapter(req) }
             pendingLoad = null
+            buildRequest(ph)?.let { req -> dispatchLoad(ph, req) }
         }
 
         // A coordinator-driven external stop (a hymn took over audio) resets the
@@ -809,6 +898,67 @@ class AudioBarController(
         ): Boolean = when (setHasTiming) {
             false -> false
             else -> stateVerse1 > 0 || currentTimingAvailable
+        }
+
+        /**
+         * Builds the recording-picker groups from plain data: one group per
+         * version whose (optionally timing-filtered) set list is non-empty, in
+         * the given version order. Pure so the grouping, [timedOnly]
+         * filtering, selection marking, and coverage flags are unit-testable
+         * without a [Host] or the repository cache.
+         */
+        internal fun buildSetGroups(
+            versionIds: List<String>,
+            currentBookId: Int,
+            selectedVersionId: String?,
+            selectedAudioId: String?,
+            timedOnly: Boolean,
+            setsOf: (versionId: String) -> List<AudioSet>?,
+            versionNameOf: (versionId: String) -> String?,
+            versionHasBook: (versionId: String) -> Boolean,
+        ): List<AudioSetGroup> = versionIds.mapNotNull { versionId ->
+            val sets = setsOf(versionId)
+                ?.let { sets -> if (timedOnly) sets.filter { it.hasTiming } else sets }
+            if (sets.isNullOrEmpty()) return@mapNotNull null
+            val versionName = versionNameOf(versionId) ?: return@mapNotNull null
+            val bookInVersion = versionHasBook(versionId)
+            AudioSetGroup(
+                versionId = versionId,
+                versionName = versionName,
+                options = sets.map { set ->
+                    AudioSetOption(
+                        audioId = set.audioId,
+                        title = set.title,
+                        selected = versionId == selectedVersionId && set.audioId == selectedAudioId,
+                        coversCurrentBook = bookInVersion && set.coversBook(currentBookId),
+                    )
+                },
+            )
+        }
+
+        /**
+         * Whether any listed recording can actually serve the book being read —
+         * gates the "play audio from this verse" verse action when applied to
+         * timing-filtered groups. Pure for unit testing.
+         */
+        internal fun hasPlayableOption(groups: List<AudioSetGroup>): Boolean =
+            groups.any { group -> group.options.any { it.coversCurrentBook } }
+
+        /**
+         * Start verse for a recording switch: an explicitly requested verse
+         * (play-from-verse) wins, then continuity with the verse that was
+         * playing; a recording without timing always starts at the chapter
+         * top, since a verse seek in it cannot resolve. Pure for unit testing.
+         */
+        internal fun startVerseForSetSwitch(
+            newSetHasTiming: Boolean,
+            pendingStartVerse1: Int,
+            playingVerse1: Int,
+        ): Int = when {
+            !newSetHasTiming -> 0
+            pendingStartVerse1 > 0 -> pendingStartVerse1
+            playingVerse1 > 0 -> playingVerse1
+            else -> 0
         }
     }
 }

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioBarControllerPlayFromVerseTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioBarControllerPlayFromVerseTest.kt
@@ -1,0 +1,150 @@
+package yuku.alkitab.base.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import yuku.alkitab.base.audio.model.AudioSet
+
+/**
+ * Pure-logic tests for the "play audio from this verse" pieces of
+ * [AudioBarController]: the timing-filtered recording-picker groups
+ * ([AudioBarController.buildSetGroups]), the availability gate for the verse
+ * action ([AudioBarController.hasPlayableOption]), and the start verse chosen
+ * when switching recordings ([AudioBarController.startVerseForSetSwitch]).
+ */
+class AudioBarControllerPlayFromVerseTest {
+
+    private fun set(audioId: String, hasTiming: Boolean, books_1: Set<Int> = (1..66).toSet()) = AudioSet(
+        audioId = audioId,
+        title = audioId.replaceFirstChar { it.uppercaseChar() },
+        hasTiming = hasTiming,
+        books_1 = books_1,
+        mp3UrlTemplate = "/audio/file/p/$audioId/{book_1}/{chapter_1}.mp3",
+        timingUrlTemplate = if (hasTiming) "/audio/timing/p/$audioId/{book_1}/{chapter_1}.json" else null,
+    )
+
+    private fun groups(
+        setsByVersion: Map<String, List<AudioSet>?>,
+        currentBookId: Int = 0,
+        selectedVersionId: String? = null,
+        selectedAudioId: String? = null,
+        timedOnly: Boolean = true,
+        versionsWithBook: Set<String> = setsByVersion.keys,
+    ) = AudioBarController.buildSetGroups(
+        versionIds = setsByVersion.keys.toList(),
+        currentBookId = currentBookId,
+        selectedVersionId = selectedVersionId,
+        selectedAudioId = selectedAudioId,
+        timedOnly = timedOnly,
+        setsOf = { setsByVersion[it] },
+        versionNameOf = { it.uppercase() },
+        versionHasBook = { it in versionsWithBook },
+    )
+
+    @Test
+    fun `timedOnly drops recordings without timing and versions left with none`() {
+        val result = groups(
+            mapOf(
+                "tb" to listOf(set("timed", hasTiming = true), set("untimed", hasTiming = false)),
+                "kjv" to listOf(set("plain", hasTiming = false)),
+            ),
+        )
+        assertEquals(listOf("tb"), result.map { it.versionId })
+        assertEquals(listOf("timed"), result.single().options.map { it.audioId })
+    }
+
+    @Test
+    fun `without timedOnly untimed recordings stay listed, matching the audio bar's sheet`() {
+        val result = groups(
+            mapOf("tb" to listOf(set("timed", hasTiming = true), set("untimed", hasTiming = false))),
+            timedOnly = false,
+        )
+        assertEquals(listOf("timed", "untimed"), result.single().options.map { it.audioId })
+    }
+
+    @Test
+    fun `one group per version in visible order, unresolved and empty versions dropped`() {
+        val result = groups(
+            linkedMapOf(
+                "tb" to listOf(set("a", hasTiming = true)),
+                "unresolved" to null,
+                "empty" to emptyList(),
+                "kjv" to listOf(set("b", hasTiming = true)),
+            ),
+        )
+        assertEquals(listOf("tb", "kjv"), result.map { it.versionId })
+    }
+
+    @Test
+    fun `the session's recording is marked selected, others not`() {
+        val result = groups(
+            mapOf("tb" to listOf(set("a", hasTiming = true), set("b", hasTiming = true))),
+            selectedVersionId = "tb",
+            selectedAudioId = "b",
+        )
+        assertEquals(
+            listOf(false, true),
+            result.single().options.map { it.selected },
+        )
+    }
+
+    @Test
+    fun `coverage of the current book gates each row and the verse action`() {
+        // Book id 39 (Matthew): covered by the NT-only set, not by the OT-only set.
+        val result = groups(
+            mapOf(
+                "tb" to listOf(
+                    set("nt", hasTiming = true, books_1 = (40..66).toSet()),
+                    set("ot", hasTiming = true, books_1 = (1..39).toSet()),
+                ),
+            ),
+            currentBookId = 39,
+        )
+        assertEquals(
+            listOf(true, false),
+            result.single().options.map { it.coversCurrentBook },
+        )
+        assertTrue(AudioBarController.hasPlayableOption(result))
+    }
+
+    @Test
+    fun `a version that does not include the current book yields no playable option`() {
+        val result = groups(
+            mapOf("tb" to listOf(set("a", hasTiming = true))),
+            versionsWithBook = emptySet(),
+        )
+        assertFalse(AudioBarController.hasPlayableOption(result))
+    }
+
+    @Test
+    fun `no timed recording anywhere means the verse action is unavailable`() {
+        val result = groups(
+            mapOf(
+                "tb" to listOf(set("untimed", hasTiming = false)),
+                "kjv" to listOf(set("plain", hasTiming = false)),
+            ),
+        )
+        assertFalse(AudioBarController.hasPlayableOption(result))
+    }
+
+    @Test
+    fun `set switch start verse - a pending play-from-verse target wins over the playing verse`() {
+        assertEquals(10, AudioBarController.startVerseForSetSwitch(newSetHasTiming = true, pendingStartVerse1 = 10, playingVerse1 = 3))
+    }
+
+    @Test
+    fun `set switch start verse - without a pending target the playing verse carries over`() {
+        assertEquals(3, AudioBarController.startVerseForSetSwitch(newSetHasTiming = true, pendingStartVerse1 = 0, playingVerse1 = 3))
+    }
+
+    @Test
+    fun `set switch start verse - a recording without timing always starts at the chapter top`() {
+        assertEquals(0, AudioBarController.startVerseForSetSwitch(newSetHasTiming = false, pendingStartVerse1 = 10, playingVerse1 = 3))
+    }
+
+    @Test
+    fun `set switch start verse - nothing pending and nothing playing starts at the chapter top`() {
+        assertEquals(0, AudioBarController.startVerseForSetSwitch(newSetHasTiming = true, pendingStartVerse1 = 0, playingVerse1 = 0))
+    }
+}

--- a/docs/modules/audio-playback.md
+++ b/docs/modules/audio-playback.md
@@ -43,7 +43,3 @@ reset → preparing → playing ⇄ paused → complete
 - The verse action-mode item "Play audio from this verse" is offered only when a visible version has a recording with verse timing that covers the book being read. When the recording that would play lacks timing, the recording sheet opens first, listing only recordings with timing (grouped per version, like the audio bar's recording chip), and the pick starts playback at the requested verse.
 - Song audio: `SongViewActivity`'s toolbar drives `SongAudioController`, whose service keeps playing (with notification) after the activity is backgrounded.
 - Starting either kind of audio stops the other via `AudioPlaybackCoordinator`.
-
-## Tests
-
-`AudioPlaybackCoordinatorTest`, `BibleAudioRepositoryTest`, `AudioCatalogRepositoryTest`, `BibleNeighborResolverTest`, `HighlightTrackerTest`, `AudioBarControllerReshowTest`, `AudioBarControllerPlayFromVerseTest`, `AudioHighlightColorTest` (unit tests under `Alkitab/src/test`).

--- a/docs/modules/audio-playback.md
+++ b/docs/modules/audio-playback.md
@@ -40,9 +40,10 @@ reset → preparing → playing ⇄ paused → complete
 ## Integration
 
 - Bible audio: `IsiActivity` shows the Compose `AudioBar` via `AudioBarController`; `HighlightTracker`'s flow drives the verse highlight while audio plays.
+- The verse action-mode item "Play audio from this verse" is offered only when a visible version has a recording with verse timing that covers the book being read. When the recording that would play lacks timing, the recording sheet opens first, listing only recordings with timing (grouped per version, like the audio bar's recording chip), and the pick starts playback at the requested verse.
 - Song audio: `SongViewActivity`'s toolbar drives `SongAudioController`, whose service keeps playing (with notification) after the activity is backgrounded.
 - Starting either kind of audio stops the other via `AudioPlaybackCoordinator`.
 
 ## Tests
 
-`AudioPlaybackCoordinatorTest`, `BibleAudioRepositoryTest`, `AudioCatalogRepositoryTest`, `BibleNeighborResolverTest`, `HighlightTrackerTest`, `AudioBarControllerReshowTest`, `AudioHighlightColorTest` (unit tests under `Alkitab/src/test`).
+`AudioPlaybackCoordinatorTest`, `BibleAudioRepositoryTest`, `AudioCatalogRepositoryTest`, `BibleNeighborResolverTest`, `HighlightTrackerTest`, `AudioBarControllerReshowTest`, `AudioBarControllerPlayFromVerseTest`, `AudioHighlightColorTest` (unit tests under `Alkitab/src/test`).

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -189,21 +189,7 @@ The mixed codebase means the remaining Java code can't use Kotlin features (exte
 
 ## TD-13: Test Coverage
 
-43 test files now exist under `Alkitab/src/test` (all Alkitab-module unit tests unless noted). Coverage grew from ~10 pre-existing files through REM-18 and the audio/Room/portable-songs work:
-
-**Storage & DAO:** `InternalDbTest`, `InternalDbHelperMigrationTest`, `DevotionDaoTest`, `PerVersionDaoTest`, `ProgressMarkDaoTest`, `ReadingPlanDaoTest`, `VersionDaoTest`, `SongDbTest`, `SongRoomDaoTest`, `SongRoomDatabaseMigrationTest`, `SongDbDataMigrationTest` (Robolectric where needed)
-
-**Sync:** `SyncDeltaTest`, `Sync_MabelTest`, `Sync_PinsTest`, `Sync_RpTest`
-
-**Reader & rendering:** `VerseRendererTest` (39 characterization tests), `FormattedTextRendererTest`, `VerseActionModeControllerTest`, `VerseTextFormatterTest`, `VerseItemSideBySideSnapshotTest`, `GotoButtonBalanceWrapTest`, `GotoButtonSideBySideSnapshotTest`
-
-**Audio (Bible audio feature):** `AudioBarControllerReshowTest`, `AudioCatalogRepositoryTest`, `AudioPlaybackCoordinatorTest`, `BibleAudioRepositoryTest`, `BibleNeighborResolverTest`, `HighlightTrackerTest`, `AudioHighlightColorTest`
-
-**Search / util:** `SearchEngineTest`, `QueryTokenizerTest`, `HighlightsTest`, `JumperTest`, `TargetDecoderTest`, `RemoveSpecialCodesTest`, `DownloadMapperTest`
-
-**Songs:** `SongBookUtilTest`, `PortableSongsBridgeTest` (drives the same songs through the legacy Parcelable path and the JSON `SongDocument` path and asserts equivalence)
-
-**Other:** `ProviderTest` (content provider), `AppServicesTest`, `JsonFileExportTest`, `VersionTest`, `GetVersionInitialsTest`; `DesktopVerseFinderTest`/`DesktopVerseParserTest` (tools/AlkitabConverter); `LauncherTest`/`VerseProviderTest` (AlkitabIntegration, androidTest)
+Unit tests under `Alkitab/src/test` (plus a few in other modules, e.g. `AlkitabYes2`, `AlkitabIntegration`) now cover storage/DAOs, sync, reader/rendering, Bible audio, search/util, songs, and the content provider — grown from a near-empty baseline through REM-18 and the audio/Room/portable-songs work. Browse `Alkitab/src/test` directly for the current file list rather than relying on an enumeration here, which drifts out of date as tests are added, renamed, or moved.
 
 **Still not tested:** YES2 reader/writer round-trip, devotion downloading (the DAO is tested, the downloader is not), reading-plan progress logic, widget update flow.
 


### PR DESCRIPTION
## Bug fix: "Putar audio dari ayat ini" started from verse 1

Selecting a verse (e.g. verse 10) and choosing "Play audio from this verse" started playback at the beginning of the chapter. Root cause in `AudioBarController`: `buildRequest()` consumed `startVerse1` (reset it to 0) the moment the request was built — but on a fresh session the service is not bound yet, so that request was **discarded** and `pendingLoad` was set. When the service connected, the request was rebuilt via `buildRequest()` with `startVerse1` already zeroed, so `startVerse_1 = 0` reached the service every time.

Fix: `buildRequest()` no longer consumes the start verse. A new `dispatchLoad()` helper clears `startVerse1` only once a request is **actually delivered** to the service; the queued-rebuild path (`projectToUi`) therefore still sees the requested verse. Chapter-follow loads (`onChapterChanged`) clear it explicitly so browsing always starts at the chapter top.

## Menu gating on verse timing

The verse action is now offered only when at least one visible version (main, or either side in split view) has a recording with verse timing (`hasTiming`) that covers the book being read — without timing there is no verse position to seek to. `IsiActivity.isAudioAvailableForVerseAction()` now delegates to the new `AudioBarController.isPlayFromVerseAvailable` instead of the plain has-any-audio check.

## Timed-recording picker when the would-play recording lacks timing

When the recording that would play has no timing (or in split view, when not every candidate does), `showFromVerse` opens the recording sheet (`AudioSetBottomSheet`) listing **only recordings with timing**, grouped per version like the audio bar's recording chip. Picking one starts playback at the requested verse — including before any session exists (`pickSet` now routes through `startSession`, which binds the service and shows the bar; dismissing the picker with no session tears back down via `hide()`).

Related smaller behaviors:
- A session already playing the reader's chapter on a timed (or timing-unknown) recording still just seeks in place; if the playing recording is known to lack timing, the timed picker opens instead of a silent no-op seek.
- `startVerseForSetSwitch` keeps the existing keep-your-place behavior on recording switches, with a pending play-from-verse target taking precedence.

## Tests

- New `AudioBarControllerPlayFromVerseTest` (11 plain-JUnit tests) covering the timing-filtered group building, the availability gate, and the set-switch start-verse decision, via new pure companion functions.
- Verified locally: `./gradlew assemblePlainDebug` and full `testPlainDebugUnitTest testPlainReleaseUnitTest` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmQuvUcjJj6Py4kZpACVbv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmQuvUcjJj6Py4kZpACVbv)_