### PR TITLE
Re-run search when the Bible version is changed on the search screen

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/ac/SearchActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/ac/SearchActivity.kt
@@ -504,6 +504,8 @@ class SearchActivity : BaseActivity() {
                 return@openVersionsDialog
             }
 
+            val versionChanged = mv.versionId != searchInVersionId
+
             searchInVersion = selectedVersion
             searchInVersionId = mv.versionId
             textSizeMult = App.services.storage.db.getPerVersionSettings(searchInVersionId).fontSizeMultiplier
@@ -515,6 +517,11 @@ class SearchActivity : BaseActivity() {
 
             @Suppress("NotifyDataSetChanged")
             adapter.notifyDataSetChanged()
+
+            // The results on screen belong to the previous version, so redo the search against the newly picked one.
+            if (versionChanged) {
+                search(searchView.query.toString())
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

On the search screen, changing the Bible version via the version button left the previous search's result list on screen. The list wasn't re-queried — it was merely re-rendered through the newly selected version (`SearchAdapter.onBindViewHolder` reads `searchInVersion`), so the ARIs still came from the old version's text while the references and verse snippets came from the new one. The user had to press the search button again to get results that actually belonged to the version they picked.

## Change

`SearchActivity`'s version-selection callback now re-executes the search with the current query after switching versions, matching what the book-filter checkboxes and the book-filter activity result already do.

- The re-run is skipped when the user dismisses the dialog on the version that was already selected, so a no-op selection doesn't churn the result list or bump the search history.
- `search()` already returns early on a blank query, so opening the screen and changing versions before typing anything stays a no-op.
- The `searcher` `Debouncer` supersedes any in-flight search, so a version change mid-search delivers only the newest result.

## Verification

`./gradlew assemblePlainDebug` — BUILD SUCCESSFUL.

---
_Generated by [Claude Code](https://claude.ai/code/session_015HxZbQd1qr6DWzjfZkHJpP)_