### PR TITLE
Fix audio log language and stale cross-chapter entries

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioLogMessage.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioLogMessage.kt
@@ -7,8 +7,9 @@ import androidx.annotation.StringRes
  * A log event before it is turned into display text: the string resource for
  * the event plus its format arguments. Producers (the HTTP event listener,
  * the player, the audio bar) emit these; [BibleAudioService] resolves them
- * against its own [Context] when appending to [PlaybackState.logs], so the
- * log reads in the user's language.
+ * when appending to [PlaybackState.logs], against a [Context] carrying the
+ * app's configured language rather than the device's, so the log reads in the
+ * language the user picked in settings.
  *
  * Keeping the resource id unresolved at the producer means those producers
  * need no [Context] and stay unit-testable by asserting on ids and args.

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioPlayer.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioPlayer.kt
@@ -47,10 +47,30 @@ import yuku.alkitab.debug.R
  * OkHttp connection-state transition for the chapter fetch (via
  * [AudioHttpEventLogger]) plus this player's own buffering/ready/error
  * transitions. [BibleAudioService] feeds this into [PlaybackState.logs] for the
- * audio bar's status line and log bottom sheet.
+ * audio bar's status line and log bottom sheet. Each event carries the
+ * [logGeneration] it belongs to so the service can drop stale ones.
  */
 @OptIn(UnstableApi::class)
