### PR TITLE
Remove multidex

### DIFF
--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -125,7 +125,6 @@ android {
         targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = buildVersionCode
         versionName = "5.0.0-b0"
-        multiDexEnabled = true
         buildConfigField("String", "SERVER_HOST", "\"$serverHost\"")
         buildConfigField("String", "RIBKA_FUNCTIONS_HOST", "\"$ribkaFunctionsHost\"")
         buildConfigField("String", "LAST_COMMIT_HASH", "\"$gitCommitHash\"")
@@ -404,7 +403,6 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.fragment.ktx)
-    implementation(libs.androidx.multidex)
     implementation(libs.androidx.percentlayout)
     implementation(libs.androidx.preference.ktx)
     implementation(libs.androidx.recyclerview)

--- a/Alkitab/src/main/java/yuku/alkitab/base/App.java
+++ b/Alkitab/src/main/java/yuku/alkitab/base/App.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.net.Uri;
 import androidx.core.app.NotificationChannelCompat;
 import androidx.core.app.NotificationManagerCompat;
-import androidx.multidex.MultiDex;
 import androidx.preference.PreferenceManager;
 import com.google.gson.Gson;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -122,11 +121,6 @@ public class App extends yuku.afw.App {
 
     public static Gson getDefaultGson() {
         return GsonWrapper.INSTANCE.gson;
-    }
-
-    protected void attachBaseContext(Context base) {
-        super.attachBaseContext(base);
-        MultiDex.install(this);
     }
 
     public static String getAppIdentifierParamsEncoded() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,6 @@ androidxCore = "1.17.0"
 androidxFragment = "1.8.9"
 androidxLifecycle = "2.9.0"
 androidxMedia3 = "1.10.1"
-androidxMultidex = "2.0.1"
 androidxPercentlayout = "1.0.0"
 androidxPreference = "1.2.1"
 androidxRecyclerview = "1.4.0"
@@ -72,7 +71,6 @@ androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplaye
 androidx-media3-datasource-okhttp = { group = "androidx.media3", name = "media3-datasource-okhttp", version.ref = "androidxMedia3" }
 androidx-media3-session = { group = "androidx.media3", name = "media3-session", version.ref = "androidxMedia3" }
 androidx-media3-exoplayer-midi = { group = "androidx.media3", name = "media3-exoplayer-midi", version.ref = "androidxMedia3" }
-androidx-multidex = { group = "androidx.multidex", name = "multidex", version.ref = "androidxMultidex" }
 androidx-percentlayout = { group = "androidx.percentlayout", name = "percentlayout", version.ref = "androidxPercentlayout" }
 androidx-preference = { group = "androidx.preference", name = "preference", version.ref = "androidxPreference" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "androidxPreference" }


### PR DESCRIPTION
The app's `minSdk` is 26, and ART has loaded multiple dex files natively since API 21. That makes the entire multidex setup a no-op:

- AGP already treats `minSdk >= 21` as native multidex, so `multiDexEnabled = true` changes nothing about how the APK is packaged.
- `MultiDex.install()` returns immediately on API 21+, so the `attachBaseContext` override in `App` did no work. Removing the override is safe because it did nothing else, and `Application.attachBaseContext` needs no override to behave correctly.

## Changes

| File | Removed |
|---|---|
| `Alkitab/build.gradle.kts` | `multiDexEnabled = true` from `defaultConfig`; the `androidx.multidex` dependency |
| `gradle/libs.versions.toml` | the `androidxMultidex` version and the `androidx-multidex` library alias |
| `Alkitab/src/main/java/yuku/alkitab/base/App.java` | the `androidx.multidex.MultiDex` import and the `attachBaseContext` override that existed only to call `MultiDex.install()` |

Nothing else in the repository referenced multidex: no ProGuard keep rules, no manifest entries, no `MultiDexApplication` usage, no docs. The `android.content.Context` import in `App.java` is kept because it is still needed to resolve the `{@link #initWithAppContext(Context)}` javadoc reference.

## Verification

Built and tested locally rather than relying on CI, running the same tasks the workflow does:

```
./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest assemblePlainDebug bundlePlainDebug
```

---
_Generated by [Claude Code](https://claude.ai/code/session_019TrcvmX74tKcpPHPpBYiNF)_