### PR TITLE
Trim AudioBar.kt comments; add dedicated content description for recording chooser

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -865,6 +865,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         lifecycleScope.launch {
             versionIds.forEach { AudioSetsRepository.setsFor(it) }
             invalidateOptionsMenu()
+            audioBinder.refreshSetChoices()
         }
     }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -728,9 +728,7 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
         lifecycleScope.launch {
             AppEvents.activeVersionChanged.collect {
-                resolveAudioSetsAsync()
-                audioBinder.onActiveVersionChanged()
-                invalidateOptionsMenu()
+                onVisibleVersionsChanged()
             }
         }
 
@@ -867,6 +865,12 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             invalidateOptionsMenu()
             audioBinder.refreshSetChoices()
         }
+    }
+
+    override fun onVisibleVersionsChanged() {
+        resolveAudioSetsAsync()
+        audioBinder.onActiveVersionChanged()
+        invalidateOptionsMenu()
     }
 
     private fun callAttentionForVerseToBothSplits(verse_1: Int) {

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/AudioBarController.kt
@@ -140,6 +140,13 @@ class AudioBarController(
     private var selectedSource: AudioSourceOption? = null
 
     /**
+     * Whether the recording sheet currently on screen was opened by the
+     * play-from-verse flow, which lists only recordings with timing. Kept so
+     * [refreshSetChoices] rebuilds the open sheet in the mode it was opened in.
+     */
+    private var setSheetTimedOnly = false
+
+    /**
      * 1-based verse the next chapter load should seek to, or `0` for the
      * chapter start. Set by [showFromVerse] (and by [pickSet] when switching
      * recordings mid-verse) and cleared by [dispatchLoad] only once a request
@@ -269,7 +276,9 @@ class AudioBarController(
         val source = selectedSource
         if (source != null && source.versionId !in host.audioVisibleVersionIds()) {
             hide()
+            return
         }
+        refreshSetChoices()
     }
 
     /**
@@ -381,6 +390,7 @@ class AudioBarController(
         }
         requestedVisible = true
         ensureComposeContent()
+        setSheetTimedOnly = true
         _uiState.update { it.copy(setGroups = groups) }
         host.audioBarVisibilityChanged(true)
     }
@@ -419,7 +429,13 @@ class AudioBarController(
         ensureComposeContent()
         ensureBound()
         _uiState.update {
-            it.copy(visible = true, preparing = service == null, pickerOptions = null, setGroups = null)
+            it.copy(
+                visible = true,
+                preparing = service == null,
+                pickerOptions = null,
+                setGroups = null,
+                canChooseSet = canChooseSet(host),
+            )
         }
         host.audioBarVisibilityChanged(true)
         val request = buildRequest(host) ?: return
@@ -567,10 +583,28 @@ class AudioBarController(
      */
     private fun selectedSet(): AudioSet? = selectedSource?.let(::resolvedSet)
 
-    /** Set list of the selected source's version, or null while unresolved. */
-    private fun setsOfSelectedVersion(): List<AudioSet>? {
-        val source = selectedSource ?: return null
-        return AudioSetsRepository.cachedSetsFor(source.versionId)?.sets
+    private fun canChooseSet(host: Host): Boolean = canChooseSet(
+        versionIds = host.audioVisibleVersionIds(),
+        setsOf = { versionId -> AudioSetsRepository.cachedSetsFor(versionId)?.sets },
+    )
+
+    /**
+     * Recomputes the parts of the UI state derived from which versions are on
+     * screen and what the set cache holds: the chooser button's visibility, and
+     * the sheet's contents while it is open. Neither is driven by
+     * [PlaybackState], so without this they would sit stale until the next
+     * position tick, and indefinitely while paused.
+     */
+    fun refreshSetChoices() {
+        val host = this.host ?: return
+        _uiState.update { current ->
+            current.copy(
+                canChooseSet = canChooseSet(host),
+                setGroups = current.setGroups?.let { previous ->
+                    buildSetGroups(host, timedOnly = setSheetTimedOnly).ifEmpty { previous }
+                },
+            )
+        }
     }
 
     /**
@@ -610,6 +644,7 @@ class AudioBarController(
             AudioBarCommand.OpenSetSheet -> {
                 val groups = buildSetGroups(host, timedOnly = false)
                 if (groups.isEmpty()) return
+                setSheetTimedOnly = false
                 _uiState.update { it.copy(setGroups = groups) }
             }
             AudioBarCommand.DismissSetSheet -> {
@@ -812,16 +847,6 @@ class AudioBarController(
             ?: selectedSource?.versionId
 
         val selectedSet = selectedSet()
-        // The recording chip appears whenever the sheet has a choice to offer:
-        // several recordings of the source version, or (split view) a second
-        // version with audio to move the source to.
-        val audioCapableVersions = host?.audioVisibleVersionIds()?.distinct()
-            ?.count { AudioSetsRepository.cachedSetsFor(it)?.sets?.isNotEmpty() == true } ?: 0
-        val setTitle = when {
-            selectedSet == null -> null
-            (setsOfSelectedVersion()?.size ?: 0) > 1 || audioCapableVersions > 1 -> selectedSet.title
-            else -> null
-        }
 
         val effectivePreparing = state.preparing || isPending
         val previousUiState = _uiState.value
@@ -842,7 +867,7 @@ class AudioBarController(
                     currentTimingAvailable = current.timingAvailable,
                 ),
                 playingVersionId = playingVersionId,
-                setTitle = setTitle,
+                canChooseSet = host != null && canChooseSet(host),
             )
         }
         // Logging re-enters here via the service's state flow, but the
@@ -974,6 +999,17 @@ class AudioBarController(
                 },
             )
         }
+
+        /**
+         * Whether the recording chooser has more than one recording to offer,
+         * counted across every visible version. In split view a single
+         * recording on each side is still a choice, since picking the other
+         * side's moves audio across the splits. Pure for unit testing.
+         */
+        internal fun canChooseSet(
+            versionIds: List<String>,
+            setsOf: (versionId: String) -> List<AudioSet>?,
+        ): Boolean = versionIds.distinct().sumOf { setsOf(it)?.size ?: 0 } > 1
 
         /**
          * Whether any listed recording can actually serve the book being read.

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -14,12 +14,14 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.outlined.Face
@@ -193,28 +195,24 @@ fun AudioBar(
         }
         if (!state.visible) return@AudioTheme
 
-        val bottomInset = WindowInsets.safeDrawing
-            .asPaddingValues()
-            .calculateBottomPadding()
         Surface(
             tonalElevation = 6.dp,
             shadowElevation = 6.dp,
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
             modifier = modifier.fillMaxWidth(),
         ) {
-            BoxWithConstraints {
+            BoxWithConstraints(
+                modifier = Modifier.windowInsetsPadding(
+                    WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom)
+                ),
+            ) {
                 var dragValue by rememberSaveable { mutableStateOf<Float?>(null) }
                 val isWide = maxWidth >= 600.dp
 
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(
-                            start = 8.dp,
-                            end = 8.dp,
-                            top = 4.dp,
-                            bottom = 4.dp + bottomInset,
-                        ),
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
                     AudioLoadStatusLine(state = state, onCommand = onCommand)

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -23,9 +23,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.ErrorOutline
-import androidx.compose.material.icons.outlined.Face
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
@@ -80,8 +81,8 @@ data class AudioBarUiState(
     val showLogSheet: Boolean,
     /** Non-null scopes the verse highlight to the pane playing this version. */
     val playingVersionId: String?,
-    /** Compact recording-title button next to the speed control; null hides it. */
-    val setTitle: String?,
+    /** False when the visible versions offer at most one recording, which hides the chooser. */
+    val canChooseSet: Boolean,
     /** When non-null, the source-picker dialog is shown over the bar. */
     val pickerOptions: List<AudioSourceOption>?,
     /** When true, the playback-speed bottom sheet is shown over the bar. */
@@ -102,7 +103,7 @@ data class AudioBarUiState(
             logs = emptyList(),
             showLogSheet = false,
             playingVersionId = null,
-            setTitle = null,
+            canChooseSet = false,
             pickerOptions = null,
             showSpeedSheet = false,
             setGroups = null,
@@ -254,7 +255,9 @@ private fun AudioBarTopRow(
         Box(Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
             Row {
                 SpeedButton(state = state, onCommand = onCommand)
-                SetChooserButton(onCommand = onCommand)
+                if (state.canChooseSet) {
+                    SetChooserButton(onCommand = onCommand)
+                }
             }
         }
 
@@ -308,6 +311,7 @@ private fun SpeedButton(
     val locale = appLocale()
     TextButton(
         onClick = { onCommand(AudioBarCommand.Speed) },
+        colors = ButtonDefaults.textButtonColors(contentColor = LocalContentColor.current),
     ) {
         Text(
             text = stringResource(R.string.audio_bar_speed_format, formatSpeedNumber(state.speed, locale)),
@@ -324,7 +328,7 @@ private fun SetChooserButton(
 ) {
     IconButton(onClick = { onCommand(AudioBarCommand.OpenSetSheet) }) {
         Icon(
-            imageVector = Icons.Outlined.Face,
+            imageVector = Icons.AutoMirrored.Filled.List,
             contentDescription = stringResource(R.string.audio_bar_select_audio),
         )
     }
@@ -560,7 +564,9 @@ private fun AudioBarWideRow(
         Box(Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
             Row {
                 SpeedButton(state = state, onCommand = onCommand)
-                SetChooserButton(onCommand = onCommand)
+                if (state.canChooseSet) {
+                    SetChooserButton(onCommand = onCommand)
+                }
             }
         }
 
@@ -645,7 +651,7 @@ private fun AudioBarPreviewNarrow() {
             logs = emptyList(),
             showLogSheet = false,
             playingVersionId = "preset/in-tb",
-            setTitle = "Alkitab Suara, a deliberately long recording title",
+            canChooseSet = true,
             pickerOptions = null,
             showSpeedSheet = false,
             setGroups = null,
@@ -672,7 +678,7 @@ private fun AudioBarPreviewWide() {
             logs = emptyList(),
             showLogSheet = false,
             playingVersionId = "preset/in-tb",
-            setTitle = "Alkitab Suara, a deliberately long recording title",
+            canChooseSet = true,
             pickerOptions = null,
             showSpeedSheet = false,
             setGroups = null,
@@ -699,7 +705,7 @@ private fun AudioBarPreviewPreparing() {
             logs = emptyList(),
             showLogSheet = false,
             playingVersionId = "preset/in-tb",
-            setTitle = null,
+            canChooseSet = false,
             pickerOptions = null,
             showSpeedSheet = false,
             setGroups = null,
@@ -732,7 +738,7 @@ private fun AudioBarPreviewSlowLoad() {
             ),
             showLogSheet = false,
             playingVersionId = "preset/in-tb",
-            setTitle = null,
+            canChooseSet = false,
             pickerOptions = null,
             showSpeedSheet = false,
             setGroups = null,
@@ -765,7 +771,7 @@ private fun AudioBarPreviewDarkError() {
             ),
             showLogSheet = false,
             playingVersionId = "preset/in-tb",
-            setTitle = null,
+            canChooseSet = false,
             pickerOptions = null,
             showSpeedSheet = false,
             setGroups = null,
@@ -792,7 +798,7 @@ private fun AudioBarPreviewWithPicker() {
             logs = emptyList(),
             showLogSheet = false,
             playingVersionId = null,
-            setTitle = null,
+            canChooseSet = false,
             pickerOptions = listOf(
                 AudioSourceOption(versionId = "preset/in-tb", shortName = "TB", audioId = "alkitabsuara", title = "Alkitab Suara"),
                 AudioSourceOption(versionId = "preset/en-kjv", shortName = "KJV", audioId = "wordproject", title = "wordproject"),

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -1,37 +1,41 @@
 package yuku.alkitab.base.audio.ui
 
-import android.content.res.Configuration
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.outlined.Face
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -41,22 +45,24 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlin.math.roundToLong
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import yuku.alkitab.base.audio.AudioLogEntry
 import yuku.alkitab.base.audio.PlaybackState
 import yuku.alkitab.debug.R
-import kotlin.math.roundToLong
 
 /**
  * UI-facing snapshot consumed by [AudioBar]. The controller projects
@@ -174,6 +180,7 @@ data class AudioSetOption(
  */
 sealed interface AudioBarCommand {
     data object PlayPause : AudioBarCommand
+
     /** Fired instead of [PlayPause] while the bar is in an error state; retries the load. */
     data object Retry : AudioBarCommand
     data object PrevVerse : AudioBarCommand
@@ -189,14 +196,14 @@ sealed interface AudioBarCommand {
     data class SeekCommit(val positionMs: Long) : AudioBarCommand
     data class PickSource(val versionId: String) : AudioBarCommand
     data object CancelPicker : AudioBarCommand
+
     /** Fired by tapping the slow-load/error status line. Opens [AudioLogBottomSheet]. */
     data object OpenLogSheet : AudioBarCommand
     data object DismissLogSheet : AudioBarCommand
 }
 
 /**
- * Top-level audio bar surface. Anchored at the bottom of `IsiActivity`'s
- * [androidx.compose.ui.platform.ComposeView] host. Shown and hidden
+ * Top-level audio bar surface. Shown and hidden
  * synchronously: the controller adds and removes the Compose content on
  * session start/end, so an enter/exit transition would only delay the layout
  * reflow the activity already commits when the host view appears.
@@ -232,12 +239,7 @@ fun AudioBar(
             )
         }
         if (!state.visible) return@AudioTheme
-        // Pull the bottom system inset out of WindowInsets so the bar
-        // a) extends its background all the way under the gesture pill, and
-        // b) keeps actual controls above the inset so the slider's mm:ss
-        // labels aren't clipped. The bar's height is deliberately left
-        // unconstrained: the Material 3 Slider's thumb shadow overflows the
-        // visible track, and a fixed-height container clips it.
+
         val bottomInset = WindowInsets.safeDrawing
             .asPaddingValues()
             .calculateBottomPadding()
@@ -247,43 +249,42 @@ fun AudioBar(
             color = MaterialTheme.colorScheme.surfaceContainerHigh,
             modifier = modifier.fillMaxWidth(),
         ) {
-            // Hoisted above the orientation branch so an in-progress seek drag
-            // survives rotation (and process death, via rememberSaveable)
-            // instead of resetting to the playback position.
-            var dragValue by rememberSaveable { mutableStateOf<Float?>(null) }
-            val landscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
-            // The status line spans the bar's full width above the controls in
-            // both orientations. Inside the transport cluster it would have to
-            // be capped narrow enough not to shove the prev/next buttons apart,
-            // ellipsizing messages with plenty of bar left over.
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        start = 8.dp,
-                        end = 8.dp,
-                        top = 4.dp,
-                        bottom = 4.dp + bottomInset,
-                    ),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
-            ) {
-                AudioLoadStatusLine(state = state, onCommand = onCommand)
-                if (landscape) {
-                    AudioBarLandscapeRow(
-                        state = state,
-                        onCommand = onCommand,
-                        dragValue = dragValue,
-                        onDragValueChange = { dragValue = it },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                } else {
-                    AudioBarTopRow(state = state, onCommand = onCommand)
-                    AudioBarSliderRow(
-                        state = state,
-                        onCommand = onCommand,
-                        dragValue = dragValue,
-                        onDragValueChange = { dragValue = it },
-                    )
+            BoxWithConstraints {
+                var dragValue by rememberSaveable { mutableStateOf<Float?>(null) }
+                val isWide = maxWidth >= 600.dp
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            start = 8.dp,
+                            end = 8.dp,
+                            top = 4.dp,
+                            bottom = 4.dp + bottomInset,
+                        ),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    AudioLoadStatusLine(state = state, onCommand = onCommand)
+                    if (isWide) {
+                        AudioBarWideRow(
+                            state = state,
+                            onCommand = onCommand,
+                            dragValue = dragValue,
+                            onDragValueChange = { dragValue = it },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    } else {
+                        AudioBarTopRow(state = state, onCommand = onCommand)
+                        AudioBarSliderRow(
+                            state = state,
+                            onCommand = onCommand,
+                            dragValue = dragValue,
+                            onDragValueChange = { dragValue = it },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 8.dp),
+                        )
+                    }
                 }
             }
         }
@@ -295,37 +296,24 @@ private fun AudioBarTopRow(
     state: AudioBarUiState,
     onCommand: (AudioBarCommand) -> Unit,
 ) {
-    // Chapter-name labels are deliberately absent: the toolbar already shows
-    // the current chapter, and on a phone they crowd out the speed indicator
-    // and force the close button to wrap.
-    //
-    // The speed chip, transport cluster, and close button take their intrinsic
-    // width and never shrink. The recording chip sits inside the left weighted
-    // slot, so however long the set title is it only ellipsizes within the
-    // leftover space instead of squeezing the transport controls. The two
-    // weighted slots get equal shares, which keeps the cluster centered and
-    // collapses to zero when the row is tight.
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        SpeedButton(state = state, onCommand = onCommand)
-
         Box(Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
-            SetButton(state = state, onCommand = onCommand)
+            Row {
+                SpeedButton(state = state, onCommand = onCommand)
+                SetChooserButton(onCommand = onCommand)
+            }
         }
 
         PrevVerseButton(state = state, onCommand = onCommand)
-
-        Spacer(Modifier.width(4.dp))
         PlayPauseButton(state = state, onCommand = onCommand)
-        Spacer(Modifier.width(4.dp))
-
         NextVerseButton(state = state, onCommand = onCommand)
 
-        Spacer(Modifier.weight(1f))
-
-        CloseButton(onCommand = onCommand)
+        Box(Modifier.weight(1f), contentAlignment = Alignment.CenterEnd) {
+            CloseButton(onCommand = onCommand)
+        }
     }
 }
 
@@ -361,9 +349,6 @@ private fun NextVerseButton(
     }
 }
 
-// `softWrap = false` keeps locales that render with a comma decimal (e.g.
-// "1,0×" in Indonesian) from wrapping into a stacked "1," / "0×" when the row
-// is tight.
 @Composable
 private fun SpeedButton(
     state: AudioBarUiState,
@@ -372,7 +357,6 @@ private fun SpeedButton(
     val locale = appLocale()
     TextButton(
         onClick = { onCommand(AudioBarCommand.Speed) },
-        modifier = Modifier.padding(horizontal = 4.dp),
     ) {
         Text(
             text = stringResource(R.string.audio_bar_speed_format, formatSpeedNumber(state.speed, locale)),
@@ -390,17 +374,13 @@ private fun SpeedButton(
  * within the leftover row space instead of squeezing the transport controls.
  */
 @Composable
-private fun SetButton(
-    state: AudioBarUiState,
+private fun SetChooserButton(
     onCommand: (AudioBarCommand) -> Unit,
 ) {
-    val title = state.setTitle ?: return
-    TextButton(onClick = { onCommand(AudioBarCommand.OpenSetSheet) }) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.labelLarge,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
+    IconButton(onClick = { onCommand(AudioBarCommand.OpenSetSheet) }) {
+        Icon(
+            imageVector = Icons.Outlined.Face,
+            contentDescription = stringResource(R.string.audio_bar_pick_source_title),
         )
     }
 }
@@ -421,7 +401,7 @@ private fun CloseButton(
  * Small tappable status line shown above the play button while a chapter load
  * is taking unusually long, or once it has failed:
  *  - **Slow load**: preparing has held continuously for
- *    [SLOW_LOAD_STATUS_DELAY_MS] with no error yet. Shows the most recent
+ *    [SLOW_LOAD_STATUS_DELAY] with no error yet. Shows the most recent
  *    [AudioBarUiState.logs] entry, so the user sees what the HTTP layer is
  *    doing (DNS, connecting, waiting for headers) instead of a bare spinner
  *    with no explanation for the delay.
@@ -458,7 +438,7 @@ private fun AudioLoadStatusLine(
 
 /**
  * `true` only once [preparing] has been continuously true for
- * [SLOW_LOAD_STATUS_DELAY_MS]; drops back to false immediately when [preparing]
+ * [SLOW_LOAD_STATUS_DELAY]; drops back to false immediately when [preparing]
  * does. Same shape as [debouncedPreparing], at the much longer delay the status
  * line is gated on. In inspection mode the delay is skipped so previews can pin
  * the slow-load state.
@@ -469,7 +449,7 @@ private fun slowLoadStatusVisible(preparing: Boolean): Boolean {
     var show by remember { mutableStateOf(false) }
     LaunchedEffect(preparing) {
         if (preparing) {
-            delay(SLOW_LOAD_STATUS_DELAY_MS)
+            delay(SLOW_LOAD_STATUS_DELAY)
             show = true
         } else {
             show = false
@@ -478,17 +458,23 @@ private fun slowLoadStatusVisible(preparing: Boolean): Boolean {
     return show
 }
 
-private const val SLOW_LOAD_STATUS_DELAY_MS = 5_000L
+private val SLOW_LOAD_STATUS_DELAY = 5_000.milliseconds
 
 /**
  * Play/pause, with two special states sharing the slot: a progress ring while
  * preparing, and an error icon when the last load failed. Tapping the error
- * icon retries the load instead of toggling playback.
+ * icon retries the load instead of toggling playback. Long-pressing opens
+ * [AudioLogBottomSheet], the same sheet [AudioLoadStatusLine] opens on tap.
  *
  * The preparing visuals (ring plus disabled swap) are debounced by
- * [PREPARING_INDICATION_DELAY_MS], so a load that completes within the window
+ * [PREPARING_INDICATION_DELAY], so a load that completes within the window
  * never flashes the ring at all. That covers a verse skip landing in
  * already-buffered data, or a chapter served from the HTTP cache.
+ *
+ * Built from a plain [Box] with [combinedClickable] rather than
+ * [FilledIconButton]: that component only exposes a single [onClick], and
+ * layering a second gesture detector around it to catch long-press races the
+ * button's own internal one for the down event instead of sharing it.
  */
 @Composable
 private fun PlayPauseButton(
@@ -497,20 +483,38 @@ private fun PlayPauseButton(
 ) {
     val haptic = LocalHapticFeedback.current
     val showPreparing = debouncedPreparing(state.preparing)
+    val enabled = !showPreparing
+    val colors = IconButtonDefaults.filledIconButtonColors()
+    val containerColor = if (enabled) colors.containerColor else colors.disabledContainerColor
+    val contentColor = if (enabled) colors.contentColor else colors.disabledContentColor
 
     Box(contentAlignment = Alignment.Center) {
-        FilledIconButton(
-            onClick = {
-                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                onCommand(if (state.error != null) AudioBarCommand.Retry else AudioBarCommand.PlayPause)
-            },
-            enabled = !showPreparing,
-            modifier = Modifier.size(48.dp),
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .clip(IconButtonDefaults.filledShape)
+                .background(containerColor)
+                .combinedClickable(
+                    interactionSource = null,
+                    indication = ripple(),
+                    enabled = enabled,
+                    role = Role.Button,
+                    onClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        onCommand(if (state.error != null) AudioBarCommand.Retry else AudioBarCommand.PlayPause)
+                    },
+                    onLongClick = {
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                        onCommand(AudioBarCommand.OpenLogSheet)
+                    },
+                ),
+            contentAlignment = Alignment.Center,
         ) {
             if (state.error != null) {
                 Icon(
                     imageVector = Icons.Filled.ErrorOutline,
                     contentDescription = stringResource(R.string.audio_bar_error_retry),
+                    tint = contentColor,
                 )
             } else {
                 AnimatedContent(
@@ -525,11 +529,13 @@ private fun PlayPauseButton(
                         Icon(
                             painter = painterResource(R.drawable.ic_audio_pause),
                             contentDescription = stringResource(R.string.audio_bar_pause),
+                            tint = contentColor,
                         )
                     } else {
                         Icon(
                             painter = painterResource(R.drawable.ic_audio_play),
                             contentDescription = stringResource(R.string.audio_bar_play),
+                            tint = contentColor,
                         )
                     }
                 }
@@ -546,7 +552,7 @@ private fun PlayPauseButton(
 
 /**
  * `true` only once [preparing] has been continuously true for
- * [PREPARING_INDICATION_DELAY_MS]; drops back to false immediately when
+ * [PREPARING_INDICATION_DELAY]; drops back to false immediately when
  * [preparing] does. In inspection mode the delay is skipped so previews can
  * pin the preparing state.
  */
@@ -556,7 +562,7 @@ private fun debouncedPreparing(preparing: Boolean): Boolean {
     var show by remember { mutableStateOf(false) }
     LaunchedEffect(preparing) {
         if (preparing) {
-            delay(PREPARING_INDICATION_DELAY_MS)
+            delay(PREPARING_INDICATION_DELAY)
             show = true
         } else {
             show = false
@@ -565,27 +571,28 @@ private fun debouncedPreparing(preparing: Boolean): Boolean {
     return show
 }
 
-private const val PREPARING_INDICATION_DELAY_MS = 100L
+private val PREPARING_INDICATION_DELAY = 100.milliseconds
 
 @Composable
 private fun AudioBarSliderRow(
     state: AudioBarUiState,
     onCommand: (AudioBarCommand) -> Unit,
     dragValue: Float?,
+    modifier: Modifier = Modifier,
     onDragValueChange: (Float?) -> Unit,
 ) {
     val effectivePosition = dragValue?.roundToLong() ?: state.positionMs
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 8.dp),
+        modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
             text = formatMmSs(effectivePosition),
-            style = MaterialTheme.typography.labelSmall.copy(fontSize = 12.sp),
-            modifier = Modifier.width(40.dp),
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier
+                .padding(end = 8.dp)
+                .widthIn(min = 24.dp),
         )
 
         AudioBarSlider(
@@ -598,11 +605,11 @@ private fun AudioBarSliderRow(
 
         Text(
             text = durationLabelText(state.durationMs),
-            style = MaterialTheme.typography.labelSmall.copy(fontSize = 12.sp),
+            style = MaterialTheme.typography.labelSmall,
             color = LocalContentColor.current.copy(alpha = 0.7f),
             modifier = Modifier
                 .padding(start = 8.dp)
-                .width(40.dp),
+                .widthIn(min = 24.dp),
         )
     }
 }
@@ -633,16 +640,8 @@ private fun AudioBarSlider(
     )
 }
 
-/**
- * Landscape variant, collapsing the bar into a single row to reclaim the
- * vertical space the two-row portrait layout costs (worse with split view).
- * The mm:ss position/duration labels are omitted here: the slider conveys
- * progress, and keeping the labels would push the control cluster into
- * wrapping. The recording chip sits in its own weighted slot so a long set
- * title ellipsizes there rather than squeezing the transport controls.
- */
 @Composable
-private fun AudioBarLandscapeRow(
+private fun AudioBarWideRow(
     state: AudioBarUiState,
     onCommand: (AudioBarCommand) -> Unit,
     dragValue: Float?,
@@ -653,31 +652,30 @@ private fun AudioBarLandscapeRow(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        AudioBarSlider(
-            state = state,
-            onCommand = onCommand,
-            dragValue = dragValue,
-            onDragValueChange = onDragValueChange,
-            modifier = Modifier.weight(2f),
-        )
 
-        Spacer(Modifier.weight(1f))
+        Box(Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
+            Row {
+                SpeedButton(state = state, onCommand = onCommand)
+                SetChooserButton(onCommand = onCommand)
+            }
+        }
 
         PrevVerseButton(state = state, onCommand = onCommand)
-
-        Spacer(Modifier.width(4.dp))
         PlayPauseButton(state = state, onCommand = onCommand)
-        Spacer(Modifier.width(4.dp))
-
         NextVerseButton(state = state, onCommand = onCommand)
 
         Box(Modifier.weight(1f), contentAlignment = Alignment.CenterEnd) {
-            SetButton(state = state, onCommand = onCommand)
+            Row {
+                AudioBarSliderRow(
+                    state = state,
+                    onCommand = onCommand,
+                    dragValue = dragValue,
+                    onDragValueChange = onDragValueChange,
+                    modifier = Modifier.weight(1f),
+                )
+                CloseButton(onCommand = onCommand)
+            }
         }
-
-        SpeedButton(state = state, onCommand = onCommand)
-
-        CloseButton(onCommand = onCommand)
     }
 }
 
@@ -724,28 +722,49 @@ internal fun formatMmSs(ms: Long): String {
     return "%d:%02d".format(mm, ss)
 }
 
-/**
- * Duration label text: blank while the player hasn't reported a real duration
- * (nothing loaded, or a new file still preparing), because a "0:00" there would
- * read as a measurement rather than "unknown". The position label keeps
- * rendering "0:00" in that state so the reset to the start stays visible.
- */
 internal fun durationLabelText(durationMs: Long): String =
     if (durationMs > 0L) formatMmSs(durationMs) else ""
 
 // -- Previews ------------------------------------------------------------------
 
-@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF, widthDp = 400)
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF, widthDp = 320)
 @Composable
-private fun AudioBarPreviewPlaying() {
+private fun AudioBarPreviewNarrow() {
     AudioBar(
         state = AudioBarUiState(
             visible = true,
             isPlaying = true,
             preparing = false,
             positionMs = 42_000L,
-            durationMs = 195_000L,
+            durationMs = 9_195_000L,
             verse_1 = 7,
+            speed = 1.0f,
+            error = null,
+            timingAvailable = true,
+            logs = emptyList(),
+            showLogSheet = false,
+            playingVersionId = "preset/in-tb",
+            setTitle = "Alkitab Suara, a deliberately long recording title",
+            pickerOptions = null,
+            showSpeedSheet = false,
+            setGroups = null,
+        ),
+        onCommand = {},
+        modifier = Modifier,
+    )
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF, widthDp = 600)
+@Composable
+private fun AudioBarPreviewWide() {
+    AudioBar(
+        state = AudioBarUiState(
+            visible = true,
+            isPlaying = true,
+            preparing = false,
+            positionMs = 142_000L,
+            durationMs = 195_000L,
+            verse_1 = 777,
             speed = 1.0f,
             error = null,
             timingAvailable = true,
@@ -789,9 +808,6 @@ private fun AudioBarPreviewPreparing() {
     )
 }
 
-// Preparing past the 5 s status-line threshold. LocalInspectionMode skips the
-// debounce delay, so `preparing = true` here pins the status line on with the
-// most recent HTTP log entry.
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF, widthDp = 400)
 @Composable
 private fun AudioBarPreviewSlowLoad() {

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/AudioBar.kt
@@ -64,19 +64,6 @@ import yuku.alkitab.base.audio.AudioLogEntry
 import yuku.alkitab.base.audio.PlaybackState
 import yuku.alkitab.debug.R
 
-/**
- * UI-facing snapshot consumed by [AudioBar]. The controller projects
- * [PlaybackState] plus chapter-navigation context into this and pushes it
- * through a `StateFlow`. Keep the data class flat and primitive-typed: the
- * Compose recomposition cost is proportional to its hash.
- *
- *  - [timingAvailable]: when false, the prev/next-verse buttons grey out.
- *  - [error]: non-null swaps the play button for an error icon; tapping it
- *    retries the load.
- *  - [logs]: timestamped HTTP/player-state log for the chapter currently
- *    loading (see [yuku.alkitab.base.audio.PlaybackState.logs]). Its last entry
- *    drives the status line's text; tapping the line opens the whole list.
- */
 data class AudioBarUiState(
     val visible: Boolean,
     val isPlaying: Boolean,
@@ -89,24 +76,14 @@ data class AudioBarUiState(
     val timingAvailable: Boolean,
     val logs: List<AudioLogEntry>,
     val showLogSheet: Boolean,
-    /** Version driving audio, or null. Used to scope the verse highlight to matching panes. */
+    /** Non-null scopes the verse highlight to the pane playing this version. */
     val playingVersionId: String?,
-    /**
-     * Title of the selected recording, shown as a compact button next to the
-     * speed control. Null hides the button: a version with a single recording
-     * should not pay for a control that offers no choice.
-     */
+    /** Compact recording-title button next to the speed control; null hides it. */
     val setTitle: String?,
     /** When non-null, the source-picker dialog is shown over the bar. */
     val pickerOptions: List<AudioSourceOption>?,
     /** When true, the playback-speed bottom sheet is shown over the bar. */
     val showSpeedSheet: Boolean,
-    /**
-     * When non-null, the recording-picker bottom sheet is shown over the bar.
-     * One group per visible version with audio, so in split view with audio on
-     * both sides the picker doubles as the mid-session way to move audio
-     * between the splits.
-     */
     val setGroups: List<AudioSetGroup>?,
 ) {
     companion object {
@@ -131,37 +108,21 @@ data class AudioBarUiState(
     }
 }
 
-/**
- * One row in the source-picker dialog: which version drives audio in split
- * view, carrying the recording that would play for it. Split-source selection
- * and set selection are distinct choices: which *version* drives audio, then
- * which *recording* of it.
- */
+/** Which version drives audio in split view, vs. which recording of it ([AudioSetGroup]). */
 data class AudioSourceOption(
     val versionId: String,
     val shortName: String,
-    /** Recording that plays when this version is picked (the persisted selection, or the default). */
     val audioId: String,
-    /** Display title of that recording. */
     val title: String,
 )
 
-/**
- * One version's recordings in the recording-picker bottom sheet. [versionName]
- * is rendered as a group header only when more than one group is shown.
- */
 data class AudioSetGroup(
     val versionId: String,
     val versionName: String,
     val options: List<AudioSetOption>,
 )
 
-/**
- * One row in the recording-picker bottom sheet. Sets not covering the current
- * book are listed but disabled ([coversCurrentBook] = false) with the reason
- * shown. Hiding them would make the list appear to change size as the user
- * moves through the Bible.
- */
+/** Sets not covering the current book stay listed but disabled, so the list doesn't reshape as the user moves through the Bible. */
 data class AudioSetOption(
     val audioId: String,
     val title: String,
@@ -169,19 +130,9 @@ data class AudioSetOption(
     val coversCurrentBook: Boolean,
 )
 
-/**
- * Commands raised by the bar's UI. The controller maps these onto
- * [yuku.alkitab.base.audio.BibleAudioService] calls.
- *
- * `SeekDrag` is fired continuously while the user drags the slider thumb so
- * the bar can show a live position preview. `SeekCommit` is fired on release;
- * the controller decides whether to snap to a verse boundary or issue a plain
- * seek (depending on whether timing is available).
- */
+/** Commands raised by the bar's UI; the controller maps these onto [yuku.alkitab.base.audio.BibleAudioService] calls. */
 sealed interface AudioBarCommand {
     data object PlayPause : AudioBarCommand
-
-    /** Fired instead of [PlayPause] while the bar is in an error state; retries the load. */
     data object Retry : AudioBarCommand
     data object PrevVerse : AudioBarCommand
     data object NextVerse : AudioBarCommand
@@ -192,21 +143,23 @@ sealed interface AudioBarCommand {
     data object OpenSetSheet : AudioBarCommand
     data object DismissSetSheet : AudioBarCommand
     data class PickSet(val versionId: String, val audioId: String) : AudioBarCommand
+
+    /** Fired continuously while dragging the slider thumb, for a live position preview. */
     data class SeekDrag(val positionMs: Long) : AudioBarCommand
+
+    /** Fired on release; the controller decides whether to snap to a verse boundary. */
     data class SeekCommit(val positionMs: Long) : AudioBarCommand
     data class PickSource(val versionId: String) : AudioBarCommand
     data object CancelPicker : AudioBarCommand
-
-    /** Fired by tapping the slow-load/error status line. Opens [AudioLogBottomSheet]. */
     data object OpenLogSheet : AudioBarCommand
     data object DismissLogSheet : AudioBarCommand
 }
 
 /**
- * Top-level audio bar surface. Shown and hidden
- * synchronously: the controller adds and removes the Compose content on
- * session start/end, so an enter/exit transition would only delay the layout
- * reflow the activity already commits when the host view appears.
+ * Top-level audio bar surface. Shown and hidden synchronously with the
+ * controller adding/removing this Compose content on session start/end; an
+ * enter/exit transition would only delay the layout reflow the activity
+ * already commits when the host view appears.
  */
 @Composable
 fun AudioBar(
@@ -367,12 +320,6 @@ private fun SpeedButton(
     }
 }
 
-/**
- * Compact recording chip showing the selected set's title, rendered only when
- * there is a choice to make ([AudioBarUiState.setTitle] is non-null). The
- * caller must place it inside a weighted slot so a long title ellipsizes
- * within the leftover row space instead of squeezing the transport controls.
- */
 @Composable
 private fun SetChooserButton(
     onCommand: (AudioBarCommand) -> Unit,
@@ -380,7 +327,7 @@ private fun SetChooserButton(
     IconButton(onClick = { onCommand(AudioBarCommand.OpenSetSheet) }) {
         Icon(
             imageVector = Icons.Outlined.Face,
-            contentDescription = stringResource(R.string.audio_bar_pick_source_title),
+            contentDescription = stringResource(R.string.audio_bar_select_audio),
         )
     }
 }
@@ -397,19 +344,6 @@ private fun CloseButton(
     }
 }
 
-/**
- * Small tappable status line shown above the play button while a chapter load
- * is taking unusually long, or once it has failed:
- *  - **Slow load**: preparing has held continuously for
- *    [SLOW_LOAD_STATUS_DELAY] with no error yet. Shows the most recent
- *    [AudioBarUiState.logs] entry, so the user sees what the HTTP layer is
- *    doing (DNS, connecting, waiting for headers) instead of a bare spinner
- *    with no explanation for the delay.
- *  - **Error**: [AudioBarUiState.error] is non-null. Shown immediately with no
- *    delay, since it is the detail behind the error icon on the play button.
- *
- * Tapping the line opens [AudioLogBottomSheet] with the full timestamped log.
- */
 @Composable
 private fun AudioLoadStatusLine(
     state: AudioBarUiState,
@@ -417,9 +351,7 @@ private fun AudioLoadStatusLine(
 ) {
     val slowLoad = slowLoadStatusVisible(state.preparing)
     if (state.error == null && !slowLoad) return
-    // In the error state the error itself is the message, not whatever
-    // happened to be logged last: a trailing state-transition entry would
-    // otherwise hide the failure the icon is pointing at.
+    // The error is the message; a trailing log entry would bury it.
     val text = state.error
         ?: state.logs.lastOrNull()?.message
         ?: stringResource(R.string.audio_bar_loading_status_fallback)
@@ -436,13 +368,6 @@ private fun AudioLoadStatusLine(
     )
 }
 
-/**
- * `true` only once [preparing] has been continuously true for
- * [SLOW_LOAD_STATUS_DELAY]; drops back to false immediately when [preparing]
- * does. Same shape as [debouncedPreparing], at the much longer delay the status
- * line is gated on. In inspection mode the delay is skipped so previews can pin
- * the slow-load state.
- */
 @Composable
 private fun slowLoadStatusVisible(preparing: Boolean): Boolean {
     if (LocalInspectionMode.current) return preparing
@@ -460,22 +385,9 @@ private fun slowLoadStatusVisible(preparing: Boolean): Boolean {
 
 private val SLOW_LOAD_STATUS_DELAY = 5_000.milliseconds
 
-/**
- * Play/pause, with two special states sharing the slot: a progress ring while
- * preparing, and an error icon when the last load failed. Tapping the error
- * icon retries the load instead of toggling playback. Long-pressing opens
- * [AudioLogBottomSheet], the same sheet [AudioLoadStatusLine] opens on tap.
- *
- * The preparing visuals (ring plus disabled swap) are debounced by
- * [PREPARING_INDICATION_DELAY], so a load that completes within the window
- * never flashes the ring at all. That covers a verse skip landing in
- * already-buffered data, or a chapter served from the HTTP cache.
- *
- * Built from a plain [Box] with [combinedClickable] rather than
- * [FilledIconButton]: that component only exposes a single [onClick], and
- * layering a second gesture detector around it to catch long-press races the
- * button's own internal one for the down event instead of sharing it.
- */
+// Box+combinedClickable, not FilledIconButton: that component only exposes a
+// single onClick, and layering a separate long-press detector around it
+// would race its internal gesture detector for the down event.
 @Composable
 private fun PlayPauseButton(
     state: AudioBarUiState,
@@ -550,12 +462,6 @@ private fun PlayPauseButton(
     }
 }
 
-/**
- * `true` only once [preparing] has been continuously true for
- * [PREPARING_INDICATION_DELAY]; drops back to false immediately when
- * [preparing] does. In inspection mode the delay is skipped so previews can
- * pin the preparing state.
- */
 @Composable
 private fun debouncedPreparing(preparing: Boolean): Boolean {
     if (LocalInspectionMode.current) return preparing
@@ -679,7 +585,6 @@ private fun AudioBarWideRow(
     }
 }
 
-/** Shown when split view is active and both visible versions have audio. */
 @Composable
 private fun SourcePickerDialog(
     options: List<AudioSourceOption>,
@@ -724,8 +629,6 @@ internal fun formatMmSs(ms: Long): String {
 
 internal fun durationLabelText(durationMs: Long): String =
     if (durationMs > 0L) formatMmSs(durationMs) else ""
-
-// -- Previews ------------------------------------------------------------------
 
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF, widthDp = 320)
 @Composable
@@ -853,8 +756,8 @@ private fun AudioBarPreviewDarkError() {
             durationMs = 60_000L,
             verse_1 = 0,
             speed = 1.0f,
-            error = "IO_NETWORK_CONNECTION_FAILED", // play button becomes a retry
-            timingAvailable = false, // some chapters have audio but no timing
+            error = "IO_NETWORK_CONNECTION_FAILED",
+            timingAvailable = false,
             logs = listOf(
                 AudioLogEntry(0L, "Loading Genesis 1"),
                 AudioLogEntry(1_000L, "HTTP request started: https://audio.example/gen1.mp3"),

--- a/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/SpeedBottomSheet.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/audio/ui/SpeedBottomSheet.kt
@@ -23,7 +23,7 @@ import java.text.NumberFormat
 import java.util.Locale
 import yuku.alkitab.debug.R
 
-val AUDIO_SPEEDS: List<Float> = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f)
+private val AUDIO_SPEEDS = floatArrayOf(0.5f, 0.7f, 0.85f, 1.0f, 1.25f, 1.5f, 1.75f, 2.0f, 3.0f)
 
 fun formatSpeedNumber(speed: Float, locale: Locale): String {
     val nf = NumberFormat.getNumberInstance(locale).apply {

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewActions.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewActions.kt
@@ -25,4 +25,13 @@ interface SplitViewActions {
 
     /** Replace split-1's data model — used to clear the pane when the split version can't display the current book. */
     fun setSplit1DataModel(model: VersesDataModel)
+
+    /**
+     * The set of versions on screen changed, so anything keyed on it has to be
+     * re-resolved: audio-set availability for the new version, the audio bar's
+     * recording chooser, and the toolbar menu. Opening, closing, or swapping
+     * the split version does not touch the globally active version, so it
+     * raises no `activeVersionChanged` event for those to hang off.
+     */
+    fun onVisibleVersionsChanged()
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/SplitViewManager.kt
@@ -248,6 +248,7 @@ class SplitViewManager(
         closeSplitDisplay()
 
         configureTextAppearancePanelForSplitVersion()
+        actions.onVisibleVersionsChanged()
     }
 
     /**
@@ -303,6 +304,7 @@ class SplitViewManager(
             host.splitHandleButton.setLabel2("${version.initials} \u25bc")
 
             configureTextAppearancePanelForSplitVersion()
+            actions.onVisibleVersionsChanged()
 
             return true
         } catch (e: Throwable) { // so we don't crash on the beginning of the app

--- a/Alkitab/src/main/res/values-af/strings.xml
+++ b/Alkitab/src/main/res/values-af/strings.xml
@@ -399,6 +399,7 @@
     <string name="audio_bar_next_verse">Volgende vers</string>
     <string name="audio_bar_pause">Wag</string>
     <string name="audio_bar_pick_source_title">Speel oudio vanaf</string>
+    <string name="audio_bar_select_audio">Kies oudio</string>
     <string name="audio_bar_play">Speel</string>
     <string name="audio_bar_prev_verse">Vorige vers</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-bg/strings.xml
+++ b/Alkitab/src/main/res/values-bg/strings.xml
@@ -400,6 +400,7 @@
     <string name="audio_bar_next_verse">Следващ стих</string>
     <string name="audio_bar_pause">Пауза</string>
     <string name="audio_bar_pick_source_title">Възпроизведи аудио от</string>
+    <string name="audio_bar_select_audio">Изберете аудио</string>
     <string name="audio_bar_play">Възпроизведи</string>
     <string name="audio_bar_prev_verse">Предишен стих</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-ceb/strings.xml
+++ b/Alkitab/src/main/res/values-ceb/strings.xml
@@ -398,6 +398,7 @@
     <string name="audio_bar_next_verse">Sunod na bersikulo</string>
     <string name="audio_bar_pause">Hunong</string>
     <string name="audio_bar_pick_source_title">Ipatugtog ang audio gikan sa</string>
+    <string name="audio_bar_select_audio">Pilia ang audio</string>
     <string name="audio_bar_play">Patugtog</string>
     <string name="audio_bar_prev_verse">Miaging bersikulo</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-cs/strings.xml
+++ b/Alkitab/src/main/res/values-cs/strings.xml
@@ -401,6 +401,7 @@
     <string name="audio_bar_next_verse">Následující verš</string>
     <string name="audio_bar_pause">Pozastavit</string>
     <string name="audio_bar_pick_source_title">Přehrát zvuk z</string>
+    <string name="audio_bar_select_audio">Vybrat zvuk</string>
     <string name="audio_bar_play">Přehrát</string>
     <string name="audio_bar_prev_verse">Předchozí verš</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-da/strings.xml
+++ b/Alkitab/src/main/res/values-da/strings.xml
@@ -399,6 +399,7 @@
     <string name="audio_bar_next_verse">Næste vers</string>
     <string name="audio_bar_pause">Pause</string>
     <string name="audio_bar_pick_source_title">Afspil lyd fra</string>
+    <string name="audio_bar_select_audio">Vælg lyd</string>
     <string name="audio_bar_play">Afspil</string>
     <string name="audio_bar_prev_verse">Foregående vers</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-de/strings.xml
+++ b/Alkitab/src/main/res/values-de/strings.xml
@@ -405,6 +405,7 @@
     <string name="audio_bar_next_verse">Nächster Vers</string>
     <string name="audio_bar_pause">Pause</string>
     <string name="audio_bar_pick_source_title">Audio abspielen von</string>
+    <string name="audio_bar_select_audio">Audio auswählen</string>
     <string name="audio_bar_play">Abspielen</string>
     <string name="audio_bar_prev_verse">Voriger Vers</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-el/strings.xml
+++ b/Alkitab/src/main/res/values-el/strings.xml
@@ -399,6 +399,7 @@
     <string name="audio_bar_next_verse">Επόμενος στίχος</string>
     <string name="audio_bar_pause">Παύση</string>
     <string name="audio_bar_pick_source_title">Αναπαραγωγή ήχου από</string>
+    <string name="audio_bar_select_audio">Επιλογή ήχου</string>
     <string name="audio_bar_play">Αναπαραγωγή</string>
     <string name="audio_bar_prev_verse">Προηγούμενος στίχος</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-es/strings.xml
+++ b/Alkitab/src/main/res/values-es/strings.xml
@@ -405,6 +405,7 @@
     <string name="audio_bar_next_verse">Versículo siguiente</string>
     <string name="audio_bar_pause">Pausa</string>
     <string name="audio_bar_pick_source_title">Reproducir audio desde</string>
+    <string name="audio_bar_select_audio">Seleccionar audio</string>
     <string name="audio_bar_play">Reproducir</string>
     <string name="audio_bar_prev_verse">Versículo anterior</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-fr/strings.xml
+++ b/Alkitab/src/main/res/values-fr/strings.xml
@@ -405,6 +405,7 @@
     <string name="audio_bar_next_verse">Verset suivant</string>
     <string name="audio_bar_pause">Pause</string>
     <string name="audio_bar_pick_source_title">Lire l\'audio depuis</string>
+    <string name="audio_bar_select_audio">Sélectionner l\'audio</string>
     <string name="audio_bar_play">Lecture</string>
     <string name="audio_bar_prev_verse">Verset précédent</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-hu/strings.xml
+++ b/Alkitab/src/main/res/values-hu/strings.xml
@@ -364,6 +364,7 @@
     <string name="audio_bar_next_verse">Következő versszak</string>
     <string name="audio_bar_pause">Szünet</string>
     <string name="audio_bar_pick_source_title">Hang lejátszása innen</string>
+    <string name="audio_bar_select_audio">Hang kiválasztása</string>
     <string name="audio_bar_play">Lejátszás</string>
     <string name="audio_bar_prev_verse">Előző versszak</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-in/strings.xml
+++ b/Alkitab/src/main/res/values-in/strings.xml
@@ -434,6 +434,7 @@
     <string name="audio_bar_prev_verse">Ayat sebelumnya</string>
     <string name="audio_bar_next_verse">Ayat berikutnya</string>
     <string name="audio_bar_pick_source_title">Putar audio dari</string>
+    <string name="audio_bar_select_audio">Pilih audio</string>
     <string name="audio_bar_speed_sheet_title">Kecepatan putar</string>
     <string name="audio_bar_set_sheet_title">Rekaman</string>
     <string name="audio_bar_set_not_available_for_book">Tidak tersedia untuk kitab ini</string>

--- a/Alkitab/src/main/res/values-it/strings.xml
+++ b/Alkitab/src/main/res/values-it/strings.xml
@@ -406,6 +406,7 @@
     <string name="audio_bar_next_verse">Versetto successivo</string>
     <string name="audio_bar_pause">Pausa</string>
     <string name="audio_bar_pick_source_title">Riproduci audio da</string>
+    <string name="audio_bar_select_audio">Seleziona audio</string>
     <string name="audio_bar_play">Riproduci</string>
     <string name="audio_bar_prev_verse">Versetto precedente</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-ja/strings.xml
+++ b/Alkitab/src/main/res/values-ja/strings.xml
@@ -400,6 +400,7 @@
     <string name="audio_bar_next_verse">次の節</string>
     <string name="audio_bar_pause">一時停止</string>
     <string name="audio_bar_pick_source_title">オーディオの再生元</string>
+    <string name="audio_bar_select_audio">オーディオを選択</string>
     <string name="audio_bar_play">再生</string>
     <string name="audio_bar_prev_verse">前の節</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-ko/strings.xml
+++ b/Alkitab/src/main/res/values-ko/strings.xml
@@ -400,6 +400,7 @@
     <string name="audio_bar_next_verse">다음 절</string>
     <string name="audio_bar_pause">정지</string>
     <string name="audio_bar_pick_source_title">오디오 재생 소스</string>
+    <string name="audio_bar_select_audio">오디오 선택</string>
     <string name="audio_bar_play">재생</string>
     <string name="audio_bar_prev_verse">이전 절</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-lv/strings.xml
+++ b/Alkitab/src/main/res/values-lv/strings.xml
@@ -399,6 +399,7 @@
     <string name="audio_bar_next_verse">Nākošais pants</string>
     <string name="audio_bar_pause">Pauze</string>
     <string name="audio_bar_pick_source_title">Atskaņot audio no</string>
+    <string name="audio_bar_select_audio">Izvēlēties audio</string>
     <string name="audio_bar_play">Atskaņot</string>
     <string name="audio_bar_prev_verse">Iepriekšējais pants</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-ms/strings.xml
+++ b/Alkitab/src/main/res/values-ms/strings.xml
@@ -399,6 +399,7 @@
     <string name="audio_bar_next_verse">Ayat seterusnya</string>
     <string name="audio_bar_pause">Jeda</string>
     <string name="audio_bar_pick_source_title">Mainkan audio dari</string>
+    <string name="audio_bar_select_audio">Pilih audio</string>
     <string name="audio_bar_play">Main</string>
     <string name="audio_bar_prev_verse">Ayat sebelumnya</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-my/strings.xml
+++ b/Alkitab/src/main/res/values-my/strings.xml
@@ -400,6 +400,7 @@
     <string name="audio_bar_next_verse">နောက်ကျမ်းပိုဒ်</string>
     <string name="audio_bar_pause">ခေတ္တရပ်ဆိုင်းရန်</string>
     <string name="audio_bar_pick_source_title">အသံဖွင့်ရန် ရင်းမြစ်</string>
+    <string name="audio_bar_select_audio">အသံရွေးရန်</string>
     <string name="audio_bar_play">ဖွင့်ရန်</string>
     <string name="audio_bar_prev_verse">ယခင်ကျမ်းပိုဒ်</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-nl/strings.xml
+++ b/Alkitab/src/main/res/values-nl/strings.xml
@@ -405,6 +405,7 @@
     <string name="audio_bar_next_verse">Volgend vers</string>
     <string name="audio_bar_pause">Pauze</string>
     <string name="audio_bar_pick_source_title">Audio afspelen van</string>
+    <string name="audio_bar_select_audio">Audio selecteren</string>
     <string name="audio_bar_play">Afspelen</string>
     <string name="audio_bar_prev_verse">Vorig vers</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-pl/strings.xml
+++ b/Alkitab/src/main/res/values-pl/strings.xml
@@ -405,6 +405,7 @@
     <string name="audio_bar_next_verse">Następny wers</string>
     <string name="audio_bar_pause">Pauza</string>
     <string name="audio_bar_pick_source_title">Odtwarzaj audio z</string>
+    <string name="audio_bar_select_audio">Wybierz audio</string>
     <string name="audio_bar_play">Odtwórz</string>
     <string name="audio_bar_prev_verse">Poprzedni wers</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-pt-rBR/strings.xml
+++ b/Alkitab/src/main/res/values-pt-rBR/strings.xml
@@ -405,6 +405,7 @@
     <string name="audio_bar_next_verse">Próximo versículo</string>
     <string name="audio_bar_pause">Pausar</string>
     <string name="audio_bar_pick_source_title">Reproduzir áudio de</string>
+    <string name="audio_bar_select_audio">Selecionar áudio</string>
     <string name="audio_bar_play">Reproduzir</string>
     <string name="audio_bar_prev_verse">Versículo anterior</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-pt/strings.xml
+++ b/Alkitab/src/main/res/values-pt/strings.xml
@@ -400,6 +400,7 @@
     <string name="audio_bar_next_verse">Versículo seguinte</string>
     <string name="audio_bar_pause">Pausa</string>
     <string name="audio_bar_pick_source_title">Reproduzir áudio de</string>
+    <string name="audio_bar_select_audio">Selecionar áudio</string>
     <string name="audio_bar_play">Reproduzir</string>
     <string name="audio_bar_prev_verse">Versículo anterior</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-ro/strings.xml
+++ b/Alkitab/src/main/res/values-ro/strings.xml
@@ -405,6 +405,7 @@
     <string name="audio_bar_next_verse">Versetul următor</string>
     <string name="audio_bar_pause">Pauză</string>
     <string name="audio_bar_pick_source_title">Redă audio din</string>
+    <string name="audio_bar_select_audio">Selectați audio</string>
     <string name="audio_bar_play">Redă</string>
     <string name="audio_bar_prev_verse">Versetul precedent</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-ru/strings.xml
+++ b/Alkitab/src/main/res/values-ru/strings.xml
@@ -405,6 +405,7 @@
     <string name="audio_bar_next_verse">Следующий стих</string>
     <string name="audio_bar_pause">Пауза</string>
     <string name="audio_bar_pick_source_title">Воспроизвести аудио из</string>
+    <string name="audio_bar_select_audio">Выбрать аудио</string>
     <string name="audio_bar_play">Воспроизвести</string>
     <string name="audio_bar_prev_verse">Предыдущий стих</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-th/strings.xml
+++ b/Alkitab/src/main/res/values-th/strings.xml
@@ -400,6 +400,7 @@
     <string name="audio_bar_next_verse">ข้อต่อไป</string>
     <string name="audio_bar_pause">หยุดฟัง</string>
     <string name="audio_bar_pick_source_title">เล่นเสียงจาก</string>
+    <string name="audio_bar_select_audio">เลือกเสียง</string>
     <string name="audio_bar_play">ฟัง</string>
     <string name="audio_bar_prev_verse">ข้อก่อน</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-tl/strings.xml
+++ b/Alkitab/src/main/res/values-tl/strings.xml
@@ -399,6 +399,7 @@
     <string name="audio_bar_next_verse">Susunod na taludtod</string>
     <string name="audio_bar_pause">Itigil sandali</string>
     <string name="audio_bar_pick_source_title">Patugtugin ang audio mula sa</string>
+    <string name="audio_bar_select_audio">Pumili ng audio</string>
     <string name="audio_bar_play">Patugtugin</string>
     <string name="audio_bar_prev_verse">Nakaraang taludtod</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-tr/strings.xml
+++ b/Alkitab/src/main/res/values-tr/strings.xml
@@ -405,6 +405,7 @@
     <string name="audio_bar_next_verse">Sonraki ayet</string>
     <string name="audio_bar_pause">Durdur</string>
     <string name="audio_bar_pick_source_title">Sesi şuradan oynat</string>
+    <string name="audio_bar_select_audio">Ses seç</string>
     <string name="audio_bar_play">Oynat</string>
     <string name="audio_bar_prev_verse">Önceki ayet</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-uk/strings.xml
+++ b/Alkitab/src/main/res/values-uk/strings.xml
@@ -401,6 +401,7 @@
     <string name="audio_bar_next_verse">Наступний вірш</string>
     <string name="audio_bar_pause">Пауза</string>
     <string name="audio_bar_pick_source_title">Відтворити аудіо з</string>
+    <string name="audio_bar_select_audio">Вибрати аудіо</string>
     <string name="audio_bar_play">Відтворити</string>
     <string name="audio_bar_prev_verse">Попередній вірш</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-vi/strings.xml
+++ b/Alkitab/src/main/res/values-vi/strings.xml
@@ -405,6 +405,7 @@
     <string name="audio_bar_next_verse">Câu sau</string>
     <string name="audio_bar_pause">Tạm dừng</string>
     <string name="audio_bar_pick_source_title">Phát âm thanh từ</string>
+    <string name="audio_bar_select_audio">Chọn âm thanh</string>
     <string name="audio_bar_play">Phát</string>
     <string name="audio_bar_prev_verse">Câu trước</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-zh-rCN/strings.xml
+++ b/Alkitab/src/main/res/values-zh-rCN/strings.xml
@@ -405,6 +405,7 @@
     <string name="audio_bar_next_verse">下一节</string>
     <string name="audio_bar_pause">暂停</string>
     <string name="audio_bar_pick_source_title">播放音频来源</string>
+    <string name="audio_bar_select_audio">选择音频</string>
     <string name="audio_bar_play">播放</string>
     <string name="audio_bar_prev_verse">上一节</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values-zh-rTW/strings.xml
+++ b/Alkitab/src/main/res/values-zh-rTW/strings.xml
@@ -398,6 +398,7 @@
     <string name="audio_bar_next_verse">下一節</string>
     <string name="audio_bar_pause">暫停</string>
     <string name="audio_bar_pick_source_title">播放音訊來源</string>
+    <string name="audio_bar_select_audio">選擇音訊</string>
     <string name="audio_bar_play">播放</string>
     <string name="audio_bar_prev_verse">上一節</string>
     <string name="audio_bar_speed_format">%1$s×</string>

--- a/Alkitab/src/main/res/values/strings.xml
+++ b/Alkitab/src/main/res/values/strings.xml
@@ -485,6 +485,7 @@
 	<string name="audio_bar_next_verse">Next verse</string>
 	<string name="audio_bar_speed_format">%1$s×</string>
 	<string name="audio_bar_pick_source_title">Play audio from</string>
+	<string name="audio_bar_select_audio">Select audio</string>
 	<string name="audio_bar_speed_sheet_title">Playback speed</string>
 	<string name="audio_bar_set_sheet_title">Recording</string>
 	<string name="audio_bar_set_not_available_for_book">Not available for this book</string>

--- a/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioBarControllerSetChoiceTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/audio/AudioBarControllerSetChoiceTest.kt
@@ -1,0 +1,84 @@
+package yuku.alkitab.base.audio
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import yuku.alkitab.base.audio.model.AudioSet
+
+/**
+ * Pure-logic tests for [AudioBarController.canChooseSet], which gates the audio
+ * bar's recording-chooser button.
+ */
+class AudioBarControllerSetChoiceTest {
+
+    private fun set(audioId: String) = AudioSet(
+        audioId = audioId,
+        title = audioId.replaceFirstChar { it.uppercaseChar() },
+        hasTiming = true,
+        books_1 = (1..66).toSet(),
+        mp3UrlTemplate = "/audio/file/p/$audioId/{book_1}/{chapter_1}.mp3",
+        timingUrlTemplate = "/audio/timing/p/$audioId/{book_1}/{chapter_1}.json",
+    )
+
+    private fun canChooseSet(setsByVersion: Map<String, List<AudioSet>?>, versionIds: List<String>? = null) =
+        AudioBarController.canChooseSet(
+            versionIds = versionIds ?: setsByVersion.keys.toList(),
+            setsOf = { setsByVersion[it] },
+        )
+
+    @Test
+    fun `a single version offering one recording leaves nothing to choose`() {
+        assertFalse(canChooseSet(mapOf("tb" to listOf(set("alkitabsuara")))))
+    }
+
+    @Test
+    fun `a single version offering two recordings is a choice`() {
+        assertTrue(canChooseSet(mapOf("tb" to listOf(set("alkitabsuara"), set("other")))))
+    }
+
+    @Test
+    fun `in split view one recording on each side is still a choice, since audio can move across the splits`() {
+        assertTrue(
+            canChooseSet(
+                mapOf(
+                    "tb" to listOf(set("alkitabsuara")),
+                    "kjv" to listOf(set("wordproject")),
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun `in split view a single recording with the other side having no audio leaves nothing to choose`() {
+        assertFalse(
+            canChooseSet(
+                mapOf(
+                    "tb" to listOf(set("alkitabsuara")),
+                    "kjv" to emptyList(),
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun `versions whose set list has not resolved yet count as offering nothing`() {
+        assertFalse(
+            canChooseSet(
+                mapOf(
+                    "tb" to listOf(set("alkitabsuara")),
+                    "kjv" to null,
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun `the same version shown in both splits is counted once`() {
+        assertFalse(
+            canChooseSet(
+                setsByVersion = mapOf("tb" to listOf(set("alkitabsuara"))),
+                versionIds = listOf("tb", "tb"),
+            )
+        )
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/compose/ComposeThemeSnapshotTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/compose/ComposeThemeSnapshotTest.kt
@@ -193,7 +193,7 @@ class ComposeThemeSnapshotTest {
                     logs = emptyList(),
                     showLogSheet = false,
                     playingVersionId = "preset/in-tb",
-                    setTitle = "Alkitab Suara",
+                    canChooseSet = true,
                     pickerOptions = null,
                     showSpeedSheet = false,
                     setGroups = null,


### PR DESCRIPTION
## Summary
- **polish audiobar UI** (`d351aa2f`): reworks `AudioBar`'s layout to a width-based (`BoxWithConstraints`) wide/narrow split instead of orientation-based, replaces the play/pause `FilledIconButton` with a `Box` + `combinedClickable` so long-press can open the log sheet without racing the button's own gesture detector, and adds the recording-chooser icon button next to the speed control.
- **Trim AudioBar.kt comments and add a dedicated content description for the recording chooser button** (`9588e474`): removes almost all comments in `AudioBar.kt`, and replaces the chooser's reused `audio_bar_pick_source_title` ("Play audio from", actually the split-view source-picker dialog's title) with a dedicated `audio_bar_select_audio` string ("Select audio" / Indonesian "Pilih audio"), translated across all 30 supported locales.
- **Keep audio bar controls inside the safe area in landscape** (`fd3ec8ca`): the bar only applied the bottom `safeDrawing` inset, so in landscape the navigation bar and the display cutout (the window uses `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES`) overlapped the close button on one side and the speed/chooser buttons on the other. Every other child of `IsiActivity`'s `root` already pads `insets.left`/`insets.right`; the audio bar was the one that did not. Now applies the horizontal and bottom insets to the content, with the padding on the `BoxWithConstraints` so the `Surface` background still paints edge-to-edge and the wide/narrow breakpoint measures the width the controls actually get.
- **Hide the recording chooser when there is nothing to choose, and refresh it on version changes** (`4f3bf765`):
  - The chooser button rendered unconditionally, so a version with a single recording and no second audio-capable split still showed a control that opened a one-row sheet. The unused `setTitle` field is replaced by `canChooseSet`, computed as the total recording count across the visible versions being greater than one. In split view one recording on each side still counts as a choice, since picking the other side's moves audio across the splits.
  - Neither the button's visibility nor an open sheet's contents are derived from `PlaybackState`, so both sat stale until the next position tick and indefinitely while paused. Adds `refreshSetChoices()`, called when the active version changes and once a newly shown version's set list finishes resolving. The sheet remembers whether it was opened by the play-from-verse flow so a rebuild keeps its timing-only filter.
  - Swaps the chooser icon from a face to a list, and gives the speed button the same content color as the icon buttons instead of the `TextButton` primary.
- **Re-resolve audio sets when the split version changes** (`542a8b7e`): opening, closing, or swapping the split version never raised `activeVersionChanged` — that event is emitted only by `loadVersion`, which changes the *globally active* version. Everything hanging off it was therefore skipped for split changes, so picking a freshly downloaded version on the split handle left its audio sets unresolved, the recording chooser without that version's recordings, and the toolbar audio icon stale. Adds `SplitViewActions.onVisibleVersionsChanged`, raised by `SplitViewManager` wherever `activeSplit1` is assigned, and routes `IsiActivity`'s existing `activeVersionChanged` handling through the same method.

## Test plan
- [x] `./gradlew assemblePlainDebug` builds successfully
- [x] `./gradlew testPlainDebugUnitTest` green — 679 tests, 0 failures, including 6 new `AudioBarControllerSetChoiceTest` cases covering the single-version, split-view, unresolved-cache, and duplicate-version-id paths
- [x] Validated all touched `strings.xml` files parse as well-formed XML
- [ ] On-device checks not possible in this environment: landscape insets with a side navigation bar / display cutout, and the download-then-pick-on-split-handle flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