-class BibleAudioPlayer(appContext: Context, private val onLogEvent: (AudioLogMessage) -> Unit) {
+class BibleAudioPlayer(
+    appContext: Context,
+    private val onLogEvent: (generation: Int, message: AudioLogMessage) -> Unit,
+) {
+
+    /**
+     * Identifies the chapter load that subsequent log events belong to. The
+     * service bumps this before swapping the media item.
+     *
+     * Loading a new chapter cancels the outgoing one's in-flight HTTP calls,
+     * and OkHttp reports that cancellation through the *old* calls' event
+     * listeners, which fire after the new load has already reset the log.
+     * Stamping each call with the generation current when it was created lets
+     * the service tell those teardown events apart from the new chapter's own.
+     *
+     * Volatile because calls are created on media3's loader threads while the
+     * service writes this from the main thread.
+     */
+    @Volatile
+    var logGeneration: Int = 0
 
     interface Listener {
         /**
@@ -77,15 +97,15 @@ class BibleAudioPlayer(appContext: Context, private val onLogEvent: (AudioLogMes
         override fun onPlaybackStateChanged(playbackState: Int) {
             when (playbackState) {
                 Player.STATE_BUFFERING -> {
-                    onLogEvent(AudioLogMessage(R.string.audio_log_player_buffering))
+                    onLogEvent(logGeneration, AudioLogMessage(R.string.audio_log_player_buffering))
                     listener?.onBuffering()
                 }
                 Player.STATE_READY -> {
-                    onLogEvent(AudioLogMessage(R.string.audio_log_player_ready))
+                    onLogEvent(logGeneration, AudioLogMessage(R.string.audio_log_player_ready))
                     listener?.onReady()
                 }
                 Player.STATE_ENDED -> {
-                    onLogEvent(AudioLogMessage(R.string.audio_log_player_ended))
+                    onLogEvent(logGeneration, AudioLogMessage(R.string.audio_log_player_ended))
                     listener?.onEnded()
                 }
                 else -> Unit
@@ -96,6 +116,7 @@ class BibleAudioPlayer(appContext: Context, private val onLogEvent: (AudioLogMes
             val code = stripErrorCodePrefix(error.errorCodeName)
             val detail = error.message
             onLogEvent(
+                logGeneration,
                 if (detail != null) {
                     AudioLogMessage(R.string.audio_log_player_error_detail, listOf(code, detail))
                 } else {
@@ -125,7 +146,14 @@ class BibleAudioPlayer(appContext: Context, private val onLogEvent: (AudioLogMes
         // newBuilder() still shares the connection pool and disk cache with the
         // shared client.
         val loggingOkHttpClient = Connections.okHttp.newBuilder()
-            .eventListenerFactory { AudioHttpEventLogger(onLogEvent) }
+            .eventListenerFactory {
+                // Snapshot the generation when the call is created, not when
+                // each event fires: a call belongs to whichever chapter load
+                // started it, and its cancellation events arrive after the
+                // next load has already bumped [logGeneration].
+                val generation = logGeneration
+                AudioHttpEventLogger { message -> onLogEvent(generation, message) }
+            }
             .build()
         val okHttpDataSourceFactory = OkHttpDataSource.Factory(loggingOkHttpClient)
             .setUserAgent(Connections.httpUserAgent)

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/BibleAudioService.kt
@@ -1,6 +1,7 @@
 package yuku.alkitab.base.audio
 
 import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
@@ -34,6 +35,7 @@ import yuku.alkitab.base.IsiActivity
 import yuku.alkitab.base.App
 import yuku.alkitab.base.storage.Prefkey
 import yuku.alkitab.base.util.AppLog
+import yuku.alkitab.base.widget.ConfigurationWrapper
 import yuku.alkitab.debug.R
 
 /**
@@ -90,6 +92,24 @@ class BibleAudioService : MediaSessionService(), AudioPlaybackCoordinator.Sessio
          * without reaching a steady state.
          */
         private const val MAX_LOG_ENTRIES = 500
+
+        /**
+         * The log after recording [entry]. Returns [logs] untouched when
+         * [eventGeneration] is not [currentGeneration], which is how a
+         * superseded chapter load's trailing cancellation events are kept out
+         * of the new chapter's log. Otherwise appends, keeping at most
+         * [maxEntries] newest. Pure for unit testing.
+         */
+        internal fun appendLogEntry(
+            logs: List<AudioLogEntry>,
+            entry: AudioLogEntry,
+            eventGeneration: Int,
+            currentGeneration: Int,
+            maxEntries: Int = MAX_LOG_ENTRIES,
+        ): List<AudioLogEntry> {
+            if (eventGeneration != currentGeneration) return logs
+            return (logs + entry).takeLast(maxEntries)
+        }
 
         private const val DEFAULT_PLAYBACK_SPEED = 1.0f
 
@@ -183,6 +203,17 @@ class BibleAudioService : MediaSessionService(), AudioPlaybackCoordinator.Sessio
     /** Persisted playback speed, loaded once at service start and updated on every [setSpeed] call. */
     private var persistedSpeed: Float = DEFAULT_PLAYBACK_SPEED
 
+    /** Backing cache for [localizedContext], keyed by the configuration serial it was built at. */
+    private var localizedContext: Context? = null
+    private var localizedContextSerial = -1
+
+    /**
+     * Which chapter load the log is currently accumulating. Bumped on every
+     * [loadChapter] and on [stop]; log events stamped with an older value are
+     * dropped. See [BibleAudioPlayer.logGeneration].
+     */
+    private var loadGeneration = 0
+
     private val playerListener = object : BibleAudioPlayer.Listener {
         override fun onBuffering() {
             // `preparing` doubles as the buffering flag rather than having a
@@ -234,7 +265,7 @@ class BibleAudioService : MediaSessionService(), AudioPlaybackCoordinator.Sessio
 
     override fun onCreate() {
         super.onCreate()
-        player = BibleAudioPlayer(applicationContext, ::appendLog)
+        player = BibleAudioPlayer(applicationContext) { generation, message -> appendLog(generation, message) }
         player.setListener(playerListener)
 
         // Apply the persisted speed to the player up front so the first chapter
@@ -347,7 +378,12 @@ class BibleAudioService : MediaSessionService(), AudioPlaybackCoordinator.Sessio
         timingLoaded = false
         // The log resets here because a retry is a fresh load attempt; mixing
         // its events with the failed attempt's would make the log sheet read as
-        // one non-chronological HTTP conversation.
+        // one non-chronological HTTP conversation. Bumping the generation
+        // before the media item is swapped keeps the outgoing chapter's
+        // cancellation events out of the new log, since those arrive from
+        // OkHttp after this reset. See [BibleAudioPlayer.logGeneration].
+        loadGeneration++
+        player.logGeneration = loadGeneration
         highlightTracker.setTiming(emptyList())
         _playbackState.update {
             it.copy(
@@ -364,7 +400,7 @@ class BibleAudioService : MediaSessionService(), AudioPlaybackCoordinator.Sessio
                 logs = listOf(
                     AudioLogEntry(
                         System.currentTimeMillis(),
-                        getString(R.string.audio_log_loading, request.displayTitle),
+                        localizedContext().getString(R.string.audio_log_loading, request.displayTitle),
                     )
                 ),
             )
@@ -516,6 +552,11 @@ class BibleAudioService : MediaSessionService(), AudioPlaybackCoordinator.Sessio
         positionJob?.cancel()
         currentRequest = null
         hasActiveSession = false
+        // Same reason as in [loadChapter]: the in-flight calls being torn down
+        // here report their cancellation afterwards, and must not land in the
+        // log the IDLE reset just cleared.
+        loadGeneration++
+        player.logGeneration = loadGeneration
         player.pause()
         _playbackState.value = PlaybackState.IDLE
         stopSelf()
@@ -615,16 +656,48 @@ class BibleAudioService : MediaSessionService(), AudioPlaybackCoordinator.Sessio
     fun logUiEvent(message: AudioLogMessage) = appendLog(message)
 
     /**
-     * Resolves [message] against this service's resources and appends it to
+     * Resolves [message] against [localizedContext] and appends it to
      * [PlaybackState.logs]. Also serves as [BibleAudioPlayer]'s `onLogEvent`
      * callback, so HTTP connection-state and player-state events land here too,
      * always on the main thread like every other `_playbackState` mutation.
      */
-    private fun appendLog(message: AudioLogMessage) {
-        val entry = AudioLogEntry(System.currentTimeMillis(), message.resolve(this))
+    private fun appendLog(message: AudioLogMessage) = appendLog(loadGeneration, message)
+
+    /**
+     * Appends [message] if it belongs to the chapter load currently on screen.
+     * Events stamped with an older [generation] come from a superseded load
+     * whose HTTP calls are only now reporting their cancellation, and showing
+     * them would attribute the previous chapter's teardown to the new one.
+     * See [BibleAudioPlayer.logGeneration].
+     */
+    private fun appendLog(generation: Int, message: AudioLogMessage) {
+        if (generation != loadGeneration) return
+        val entry = AudioLogEntry(System.currentTimeMillis(), message.resolve(localizedContext()))
         _playbackState.update {
-            it.copy(logs = (it.logs + entry).takeLast(MAX_LOG_ENTRIES))
+            it.copy(logs = appendLogEntry(it.logs, entry, generation, loadGeneration))
         }
+    }
+
+    /**
+     * Context for resolving every user-visible string this service produces.
+     *
+     * A Service never goes through `BaseActivity.attachBaseContext`, so its own
+     * resources follow the device locale: resolving against `this` would print
+     * the log in the device language even when the user has picked a different
+     * one in the app's settings.
+     *
+     * Cached, and rebuilt when the language preference changes, which is what
+     * [ConfigurationWrapper.getSerialCounter] tracks. Rebuilding per call would
+     * mean a `createConfigurationContext` for each of the dozens of HTTP events
+     * a single chapter load emits.
+     */
+    private fun localizedContext(): Context {
+        val serial = ConfigurationWrapper.getSerialCounter()
+        if (serial != localizedContextSerial || localizedContext == null) {
+            localizedContext = ConfigurationWrapper.localizedContext(this)
+            localizedContextSerial = serial
+        }
+        return localizedContext ?: this
     }
 
     private fun startPositionPolling() {

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/ConfigurationWrapper.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/ConfigurationWrapper.java
@@ -38,6 +38,26 @@ public class ConfigurationWrapper {
 		return new ContextWrapper(base.createConfigurationContext(config));
 	}
 
+	/**
+	 * A context whose resources resolve strings in the app's configured
+	 * language, independent of the device locale.
+	 *
+	 * For components that never go through {@link #wrap}: only activities do,
+	 * via {@code BaseActivity.attachBaseContext}, so a service or any other
+	 * non-UI component resolving strings against its own context gets the
+	 * device language and silently ignores the in-app language preference.
+	 *
+	 * Unlike {@link #wrap} this copies the configuration rather than mutating
+	 * the caller's, and leaves font scale alone: callers here are producing
+	 * strings, not laying out text.
+	 */
+	@NonNull
+	public static Context localizedContext(@NonNull final Context base) {
+		final Configuration config = new Configuration(base.getResources().getConfiguration());
+		config.setLocale(getLocaleFromPreferences());
+		return base.createConfigurationContext(config);
+	}
+
 	private static final AtomicInteger serialCounter = new AtomicInteger();
 
 	public static int getSerialCounter() {

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/BibleAudioServiceLogTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/BibleAudioServiceLogTest.kt
@@ -1,0 +1,81 @@
+package yuku.alkitab.base.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Pure-logic tests for how the audio load log accumulates: which events belong
+ * to the chapter currently on screen, and the cap that bounds the list.
+ */
+class BibleAudioServiceLogTest {
+
+    private fun entry(message: String) = AudioLogEntry(timestampMs = 0L, message = message)
+
+    @Test
+    fun `an event from the current load is appended`() {
+        val logs = listOf(entry("Loading Genesis 1"))
+        val result = BibleAudioService.appendLogEntry(
+            logs = logs,
+            entry = entry("Connecting"),
+            eventGeneration = 3,
+            currentGeneration = 3,
+        )
+        assertEquals(listOf("Loading Genesis 1", "Connecting"), result.map { it.message })
+    }
+
+    @Test
+    fun `a superseded load's trailing cancellation events are dropped`() {
+        // The reported bug: switching chapters cancels the outgoing chapter's
+        // in-flight calls, and OkHttp reports that cancellation after the new
+        // load has already reset the log.
+        val logs = listOf(entry("Loading Psalms 104"))
+        val result = BibleAudioService.appendLogEntry(
+            logs = logs,
+            entry = entry("Response failed: stream was reset: CANCEL"),
+            eventGeneration = 2,
+            currentGeneration = 3,
+        )
+        assertSame("the list should not be rebuilt when nothing is recorded", logs, result)
+    }
+
+    @Test
+    fun `an event from a later generation is dropped too`() {
+        // Defensive: generations only move forward, but the rule is equality,
+        // not "newer wins", so a stale comparison can never leak either way.
+        val logs = listOf(entry("Loading Genesis 1"))
+        val result = BibleAudioService.appendLogEntry(
+            logs = logs,
+            entry = entry("Connecting"),
+            eventGeneration = 9,
+            currentGeneration = 3,
+        )
+        assertSame(logs, result)
+    }
+
+    @Test
+    fun `the log keeps the newest entries once it reaches the cap`() {
+        val logs = (1..4).map { entry("event $it") }
+        val result = BibleAudioService.appendLogEntry(
+            logs = logs,
+            entry = entry("event 5"),
+            eventGeneration = 1,
+            currentGeneration = 1,
+            maxEntries = 3,
+        )
+        assertEquals(listOf("event 3", "event 4", "event 5"), result.map { it.message })
+    }
+
+    @Test
+    fun `a log exactly at the cap drops its oldest entry to make room`() {
+        val logs = (1..3).map { entry("event $it") }
+        val result = BibleAudioService.appendLogEntry(
+            logs = logs,
+            entry = entry("event 4"),
+            eventGeneration = 1,
+            currentGeneration = 1,
+            maxEntries = 3,
+        )
+        assertEquals(listOf("event 2", "event 3", "event 4"), result.map { it.message })
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/ConfigurationWrapperLocalizedContextTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/ConfigurationWrapperLocalizedContextTest.kt
@@ -1,0 +1,82 @@
+package yuku.alkitab.base.widget
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import java.util.Locale
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import yuku.afw.App as AfwApp
+import yuku.afw.storage.Preferences
+import yuku.alkitab.debug.R
+
+/**
+ * Regression tests for [ConfigurationWrapper.localizedContext]: strings must
+ * follow the app's own language preference, not the device locale.
+ *
+ * Components that never go through `BaseActivity.attachBaseContext` (services,
+ * receivers, workers) resolve against the device locale by default, which
+ * silently ignores the in-app language setting. The device locale is pinned to
+ * English here while the preference asks for Indonesian, so a regression shows
+ * up as English text rather than as a passing tautology.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, sdk = [34], qualifiers = "en-rUS")
+class ConfigurationWrapperLocalizedContextTest {
+
+    private lateinit var defaultLocaleBeforeTest: Locale
+
+    @Before
+    fun setUp() {
+        AfwApp.initWithAppContext(ApplicationProvider.getApplicationContext())
+        defaultLocaleBeforeTest = Locale.getDefault()
+        Locale.setDefault(Locale.US)
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(defaultLocaleBeforeTest)
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        Preferences.remove(context.getString(R.string.pref_language_key))
+    }
+
+    @Test
+    fun `strings resolve in the app language preference even when the device locale differs`() {
+        Preferences.setString(R.string.pref_language_key, "in")
+
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        val localized = ConfigurationWrapper.localizedContext(context)
+
+        assertEquals("Memuat Kejadian 1", localized.getString(R.string.audio_log_loading, "Kejadian 1"))
+    }
+
+    @Test
+    fun `the plain application context still resolves in the device locale`() {
+        Preferences.setString(R.string.pref_language_key, "in")
+
+        val context = ApplicationProvider.getApplicationContext<Application>()
+
+        // The bug being guarded against: this is what a Service resolving
+        // against itself gets, and it is why log strings need an explicit
+        // localized context rather than `this`.
+        assertNotEquals(
+            context.getString(R.string.audio_log_loading, "Genesis 1"),
+            ConfigurationWrapper.localizedContext(context).getString(R.string.audio_log_loading, "Genesis 1"),
+        )
+    }
+
+    @Test
+    fun `DEFAULT preference falls back to the device locale`() {
+        Preferences.setString(R.string.pref_language_key, "DEFAULT")
+
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        val localized = ConfigurationWrapper.localizedContext(context)
+
+        assertEquals("Loading Genesis 1", localized.getString(R.string.audio_log_loading, "Genesis 1"))
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,7 @@ Detailed documentation for each major feature module:
 - GIDs (globally unique IDs) are used alongside database `_id` for sync-capable entities
 - `Ari` encoding is used universally for verse references — never store book/chapter/verse separately
 - Version IDs follow format `"internal"`, `"preset/[name]"`, or `"file/[path]"`
+- **IMPORTANT. The app has its own in-app language setting (`pref_language`), independent of the device locale.** Only activities pick it up automatically: `BaseActivity.attachBaseContext` runs the context through `ConfigurationWrapper.wrap`, so anything resolving strings against an activity (including Compose `stringResource`, whose `LocalContext` is the activity) is already correct. Everything else is not. A `Service`, a `BroadcastReceiver`, a `Worker`, `App.context`, or any `applicationContext` resolves against the *device* locale, so `getString` there prints the wrong language for every user whose in-app choice differs from their device. When such a component produces user-visible text, resolve it against `ConfigurationWrapper.localizedContext(...)` instead. Cache that context rather than rebuilding it per string, and rebuild when `ConfigurationWrapper.getSerialCounter()` changes, which is how a language change is signalled. Prefer keeping the string resource unresolved (a res id plus args) until it reaches whatever component knows the right context — see `AudioLogMessage`.
 
 ## Unit Testing
 


### PR DESCRIPTION
Two follow-up bugs in the audio load log added by #265, both reported from device testing.

## The log ignored the in-app language setting

With the app set to Bahasa Indonesia on an English device, every log line and status still read in English.

The in-app language preference is applied only by `BaseActivity.attachBaseContext`, which runs the context through `ConfigurationWrapper.wrap`. A `Service` never goes through that, so `BibleAudioService` resolving strings against `this` got the *device* locale and ignored the preference entirely. The Compose side was already correct, since `stringResource` resolves against the activity, which is why only the service-produced text was affected.

`ConfigurationWrapper.localizedContext` now builds a context carrying the configured language for components that never go through `wrap()`. It copies the configuration rather than mutating the caller's, and leaves font scale alone, since callers here are producing strings rather than laying out text. The service caches the context and rebuilds it when the language preference changes (`getSerialCounter`, the existing signal), because a single chapter load emits dozens of events and each rebuild is a `createConfigurationContext`.

This trap applies to any service, receiver or worker producing user-visible text, so `CLAUDE.md` now records the rule.

## Starting a chapter showed the previous connection's teardown

```
12:45:17.654 Loading Mazmur 104
12:45:17.657 Response failed: stream was reset: CANCEL
12:45:17.657 HTTP request failed: Canceled
12:45:17.658 Connection released
12:45:17.658 HTTP request started: .../19/104.mp3
12:45:17.663 Connection acquired (reused)
```

Loading a chapter cancels the outgoing one's in-flight HTTP calls, and OkHttp reports that cancellation through the *old* calls' event listeners, which fire after the new load has already reset the log. The listener had no way to tell which load a call belonged to, so the teardown landed in the new chapter's log.

Each call now snapshots the load generation current when it was created, and the service drops events whose generation is no longer the one on screen. The bump happens before the media item is swapped, so the cancellations that swap triggers are already stale by the time they arrive. `stop()` bumps it too, so teardown cannot repopulate the log the `IDLE` reset just cleared.

## Tests

`./gradlew assemblePlainDebug testPlainDebugUnitTest` passes locally against the merged `develop` (666 tests, 0 failures).

- `ConfigurationWrapperLocalizedContextTest` pins the device locale to English while the preference asks for Indonesian, so a regression surfaces as English text rather than a passing tautology. It also asserts the plain application context still resolves in the device locale, which is the bug being guarded against, and that `DEFAULT` falls back to the device locale.
- `BibleAudioServiceLogTest` covers the generation rule (including the reported cancel-after-reset case) and the log cap's boundary.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GbmBQoysCwsW8NaSzJesxc)_