### PR TITLE
Recover from a failed audio-set fetch, and resolve audio URL templates

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -709,10 +709,9 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         lifecycleScope.launch { AppEvents.needsRestart.collect { needsRestart = true } }
 
         // Audio bar: attach the Compose host and wire up the menu refresh.
-        // Audio-set availability is resolved per version and asynchronously
-        // (see resolveAudioSetsAsync), so the toolbar icon appears once the
-        // answer for the visible version(s) lands.
-        resolveAudioSetsAsync()
+        // Audio-set availability is resolved per version and asynchronously by
+        // resolveAudioSetsAsync, which onStart drives, so the toolbar icon
+        // appears once the answer for the visible version(s) lands.
         val audioBarView: ComposeView = findViewById(R.id.audio_bar)
         audioBinder.attach(audioBarHost, audioBarView)
         lifecycleScope.launch {
@@ -1214,6 +1213,11 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         // across recreation (rotation) or while we were backgrounded. Covers
         // both a freshly recreated activity and a return on the same instance.
         audioBinder.reshowIfSessionActive()
+
+        // Also the recovery point for a version whose audio-set resolution
+        // failed: returning to the reader is when the connectivity that hid the
+        // icon is most likely to have come back.
+        resolveAudioSetsAsync()
     }
 
     override fun onDestroy() {

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioSetsRepository.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioSetsRepository.kt
@@ -1,6 +1,7 @@
 package yuku.alkitab.base.audio
 
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -30,10 +31,14 @@ import yuku.alkitab.debug.BuildConfig
  *   name (a `file/…` version, or an internal version whose flavor declares
  *   none) short-circuits to an empty set list without a network request.
  * - **In-memory cache** keyed by versionId, holding negative results too, so a
- *   version with no audio does not re-query on every chapter turn. Network
- *   and parse failures also resolve (and cache) as an empty set list, per the
- *   backend contract's error-handling table: the entry point stays hidden
- *   rather than showing a dead button, and there is no retry loop.
+ *   version with no audio does not re-query on every chapter turn. "No
+ *   recordings" from the server is a resolved answer, kept for the life of the
+ *   process.
+ * - **Failures expire** after [FAILURE_RETRY_AFTER_NANOS]. They resolve to an
+ *   empty set list too, per the backend contract's error-handling table, so the
+ *   entry point stays hidden rather than showing a dead button. Keeping that
+ *   for the life of the process would let one flaky moment at startup hide
+ *   audio with nothing on screen to retry from.
  * - **Disk cache** is the 50 MB OkHttp cache on `Connections.okHttp`, honoring
  *   the backend's `Cache-Control`. There is no app-managed file, no bundled
  *   asset, and no hand-rolled ETag bookkeeping.
@@ -45,6 +50,9 @@ object AudioSetsRepository {
 
     private const val TAG = "AudioSetsRepo"
     private const val SETS_PATH = "/audio/sets/"
+
+    /** Long enough that an outage cannot become a request per chapter turn. */
+    private val FAILURE_RETRY_AFTER_NANOS = TimeUnit.SECONDS.toNanos(30)
 
     // ignoreUnknownKeys tolerates additive fields (e.g. `generatedAt`), but the
     // parse stays strict about missing fields: the models declare no default
@@ -65,7 +73,13 @@ object AudioSetsRepository {
     internal var presetNameResolver: PresetNameResolver = defaultPresetNameResolver
     internal var http: AudioHttp = defaultHttp
 
-    private val cache = ConcurrentHashMap<String, AudioSets>()
+    /** Clock seam so the failure cooldown is testable without a real wait. */
+    internal var nanoTime: () -> Long = System::nanoTime
+
+    /** [staleAtNanos] is null for a resolved answer, a deadline for a failed one. */
+    private class Entry(val sets: AudioSets, val staleAtNanos: Long?)
+
+    private val cache = ConcurrentHashMap<String, Entry>()
 
     /**
      * In-flight requests keyed by versionId, so concurrent [setsFor] callers
@@ -84,19 +98,19 @@ object AudioSetsRepository {
     /**
      * Returns the audio sets for [versionId], from the in-memory cache when
      * resolved before, otherwise fetching from the backend. Never throws: any
-     * failure resolves to an empty set list, which is cached like any other
-     * answer.
+     * failure resolves to an empty set list, cached only until the cooldown
+     * described on this class expires.
      */
     suspend fun setsFor(versionId: String): AudioSets {
-        cache[versionId]?.let { return it }
+        liveEntry(versionId)?.let { return it.sets }
         val deferred = mutex.withLock {
-            cache[versionId]?.let { return it }
+            liveEntry(versionId)?.let { return it.sets }
             inFlight.getOrPut(versionId) {
                 scope.async {
-                    val result = fetchSets(versionId)
-                    cache[versionId] = result
+                    val entry = resolveEntry(versionId)
+                    cache[versionId] = entry
                     mutex.withLock { inFlight.remove(versionId) }
-                    result
+                    entry.sets
                 }
             }
         }
@@ -105,35 +119,51 @@ object AudioSetsRepository {
 
     /**
      * Non-blocking peek at the in-memory cache. Null means [versionId] has not
-     * been resolved yet this process. Callers (menu preparation) hide the
-     * entry point and kick off [setsFor], re-preparing once it lands.
+     * been resolved yet, or its last resolution failed and the cooldown has
+     * passed. Callers (menu preparation) hide the entry point and kick off
+     * [setsFor], re-preparing once it lands.
      */
-    fun cachedSetsFor(versionId: String): AudioSets? = cache[versionId]
+    fun cachedSetsFor(versionId: String): AudioSets? = liveEntry(versionId)?.sets
 
     /**
      * Drops the cached answer for [versionId] so the next [setsFor] queries
-     * again. The audio bar's user-initiated retry after a load error is the
-     * only place a cached negative result gets re-tested; everything else
-     * keeps the no-retry-loop behavior.
+     * again. The audio bar's user-initiated retry uses this to re-test an
+     * answer without waiting out the failure cooldown.
      */
     fun invalidate(versionId: String) {
         cache.remove(versionId)
     }
 
-    private suspend fun fetchSets(versionId: String): AudioSets {
+    /** The cached entry for [versionId], dropping and reporting an expired one as absent. */
+    private fun liveEntry(versionId: String): Entry? {
+        val entry = cache[versionId] ?: return null
+        val staleAt = entry.staleAtNanos ?: return entry
+        // Compare by subtraction so the check survives nanoTime()'s wraparound.
+        if (nanoTime() - staleAt < 0) return entry
+        cache.remove(versionId, entry)
+        return null
+    }
+
+    /** Only a transport or parse failure gets a deadline; everything else is an answer. */
+    private suspend fun resolveEntry(versionId: String): Entry {
         val presetName = presetNameResolver.presetNameFor(versionId)
-            ?: return emptySets("")
+            ?: return Entry(emptySets(""), null)
+        val sets = fetchSets(presetName)
+            ?: return Entry(emptySets(presetName), nanoTime() + FAILURE_RETRY_AFTER_NANOS)
+        return Entry(sets, null)
+    }
+
+    /** Null on any transport or parse failure, so the caller can tell it apart from an empty answer. */
+    private suspend fun fetchSets(presetName: String): AudioSets? {
         val url = BuildConfig.SERVER_HOST + SETS_PATH + presetName
-        val body = http.getBody(url)
-            ?: return emptySets(presetName)
+        val body = http.getBody(url) ?: return null
         parseSets(body)?.let { return it }
         // The unparseable bytes may be a corrupted entry served from the HTTP
         // disk cache. Fetch once past the cache, which also replaces the
         // entry, and give the fresh payload a parse.
         AppLog.w(TAG, "audio sets for $presetName did not parse; refetching past the HTTP cache")
-        val fresh = http.getBodyRevalidating(url)
-            ?: return emptySets(presetName)
-        return parseSets(fresh) ?: emptySets(presetName)
+        val fresh = http.getBodyRevalidating(url) ?: return null
+        return parseSets(fresh)
     }
 
     private fun parseSets(body: String): AudioSets? {
@@ -174,5 +204,6 @@ object AudioSetsRepository {
         inFlight.clear()
         presetNameResolver = defaultPresetNameResolver
         http = defaultHttp
+        nanoTime = System::nanoTime
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioRepository.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioRepository.kt
@@ -2,6 +2,7 @@ package yuku.alkitab.base.audio
 
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import yuku.alkitab.base.audio.model.AudioSet
 import yuku.alkitab.base.audio.model.ChapterTiming
 import yuku.alkitab.base.util.AppLog
@@ -31,8 +32,9 @@ object BibleAudioRepository {
     /**
      * Resolves the absolute chapter MP3 URL for
      * `(versionId, audioId, bookId, chapter_1)`, or null when [versionId] has
-     * no recording with [audioId]. The caller should never have asked:
-     * toolbar-icon visibility is gated on the resolved set list.
+     * no recording with [audioId], or the recording's template does not resolve
+     * to a URL. On the missing-recording path the caller should never have
+     * asked: toolbar-icon visibility is gated on the resolved set list.
      */
     suspend fun buildChapterUrl(versionId: String, audioId: String, bookId: Int, chapter_1: Int): String? {
         val set = resolveSet(versionId, audioId) ?: return null
@@ -47,6 +49,7 @@ object BibleAudioRepository {
      *  - no recording with [audioId] for [versionId],
      *  - a recording without timing (`timingUrlTemplate` is null, so the
      *    request is skipped entirely),
+     *  - a `timingUrlTemplate` that does not resolve to a URL,
      *  - any non-2xx response or I/O error,
      *  - JSON parse failure.
      *
@@ -56,7 +59,7 @@ object BibleAudioRepository {
     suspend fun fetchTiming(versionId: String, audioId: String, bookId: Int, chapter_1: Int): ChapterTiming? {
         val set = resolveSet(versionId, audioId) ?: return null
         val template = set.timingUrlTemplate ?: return null
-        val url = expandTemplate(template, bookId, chapter_1)
+        val url = expandTemplate(template, bookId, chapter_1) ?: return null
         val body = http.getBody(url) ?: return null
         parseTiming(body, url)?.let { return it }
         // The unparseable bytes may be a corrupted entry served from the HTTP
@@ -79,10 +82,24 @@ object BibleAudioRepository {
     private suspend fun resolveSet(versionId: String, audioId: String): AudioSet? =
         AudioSetsRepository.setsFor(versionId).sets.firstOrNull { it.audioId == audioId }
 
-    private fun expandTemplate(template: String, bookId: Int, chapter_1: Int): String {
+    private val serverBase by lazy { BuildConfig.SERVER_HOST.toHttpUrl() }
+
+    /**
+     * Substitutes the placeholders in [template] and resolves the result
+     * against [serverBase] the way a browser resolves an href: a path-absolute
+     * template lands on the backend host, an absolute URL is taken as it
+     * stands. Null when the expansion is not a resolvable URL reference.
+     */
+    private fun expandTemplate(template: String, bookId: Int, chapter_1: Int): String? {
         val book_1 = bookId + 1
-        return BuildConfig.SERVER_HOST + template
+        val expanded = template
             .replace("{book_1}", book_1.toString())
             .replace("{chapter_1}", chapter_1.toString())
+        val resolved = serverBase.resolve(expanded)
+        if (resolved == null) {
+            AppLog.w(TAG, "audio URL template did not resolve: $expanded")
+            return null
+        }
+        return resolved.toString()
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/model/AudioSet.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/model/AudioSet.kt
@@ -6,9 +6,11 @@ import kotlinx.serialization.Serializable
  * One recording of a Bible version. Recordings of the same text differ in
  * narrator, in which books they cover, and in whether verse timing exists.
  *
- * The URL templates are relative paths on `BuildConfig.SERVER_HOST`; the
- * client expands `{book_1}` and `{chapter_1}` via literal string replace and
- * never assembles a media path from parts.
+ * The URL templates are URL references resolved against
+ * `BuildConfig.SERVER_HOST`: a path-absolute template lands on the backend
+ * host, an absolute URL points wherever it says. The client expands `{book_1}`
+ * and `{chapter_1}` via literal string replace and never assembles a media
+ * path from parts.
  *
  * Every field is required. See [AudioSets] for why the models declare no
  * default parameter values. [timingUrlTemplate] is explicitly `null` (not

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioSetsRepositoryTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioSetsRepositoryTest.kt
@@ -1,5 +1,6 @@
 package yuku.alkitab.base.audio
 
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -182,15 +183,83 @@ class AudioSetsRepositoryTest {
     }
 
     @Test
-    fun `a transport failure resolves to an empty set list and is cached as a negative result`() = runBlocking {
+    fun `a transport failure resolves to an empty set list and is cached only for the cooldown`() = runBlocking {
         val http = FakeHttp { null }
         AudioSetsRepository.http = http
+        var now = 0L
+        AudioSetsRepository.nanoTime = { now }
 
         val sets = AudioSetsRepository.setsFor("preset/in-tb")
         assertTrue(sets.sets.isEmpty())
 
+        now += TimeUnit.SECONDS.toNanos(29)
         AudioSetsRepository.setsFor("preset/in-tb")
-        assertEquals("no retry loop: the failure is cached", 1, http.calls.get())
+        assertEquals("no retry loop: within the cooldown the failure is cached", 1, http.calls.get())
+
+        now += TimeUnit.SECONDS.toNanos(2)
+        AudioSetsRepository.setsFor("preset/in-tb")
+        assertEquals("past the cooldown the failure is re-queried", 2, http.calls.get())
+    }
+
+    @Test
+    fun `an expired failure reads as unresolved so menu preparation kicks off a fresh query`() = runBlocking {
+        AudioSetsRepository.http = FakeHttp { null }
+        var now = 0L
+        AudioSetsRepository.nanoTime = { now }
+
+        AudioSetsRepository.setsFor("preset/in-tb")
+        assertNotNull("within the cooldown the failed answer is served", AudioSetsRepository.cachedSetsFor("preset/in-tb"))
+
+        now += TimeUnit.SECONDS.toNanos(31)
+        assertNull(
+            "an expired failure must read as unresolved, otherwise the audio icon stays hidden forever",
+            AudioSetsRepository.cachedSetsFor("preset/in-tb"),
+        )
+    }
+
+    @Test
+    fun `a recovered fetch after a failed one replaces the cached answer for good`() = runBlocking {
+        var body: String? = null
+        val http = FakeHttp { body }
+        AudioSetsRepository.http = http
+        var now = 0L
+        AudioSetsRepository.nanoTime = { now }
+
+        assertTrue(AudioSetsRepository.setsFor("preset/in-tb").sets.isEmpty())
+
+        body = IN_TB_SETS_JSON
+        now += TimeUnit.SECONDS.toNanos(31)
+        assertEquals(2, AudioSetsRepository.setsFor("preset/in-tb").sets.size)
+
+        now += TimeUnit.DAYS.toNanos(1)
+        assertEquals("a resolved answer never expires", 2, AudioSetsRepository.setsFor("preset/in-tb").sets.size)
+        assertEquals(2, http.calls.get())
+    }
+
+    @Test
+    fun `a version with no preset identity is a resolved answer and never expires`() = runBlocking {
+        val http = FakeHttp { IN_TB_SETS_JSON }
+        AudioSetsRepository.http = http
+        var now = 0L
+        AudioSetsRepository.nanoTime = { now }
+
+        assertTrue(AudioSetsRepository.setsFor("file//sdcard/some.yes").sets.isEmpty())
+        now += TimeUnit.DAYS.toNanos(1)
+        assertNotNull(AudioSetsRepository.cachedSetsFor("file//sdcard/some.yes"))
+        assertEquals(0, http.calls.get())
+    }
+
+    @Test
+    fun `an empty answer from the server never expires`() = runBlocking {
+        val http = FakeHttp { """{"schema":2,"preset":"in-tb","sets":[]}""" }
+        AudioSetsRepository.http = http
+        var now = 0L
+        AudioSetsRepository.nanoTime = { now }
+
+        assertTrue(AudioSetsRepository.setsFor("preset/in-tb").sets.isEmpty())
+        now += TimeUnit.DAYS.toNanos(1)
+        AudioSetsRepository.setsFor("preset/in-tb")
+        assertEquals("'no recordings' is an answer, not a failure", 1, http.calls.get())
     }
 
     @Test

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/BibleAudioRepositoryTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/BibleAudioRepositoryTest.kt
@@ -90,7 +90,43 @@ class BibleAudioRepositoryTest {
         assertTrue(url!!.contains("/audio/file/in-tb/alkitabsuara/42/3.mp3"))
     }
 
+    @Test
+    fun `buildChapterUrl uses an absolute template as it stands instead of pasting it onto SERVER_HOST`() = runBlocking {
+        AudioSetsRepository.resetForTest()
+        AudioSetsRepository.presetNameResolver = AudioSetsRepository.PresetNameResolver { "in-tb" }
+        AudioSetsRepository.http = AudioHttp { ABSOLUTE_TEMPLATE_SETS_JSON }
+
+        val url = BibleAudioRepository.buildChapterUrl("preset/in-tb", "remote", bookId = 41, chapter_1 = 3)
+        assertEquals("https://audio.example.test/in-tb/remote/42/3.mp3", url)
+    }
+
+    @Test
+    fun `buildChapterUrl returns null for a template that is not a resolvable URL reference`() = runBlocking {
+        AudioSetsRepository.resetForTest()
+        AudioSetsRepository.presetNameResolver = AudioSetsRepository.PresetNameResolver { "in-tb" }
+        AudioSetsRepository.http = AudioHttp {
+            setsJson(mp3UrlTemplate = "http://", timingUrlTemplate = null)
+        }
+
+        assertNull(BibleAudioRepository.buildChapterUrl("preset/in-tb", "remote", bookId = 0, chapter_1 = 1))
+    }
+
     // -- fetchTiming --------------------------------------------------------------
+
+    @Test
+    fun `fetchTiming uses an absolute timing template as it stands`() = runBlocking {
+        AudioSetsRepository.resetForTest()
+        AudioSetsRepository.presetNameResolver = AudioSetsRepository.PresetNameResolver { "in-tb" }
+        AudioSetsRepository.http = AudioHttp { ABSOLUTE_TEMPLATE_SETS_JSON }
+        val http = FakeHttp {
+            """{"schema":2,"preset":"in-tb","audioId":"remote","book_1":42,"chapter_1":3,"durationMs":1000,"verses":[]}"""
+        }
+        BibleAudioRepository.http = http
+
+        assertNotNull(BibleAudioRepository.fetchTiming("preset/in-tb", "remote", bookId = 41, chapter_1 = 3))
+        assertEquals("https://audio.example.test/in-tb/remote/42/3.json", http.urls.single())
+    }
+
 
     @Test
     fun `fetchTiming parses the documented timing response`() = runBlocking {
@@ -190,5 +226,24 @@ class BibleAudioRepositoryTest {
             """{"schema":2,"preset":"in-tb","audioId":"alkitabsuara","book_1":1,"chapter_1":1,"verses":[]}"""
         }
         assertNull(BibleAudioRepository.fetchTiming("preset/in-tb", "alkitabsuara", bookId = 0, chapter_1 = 1))
+    }
+
+    companion object {
+        private fun setsJson(mp3UrlTemplate: String, timingUrlTemplate: String?): String {
+            val timing = timingUrlTemplate?.let { "\"$it\"" } ?: "null"
+            return """
+                {"schema":2,"preset":"in-tb","sets":[
+                  {"audioId":"remote","title":"Remote","hasTiming":${timingUrlTemplate != null},
+                   "books_1":[${(1..66).joinToString(",")}],
+                   "mp3UrlTemplate":"$mp3UrlTemplate","timingUrlTemplate":$timing}
+                ]}
+            """.trimIndent()
+        }
+
+        /** One recording whose templates point at a host of their own. */
+        val ABSOLUTE_TEMPLATE_SETS_JSON = setsJson(
+            mp3UrlTemplate = "https://audio.example.test/in-tb/remote/{book_1}/{chapter_1}.mp3",
+            timingUrlTemplate = "https://audio.example.test/in-tb/remote/{book_1}/{chapter_1}.json",
+        )
     }
 }

--- a/docs/features/audio-bible/backend-contract.md
+++ b/docs/features/audio-bible/backend-contract.md
@@ -86,8 +86,8 @@ GET /audio/sets/in-tb
 | `title` | Display name. Falls back to the raw `audioId` when the backend has no mapping, so an unlabelled set reads as its slug rather than disappearing. |
 | `hasTiming` | `false` → the recording plays but has no verse timing. Known up front, so highlight and verse-skip render disabled from the start. |
 | `books_1` | 1-based book coverage. Ragged — a recording may omit whole books. |
-| `mp3UrlTemplate` | Expand `{book_1}` and `{chapter_1}`; resolve against `SERVER_HOST`. |
-| `timingUrlTemplate` | `null` exactly when `hasTiming` is false. |
+| `mp3UrlTemplate` | Expand `{book_1}` and `{chapter_1}`, then resolve against `SERVER_HOST` as a URL reference. A path-absolute template (`/audio/file/…`) lands on the backend host; an absolute `https://…` template is used as it stands. Which form a recording uses is the backend's choice, per recording. |
+| `timingUrlTemplate` | Same resolution rules as `mp3UrlTemplate`. `null` exactly when `hasTiming` is false. |
 
 **Guarantees the client relies on:**
 


### PR DESCRIPTION
Two fixes in the Bible audio layer.

## 1. `AudioSetsRepository` cached a failed resolution forever

A network or parse failure resolves to an empty set list, and an empty set list hides the audio entry point. Caching that for the life of the process meant **one flaky moment at startup removed audio for that version until the app was force-stopped**, with no indication anything had failed and no reachable retry: the only invalidation path is the audio bar's retry button, which sits behind the hidden entry point.

Failed answers now carry a 30 second deadline and read as unresolved once it passes. Resolved answers, including a genuine "no recordings" and a version with no preset identity, are still kept for the whole process. `IsiActivity.onStart` drives the re-query, so returning to the reader restores the icon; that also covers the cold-start resolve `onCreate` was doing, so the duplicate call is gone.

The cooldown is a testable seam (`nanoTime`), and the staleness check compares by subtraction so it survives `System.nanoTime()`'s documented wraparound.

## 2. URL templates were concatenated onto `SERVER_HOST`

`BibleAudioRepository.expandTemplate` did `BuildConfig.SERVER_HOST + template`, so only a path-absolute template could ever work. An absolute one produced `https://api.alkitab.apphttps://…`, which OkHttp's `HttpUrl` parser rejects outright (the `:` after `apphttps` starts a non-numeric port) — and `AudioHttp.execute` only catches `IOException`, so it would have thrown rather than degraded.

It now resolves the expanded template against `SERVER_HOST` as a URL reference, the way a browser resolves an href. A path-absolute template lands on the backend host; an absolute one is used as it stands. `mp3UrlTemplate` and `timingUrlTemplate` share the function, so both accept either form, and which form a recording uses becomes the backend's choice, per recording, with no app release. A template that is not a resolvable reference yields null and is logged instead of producing a nonsense URL.

`backend-contract.md` is updated to state the resolution rule for both templates.

## Verification

Local `./gradlew assemblePlainDebug` and `testPlainDebugUnitTest`: **665 tests, 0 failures**.

`AudioSetsRepositoryTest` gains 5 cases covering the cooldown boundary, expiry-reads-as-unresolved, recovery after a failure, and the two never-expire paths. `BibleAudioRepositoryTest` gains 3 covering an absolute template for both MP3 and timing, and a template that will not resolve.