### PR TITLE
Add an "Alkitab GPT" verse action for devices that already have the app

### DIFF
--- a/Alkitab/src/main/AndroidManifest.xml
+++ b/Alkitab/src/main/AndroidManifest.xml
@@ -456,6 +456,7 @@
 		<package android:name="org.sabda.kamus" />
 		<package android:name="org.sabda.pedia" />
 		<package android:name="org.sabda.tafsiran" />
+		<package android:name="org.sabda.gpt" />
 		<package android:name="yuku.esvsbasal" />
 		<package android:name="palki.maps" />
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -288,10 +288,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
     }
 
-    /**
-     * True once [resolveAlkitabGptAsync] has found the separate "Alkitab GPT" app installed.
-     * Stays false on devices without it, which is what keeps the menu item hidden.
-     */
     override var hasAlkitabGpt = false
         private set
 
@@ -745,15 +741,6 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         AppLog.d(TAG, "@@onCreate end")
     }
 
-    /**
-     * Looks up the separate "Alkitab GPT" app in the background and records the answer in
-     * [hasAlkitabGpt].
-     *
-     * The lookup itself suspends on an IO dispatcher, so the main thread never waits on
-     * PackageManager. The action mode may already be showing when the answer lands (the user can
-     * select a verse before this finishes), hence the `invalidate()`: it re-runs
-     * `onPrepareActionMode`, which is where the menu item's visibility is decided.
-     */
     private fun resolveAlkitabGptAsync() {
         lifecycleScope.launch {
             if (!AlkitabGptIntegration.isChatPopupAvailable(this@IsiActivity)) return@launch

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -83,6 +83,7 @@ import yuku.alkitab.base.model.MVersionDb
 import yuku.alkitab.base.settings.ExperimentalFlags
 import yuku.alkitab.base.settings.SettingsActivity
 import yuku.alkitab.base.storage.Prefkey
+import yuku.alkitab.base.util.AlkitabGptIntegration
 import yuku.alkitab.base.util.AppLog
 import yuku.alkitab.base.util.Appearances
 import yuku.alkitab.base.util.BackForwardListController
@@ -286,6 +287,13 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             false
         }
     }
+
+    /**
+     * Non-null once [resolveAlkitabGptAsync] has found the separate "Alkitab GPT" app installed.
+     * Stays null on devices without it, which is what keeps the menu item hidden.
+     */
+    override var alkitabGptLaunchIntent: Intent? = null
+        private set
 
     /**
      * Container class to make sure that the fields are changed simultaneously.
@@ -705,6 +713,8 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
             }
         }
 
+        resolveAlkitabGptAsync()
+
         lifecycleScope.launch { AppEvents.attributeMapChanged.collect { reloadBothAttributeMaps() } }
         lifecycleScope.launch { AppEvents.needsRestart.collect { needsRestart = true } }
 
@@ -733,6 +743,24 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
         }
 
         AppLog.d(TAG, "@@onCreate end")
+    }
+
+    /**
+     * Looks up the separate "Alkitab GPT" app in the background and, when it is installed, keeps
+     * the intent that opens it in [alkitabGptLaunchIntent].
+     *
+     * PackageManager lookups are binder calls into system_server and can stall for a noticeable
+     * time on a loaded device, so this must never run on the main thread. The action mode may
+     * already be showing when the answer lands (the user can select a verse before this
+     * finishes), hence the `invalidate()`: it re-runs `onPrepareActionMode`, which is where the
+     * menu item's visibility is decided.
+     */
+    private fun resolveAlkitabGptAsync() {
+        lifecycleScope.launch {
+            val intent = AlkitabGptIntegration.resolveLaunchIntent(this@IsiActivity) ?: return@launch
+            alkitabGptLaunchIntent = intent
+            actionMode?.invalidate()
+        }
     }
 
     /**

--- a/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/IsiActivity.kt
@@ -289,10 +289,10 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     }
 
     /**
-     * Non-null once [resolveAlkitabGptAsync] has found the separate "Alkitab GPT" app installed.
-     * Stays null on devices without it, which is what keeps the menu item hidden.
+     * True once [resolveAlkitabGptAsync] has found the separate "Alkitab GPT" app installed.
+     * Stays false on devices without it, which is what keeps the menu item hidden.
      */
-    override var alkitabGptLaunchIntent: Intent? = null
+    override var hasAlkitabGpt = false
         private set
 
     /**
@@ -746,19 +746,18 @@ class IsiActivity : BaseLeftDrawerActivity(), LeftDrawer.Text.Listener, VerseAct
     }
 
     /**
-     * Looks up the separate "Alkitab GPT" app in the background and, when it is installed, keeps
-     * the intent that opens it in [alkitabGptLaunchIntent].
+     * Looks up the separate "Alkitab GPT" app in the background and records the answer in
+     * [hasAlkitabGpt].
      *
-     * PackageManager lookups are binder calls into system_server and can stall for a noticeable
-     * time on a loaded device, so this must never run on the main thread. The action mode may
-     * already be showing when the answer lands (the user can select a verse before this
-     * finishes), hence the `invalidate()`: it re-runs `onPrepareActionMode`, which is where the
-     * menu item's visibility is decided.
+     * The lookup itself suspends on an IO dispatcher, so the main thread never waits on
+     * PackageManager. The action mode may already be showing when the answer lands (the user can
+     * select a verse before this finishes), hence the `invalidate()`: it re-runs
+     * `onPrepareActionMode`, which is where the menu item's visibility is decided.
      */
     private fun resolveAlkitabGptAsync() {
         lifecycleScope.launch {
-            val intent = AlkitabGptIntegration.resolveLaunchIntent(this@IsiActivity) ?: return@launch
-            alkitabGptLaunchIntent = intent
+            if (!AlkitabGptIntegration.isChatPopupAvailable(this@IsiActivity)) return@launch
+            hasAlkitabGpt = true
             actionMode?.invalidate()
         }
     }

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
@@ -160,10 +160,6 @@ class VerseActionModeController(
         // do not show dictionary item if not needed because of auto-lookup from
         menuDictionary.isVisible = c.menuDictionary && !Preferences.getBoolean(host.activity.getString(R.string.pref_autoDictionaryAnalyze_key), host.activity.resources.getBoolean(R.bool.pref_autoDictionaryAnalyze_default))
 
-        // Alkitab GPT is only offered when that app is already installed. The lookup that answers
-        // that runs off the main thread, so its result can land after the action mode was created;
-        // deciding visibility here (rather than in onCreateActionMode) means every `invalidate()`
-        // picks up the answer as soon as it arrives.
         menu.findItem(R.id.menuAlkitabGpt).isVisible = host.hasAlkitabGpt
 
         val menuRibkaReport = menu.findItem(R.id.menuRibkaReport)
@@ -416,8 +412,6 @@ class VerseActionModeController(
 
             R.id.menuAlkitabGpt -> {
 
-                // Alkitab GPT takes a passage, not a verse list, so a non-contiguous selection is
-                // sent as the range that spans it.
                 val intent = AlkitabGptIntegration.chatPopupIntent(
                     bookName = host.activeSplit0Book.shortName,
                     chapter_1 = host.chapter_1,

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
@@ -19,6 +19,7 @@ import yuku.alkitab.base.dialog.TypeHighlightDialog
 import yuku.alkitab.base.dialog.VersesDialog
 import yuku.alkitab.base.model.MVersion
 import yuku.alkitab.base.model.MVersionDb
+import yuku.alkitab.base.util.AlkitabGptIntegration
 import yuku.alkitab.base.util.AppLog
 import yuku.alkitab.base.util.ClipboardUtil
 import yuku.alkitab.base.util.ExtensionManager
@@ -158,6 +159,12 @@ class VerseActionModeController(
 
         // do not show dictionary item if not needed because of auto-lookup from
         menuDictionary.isVisible = c.menuDictionary && !Preferences.getBoolean(host.activity.getString(R.string.pref_autoDictionaryAnalyze_key), host.activity.resources.getBoolean(R.bool.pref_autoDictionaryAnalyze_default))
+
+        // Alkitab GPT is only offered when that app is already installed. The lookup that answers
+        // that runs off the main thread, so its result can land after the action mode was created;
+        // deciding visibility here (rather than in onCreateActionMode) means every `invalidate()`
+        // picks up the answer as soon as it arrives.
+        menu.findItem(R.id.menuAlkitabGpt).isVisible = host.alkitabGptLaunchIntent != null
 
         val menuRibkaReport = menu.findItem(R.id.menuRibkaReport)
         menuRibkaReport.isVisible = single && actions.checkRibkaEligibility() != RibkaEligibility.None
@@ -407,6 +414,21 @@ class VerseActionModeController(
                 true
             }
 
+            R.id.menuAlkitabGpt -> {
+                val template = host.alkitabGptLaunchIntent
+                if (template != null) {
+                    val ari = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, selected.get(0))
+                    val reference = VerseTextFormatter.referenceFromSelectedVerses(selected, host.activeSplit0Book, host.chapter_1)
+
+                    try {
+                        host.activity.startActivity(AlkitabGptIntegration.withVerse(template, ari, reference, plainTextOfSelectedVerses(selected)))
+                    } catch (e: Exception) {
+                        AppLog.e(TAG, "Alkitab GPT starting", e)
+                    }
+                }
+                true
+            }
+
             R.id.menuGuide -> {
 
                 val ari = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, 0)
@@ -554,6 +576,15 @@ class VerseActionModeController(
             actions.uncheckAllVersesSplit0()
         }
     }
+
+    /**
+     * The selected verses of the primary split as plain text, one verse per line, with the
+     * inline formatting codes stripped.
+     */
+    private fun plainTextOfSelectedVerses(selectedVerses_1: IntArrayList): String =
+        (0 until selectedVerses_1.size())
+            .mapNotNull { FormattedVerseText.removeSpecialCodes(host.dataSplit0.getVerseText(selectedVerses_1.get(it))) }
+            .joinToString("\n")
 
     /**
      * Resolves the two "copy/share" preferences and the split/non-split version

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeController.kt
@@ -164,7 +164,7 @@ class VerseActionModeController(
         // that runs off the main thread, so its result can land after the action mode was created;
         // deciding visibility here (rather than in onCreateActionMode) means every `invalidate()`
         // picks up the answer as soon as it arrives.
-        menu.findItem(R.id.menuAlkitabGpt).isVisible = host.alkitabGptLaunchIntent != null
+        menu.findItem(R.id.menuAlkitabGpt).isVisible = host.hasAlkitabGpt
 
         val menuRibkaReport = menu.findItem(R.id.menuRibkaReport)
         menuRibkaReport.isVisible = single && actions.checkRibkaEligibility() != RibkaEligibility.None
@@ -415,16 +415,20 @@ class VerseActionModeController(
             }
 
             R.id.menuAlkitabGpt -> {
-                val template = host.alkitabGptLaunchIntent
-                if (template != null) {
-                    val ari = Ari.encode(host.activeSplit0Book.bookId, host.chapter_1, selected.get(0))
-                    val reference = VerseTextFormatter.referenceFromSelectedVerses(selected, host.activeSplit0Book, host.chapter_1)
 
-                    try {
-                        host.activity.startActivity(AlkitabGptIntegration.withVerse(template, ari, reference, plainTextOfSelectedVerses(selected)))
-                    } catch (e: Exception) {
-                        AppLog.e(TAG, "Alkitab GPT starting", e)
-                    }
+                // Alkitab GPT takes a passage, not a verse list, so a non-contiguous selection is
+                // sent as the range that spans it.
+                val intent = AlkitabGptIntegration.chatPopupIntent(
+                    bookName = host.activeSplit0Book.shortName,
+                    chapter_1 = host.chapter_1,
+                    verseStart_1 = selected.get(0),
+                    verseEnd_1 = selected.get(selected.size() - 1),
+                )
+
+                try {
+                    host.activity.startActivity(intent)
+                } catch (e: Exception) {
+                    AppLog.e(TAG, "Alkitab GPT starting", e)
                 }
                 true
             }
@@ -576,15 +580,6 @@ class VerseActionModeController(
             actions.uncheckAllVersesSplit0()
         }
     }
-
-    /**
-     * The selected verses of the primary split as plain text, one verse per line, with the
-     * inline formatting codes stripped.
-     */
-    private fun plainTextOfSelectedVerses(selectedVerses_1: IntArrayList): String =
-        (0 until selectedVerses_1.size())
-            .mapNotNull { FormattedVerseText.removeSpecialCodes(host.dataSplit0.getVerseText(selectedVerses_1.get(it))) }
-            .joinToString("\n")
 
     /**
      * Resolves the two "copy/share" preferences and the split/non-split version

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeHost.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeHost.kt
@@ -42,11 +42,6 @@ interface VerseActionModeHost {
 
     val hasEsvsbAsal: Boolean
 
-    /**
-     * Whether the separate "Alkitab GPT" app is installed and can take a chat-popup request.
-     * False until the asynchronous lookup finishes, which is why the controller re-reads this on
-     * every `onPrepareActionMode` rather than caching it.
-     */
     val hasAlkitabGpt: Boolean
 
     /**

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeHost.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeHost.kt
@@ -1,5 +1,6 @@
 package yuku.alkitab.base.actionmode
 
+import android.content.Intent
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import yuku.alkitab.base.model.MVersion
@@ -41,6 +42,13 @@ interface VerseActionModeHost {
     val dataSplit1: VersesDataModel
 
     val hasEsvsbAsal: Boolean
+
+    /**
+     * Ready-to-start intent template for the separate "Alkitab GPT" app, or null when that app
+     * is not installed on the device (also null until the asynchronous lookup finishes, which is
+     * why the controller re-reads this on every `onPrepareActionMode` rather than caching it).
+     */
+    val alkitabGptLaunchIntent: Intent?
 
     /**
      * Set to false by the Activity when it wants to keep the checked verses

--- a/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeHost.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/actionmode/VerseActionModeHost.kt
@@ -1,6 +1,5 @@
 package yuku.alkitab.base.actionmode
 
-import android.content.Intent
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import yuku.alkitab.base.model.MVersion
@@ -44,11 +43,11 @@ interface VerseActionModeHost {
     val hasEsvsbAsal: Boolean
 
     /**
-     * Ready-to-start intent template for the separate "Alkitab GPT" app, or null when that app
-     * is not installed on the device (also null until the asynchronous lookup finishes, which is
-     * why the controller re-reads this on every `onPrepareActionMode` rather than caching it).
+     * Whether the separate "Alkitab GPT" app is installed and can take a chat-popup request.
+     * False until the asynchronous lookup finishes, which is why the controller re-reads this on
+     * every `onPrepareActionMode` rather than caching it.
      */
-    val alkitabGptLaunchIntent: Intent?
+    val hasAlkitabGpt: Boolean
 
     /**
      * Set to false by the Activity when it wants to keep the checked verses

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/AlkitabGptIntegration.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/AlkitabGptIntegration.kt
@@ -9,20 +9,15 @@ import kotlinx.coroutines.withContext
  * Integration with the separate "Alkitab GPT" app (an AI Bible-study companion by SABDA),
  * reachable from the verse action mode when the user already has it installed.
  *
- * Alkitab GPT exposes `ChatPopUpActivity` under [ACTION_SHOW_CHAT_POPUP] and reads the verse
- * context from the extras below (its `ChatContextFactory`). The intent is deliberately left
- * flagless: that activity uses a translucent theme and finishes itself in `onPause`, so it is
- * meant to appear as a popup on top of the calling app's task.
+ * The intent is deliberately flagless: `ChatPopUpActivity` is translucent and finishes itself in
+ * `onPause`, so it is meant to sit on top of the calling app's task.
  */
 object AlkitabGptIntegration {
     const val PACKAGE_NAME = "org.sabda.gpt"
 
     const val ACTION_SHOW_CHAT_POPUP = "org.sabda.gpt.action.SHOW_CHAT_POPUP"
 
-    /**
-     * The host-app name Alkitab GPT recognises as this app. It keys the popup's header colors,
-     * its logo, and the `apps_alkitab` prefix on the chat thread, so it has to match exactly.
-     */
+    /** Keys the popup's header colors, its logo, and the chat thread prefix, so it must match exactly. */
     const val SOURCE = "Apps Alkitab"
 
     const val EXTRA_BOOK_NAME = "bookName"
@@ -31,22 +26,10 @@ object AlkitabGptIntegration {
     const val EXTRA_VERSE_END = "verseEnd"
     const val EXTRA_SOURCE = "source"
 
-    /**
-     * Whether Alkitab GPT is installed and new enough to accept a chat-popup request.
-     *
-     * PackageManager lookups are binder calls into system_server and can stall for a noticeable
-     * time on a loaded device, so this suspends on [Dispatchers.IO] instead of blocking the
-     * caller's thread.
-     */
     suspend fun isChatPopupAvailable(context: Context): Boolean = withContext(Dispatchers.IO) {
         chatPopupIntent().resolveActivity(context.packageManager) != null
     }
 
-    /**
-     * A chat-popup request for the given passage. [verseStart_1] and [verseEnd_1] are the ends of
-     * the selection: Alkitab GPT renders them as "Kejadian 1:1-3", collapsing to a single verse
-     * when they are equal.
-     */
     fun chatPopupIntent(bookName: String, chapter_1: Int, verseStart_1: Int, verseEnd_1: Int): Intent =
         chatPopupIntent()
             .putExtra(EXTRA_BOOK_NAME, bookName)

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/AlkitabGptIntegration.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/AlkitabGptIntegration.kt
@@ -1,0 +1,64 @@
+package yuku.alkitab.base.util
+
+import android.content.Context
+import android.content.Intent
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Integration with the separate "Alkitab GPT" app (an AI Bible-study companion by SABDA),
+ * reachable from the verse action mode when the user already has it installed.
+ *
+ * Every PackageManager lookup here is a binder round-trip to system_server, which can stall
+ * for tens of milliseconds under load, so resolution is a suspending call meant for a
+ * background dispatcher. [resolveLaunchIntent] answers both questions the caller has (is it
+ * installed, and how do we open it) in one pass, so nothing has to touch PackageManager again
+ * on the main thread when the user taps the menu item.
+ */
+object AlkitabGptIntegration {
+    const val PACKAGE_NAME = "org.sabda.gpt"
+
+    /**
+     * The verse-lookup action, following the same `org.sabda.<app>.action.VIEW` convention as
+     * the Pedia and Tafsiran integrations. Older builds of Alkitab GPT may not declare it; see
+     * [resolveLaunchIntent] for the fallback.
+     */
+    private const val ACTION_VIEW = "org.sabda.gpt.action.VIEW"
+
+    const val EXTRA_ARI = "ari"
+    const val EXTRA_REFERENCE = "reference"
+    const val EXTRA_VERSE_TEXT = "verseText"
+
+    /**
+     * A ready-to-start intent template for Alkitab GPT, or null when the app is not installed.
+     *
+     * Prefers the verse-lookup action so the app can open straight to the selected verse, and
+     * falls back to the launcher entry point when that action is not declared. The fallback
+     * still carries the verse extras: an app that does not understand them ignores them, and
+     * the user at least lands in Alkitab GPT instead of nowhere.
+     *
+     * Suspends on [Dispatchers.IO] rather than blocking the caller's thread.
+     */
+    suspend fun resolveLaunchIntent(context: Context): Intent? = withContext(Dispatchers.IO) {
+        val pm = context.packageManager
+
+        val viewIntent = Intent(ACTION_VIEW).setPackage(PACKAGE_NAME)
+        if (viewIntent.resolveActivity(pm) != null) {
+            return@withContext viewIntent
+        }
+
+        pm.getLaunchIntentForPackage(PACKAGE_NAME)
+    }
+
+    /**
+     * Copies [template] (as returned by [resolveLaunchIntent]) and attaches the selected verse.
+     * The template is reused across taps, so it must not be mutated in place.
+     */
+    fun withVerse(template: Intent, ari: Int, reference: String, verseText: String?): Intent =
+        Intent(template)
+            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            .putExtra(EXTRA_ARI, ari)
+            .putExtra(EXTRA_REFERENCE, reference)
+            .putExtra(EXTRA_VERSE_TEXT, verseText)
+}

--- a/Alkitab/src/main/java/yuku/alkitab/base/util/AlkitabGptIntegration.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/AlkitabGptIntegration.kt
@@ -9,56 +9,51 @@ import kotlinx.coroutines.withContext
  * Integration with the separate "Alkitab GPT" app (an AI Bible-study companion by SABDA),
  * reachable from the verse action mode when the user already has it installed.
  *
- * Every PackageManager lookup here is a binder round-trip to system_server, which can stall
- * for tens of milliseconds under load, so resolution is a suspending call meant for a
- * background dispatcher. [resolveLaunchIntent] answers both questions the caller has (is it
- * installed, and how do we open it) in one pass, so nothing has to touch PackageManager again
- * on the main thread when the user taps the menu item.
+ * Alkitab GPT exposes `ChatPopUpActivity` under [ACTION_SHOW_CHAT_POPUP] and reads the verse
+ * context from the extras below (its `ChatContextFactory`). The intent is deliberately left
+ * flagless: that activity uses a translucent theme and finishes itself in `onPause`, so it is
+ * meant to appear as a popup on top of the calling app's task.
  */
 object AlkitabGptIntegration {
     const val PACKAGE_NAME = "org.sabda.gpt"
 
-    /**
-     * The verse-lookup action, following the same `org.sabda.<app>.action.VIEW` convention as
-     * the Pedia and Tafsiran integrations. Older builds of Alkitab GPT may not declare it; see
-     * [resolveLaunchIntent] for the fallback.
-     */
-    private const val ACTION_VIEW = "org.sabda.gpt.action.VIEW"
-
-    const val EXTRA_ARI = "ari"
-    const val EXTRA_REFERENCE = "reference"
-    const val EXTRA_VERSE_TEXT = "verseText"
+    const val ACTION_SHOW_CHAT_POPUP = "org.sabda.gpt.action.SHOW_CHAT_POPUP"
 
     /**
-     * A ready-to-start intent template for Alkitab GPT, or null when the app is not installed.
-     *
-     * Prefers the verse-lookup action so the app can open straight to the selected verse, and
-     * falls back to the launcher entry point when that action is not declared. The fallback
-     * still carries the verse extras: an app that does not understand them ignores them, and
-     * the user at least lands in Alkitab GPT instead of nowhere.
-     *
-     * Suspends on [Dispatchers.IO] rather than blocking the caller's thread.
+     * The host-app name Alkitab GPT recognises as this app. It keys the popup's header colors,
+     * its logo, and the `apps_alkitab` prefix on the chat thread, so it has to match exactly.
      */
-    suspend fun resolveLaunchIntent(context: Context): Intent? = withContext(Dispatchers.IO) {
-        val pm = context.packageManager
+    const val SOURCE = "Apps Alkitab"
 
-        val viewIntent = Intent(ACTION_VIEW).setPackage(PACKAGE_NAME)
-        if (viewIntent.resolveActivity(pm) != null) {
-            return@withContext viewIntent
-        }
+    const val EXTRA_BOOK_NAME = "bookName"
+    const val EXTRA_CHAPTER = "chapter"
+    const val EXTRA_VERSE_START = "verseStart"
+    const val EXTRA_VERSE_END = "verseEnd"
+    const val EXTRA_SOURCE = "source"
 
-        pm.getLaunchIntentForPackage(PACKAGE_NAME)
+    /**
+     * Whether Alkitab GPT is installed and new enough to accept a chat-popup request.
+     *
+     * PackageManager lookups are binder calls into system_server and can stall for a noticeable
+     * time on a loaded device, so this suspends on [Dispatchers.IO] instead of blocking the
+     * caller's thread.
+     */
+    suspend fun isChatPopupAvailable(context: Context): Boolean = withContext(Dispatchers.IO) {
+        chatPopupIntent().resolveActivity(context.packageManager) != null
     }
 
     /**
-     * Copies [template] (as returned by [resolveLaunchIntent]) and attaches the selected verse.
-     * The template is reused across taps, so it must not be mutated in place.
+     * A chat-popup request for the given passage. [verseStart_1] and [verseEnd_1] are the ends of
+     * the selection: Alkitab GPT renders them as "Kejadian 1:1-3", collapsing to a single verse
+     * when they are equal.
      */
-    fun withVerse(template: Intent, ari: Int, reference: String, verseText: String?): Intent =
-        Intent(template)
-            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
-            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            .putExtra(EXTRA_ARI, ari)
-            .putExtra(EXTRA_REFERENCE, reference)
-            .putExtra(EXTRA_VERSE_TEXT, verseText)
+    fun chatPopupIntent(bookName: String, chapter_1: Int, verseStart_1: Int, verseEnd_1: Int): Intent =
+        chatPopupIntent()
+            .putExtra(EXTRA_BOOK_NAME, bookName)
+            .putExtra(EXTRA_CHAPTER, chapter_1)
+            .putExtra(EXTRA_VERSE_START, verseStart_1)
+            .putExtra(EXTRA_VERSE_END, verseEnd_1)
+            .putExtra(EXTRA_SOURCE, SOURCE)
+
+    private fun chatPopupIntent() = Intent(ACTION_SHOW_CHAT_POPUP).setPackage(PACKAGE_NAME)
 }

--- a/Alkitab/src/main/res/menu/context_isi.xml
+++ b/Alkitab/src/main/res/menu/context_isi.xml
@@ -91,8 +91,6 @@
 		app:showAsAction="never"
 		tools:ignore="HardcodedText" />
 
-	<!-- Shown only when the separate "Alkitab GPT" app is installed; visibility is set in code
-	     once the asynchronous package lookup finishes. -->
 	<item
 		android:id="@+id/menuAlkitabGpt"
 		android:title="Alkitab GPT"

--- a/Alkitab/src/main/res/menu/context_isi.xml
+++ b/Alkitab/src/main/res/menu/context_isi.xml
@@ -91,6 +91,15 @@
 		app:showAsAction="never"
 		tools:ignore="HardcodedText" />
 
+	<!-- Shown only when the separate "Alkitab GPT" app is installed; visibility is set in code
+	     once the asynchronous package lookup finishes. -->
+	<item
+		android:id="@+id/menuAlkitabGpt"
+		android:title="Alkitab GPT"
+		android:visible="false"
+		app:showAsAction="never"
+		tools:ignore="HardcodedText" />
+
 	<!-- For the following 3 items, the showAsAction value is set in code -->
 	<item
 		android:id="@+id/menuGuide"

--- a/Alkitab/src/test/java/yuku/alkitab/base/actionmode/VerseActionModeControllerTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/actionmode/VerseActionModeControllerTest.kt
@@ -1,6 +1,5 @@
 package yuku.alkitab.base.actionmode
 
-import android.content.Intent
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
@@ -20,7 +19,6 @@ import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -86,7 +84,7 @@ class VerseActionModeControllerTest {
         every { host.root } returns android.widget.FrameLayout(activity)
         every { host.chapter_1 } returns 1
         every { host.hasEsvsbAsal } returns false
-        every { host.alkitabGptLaunchIntent } returns null
+        every { host.hasAlkitabGpt } returns false
         every { host.activeSplit0Book } returns makeBook("Gen")
         every { host.activeSplit0Version } returns mockk(relaxed = true) {
             every { shortName } returns "KJV"
@@ -239,7 +237,7 @@ class VerseActionModeControllerTest {
     @Test
     fun `onPrepareActionMode hides the Alkitab GPT item when that app is not installed`() {
         every { host.selectedVersesSplit0_1 } returns ints(1)
-        every { host.alkitabGptLaunchIntent } returns null
+        every { host.hasAlkitabGpt } returns false
 
         val menu = inflateMenu()
         controller.onCreateActionMode(mode, menu)
@@ -260,7 +258,7 @@ class VerseActionModeControllerTest {
         assertFalse(menu.findItem(R.id.menuAlkitabGpt).isVisible)
 
         // The result lands and the action mode is invalidated, which re-runs onPrepareActionMode.
-        every { host.alkitabGptLaunchIntent } returns Intent(Intent.ACTION_VIEW).setPackage(AlkitabGptIntegration.PACKAGE_NAME)
+        every { host.hasAlkitabGpt } returns true
         controller.onPrepareActionMode(mode, menu)
         assertTrue(menu.findItem(R.id.menuAlkitabGpt).isVisible)
     }
@@ -340,13 +338,11 @@ class VerseActionModeControllerTest {
     }
 
     @Test
-    fun `clicking the Alkitab GPT menu item starts the resolved intent with the ARI, reference, and plain verse text of the selection`() {
-        val template = Intent("org.sabda.gpt.action.VIEW").setPackage(AlkitabGptIntegration.PACKAGE_NAME)
-
-        every { host.activeSplit0Book } returns makeBook("Gen").apply { bookId = 0 }
-        every { host.selectedVersesSplit0_1 } returns ints(1, 2)
-        every { host.dataSplit0 } returns makeData("@@In the @9beginning@7...", "And the earth...")
-        every { host.alkitabGptLaunchIntent } returns template
+    fun `clicking the Alkitab GPT menu item opens the chat popup on the book, chapter, and verse range of the selection`() {
+        every { host.activeSplit0Book } returns makeBook("Kejadian")
+        every { host.chapter_1 } returns 3
+        every { host.selectedVersesSplit0_1 } returns ints(15, 16, 17)
+        every { host.hasAlkitabGpt } returns true
 
         val menu = inflateMenu()
         controller.onCreateActionMode(mode, menu)
@@ -354,28 +350,29 @@ class VerseActionModeControllerTest {
         controller.onActionItemClicked(mode, menu.findItem(R.id.menuAlkitabGpt))
 
         val started = shadowOf(activity).nextStartedActivity
-        assertEquals("org.sabda.gpt.action.VIEW", started.action)
+        assertEquals(AlkitabGptIntegration.ACTION_SHOW_CHAT_POPUP, started.action)
         assertEquals(AlkitabGptIntegration.PACKAGE_NAME, started.getPackage())
-        // Ari.encode(bookId=0, chapter=1, verse=1) = (1<<8) | 1 = 257
-        assertEquals(257, started.getIntExtra(AlkitabGptIntegration.EXTRA_ARI, 0))
-        assertEquals("Gen 1:1-2", started.getStringExtra(AlkitabGptIntegration.EXTRA_REFERENCE))
-        assertEquals("In the beginning...\nAnd the earth...", started.getStringExtra(AlkitabGptIntegration.EXTRA_VERSE_TEXT))
-
-        // The template is shared across taps, so it must not have picked up the extras itself.
-        assertFalse(template.hasExtra(AlkitabGptIntegration.EXTRA_ARI))
+        assertEquals("Kejadian", started.getStringExtra(AlkitabGptIntegration.EXTRA_BOOK_NAME))
+        assertEquals(3, started.getIntExtra(AlkitabGptIntegration.EXTRA_CHAPTER, -1))
+        assertEquals(15, started.getIntExtra(AlkitabGptIntegration.EXTRA_VERSE_START, -1))
+        assertEquals(17, started.getIntExtra(AlkitabGptIntegration.EXTRA_VERSE_END, -1))
+        assertEquals(AlkitabGptIntegration.SOURCE, started.getStringExtra(AlkitabGptIntegration.EXTRA_SOURCE))
     }
 
     @Test
-    fun `clicking the Alkitab GPT menu item starts nothing when the app is not installed`() {
-        every { host.selectedVersesSplit0_1 } returns ints(1)
-        every { host.alkitabGptLaunchIntent } returns null
+    fun `clicking the Alkitab GPT menu item sends a non-contiguous selection as the range that spans it`() {
+        every { host.activeSplit0Book } returns makeBook("Kejadian")
+        every { host.selectedVersesSplit0_1 } returns ints(2, 5, 9)
+        every { host.hasAlkitabGpt } returns true
 
         val menu = inflateMenu()
         controller.onCreateActionMode(mode, menu)
         controller.onPrepareActionMode(mode, menu)
         controller.onActionItemClicked(mode, menu.findItem(R.id.menuAlkitabGpt))
 
-        assertNull(shadowOf(activity).nextStartedActivity)
+        val started = shadowOf(activity).nextStartedActivity
+        assertEquals(2, started.getIntExtra(AlkitabGptIntegration.EXTRA_VERSE_START, -1))
+        assertEquals(9, started.getIntExtra(AlkitabGptIntegration.EXTRA_VERSE_END, -1))
     }
 
     @Test

--- a/Alkitab/src/test/java/yuku/alkitab/base/actionmode/VerseActionModeControllerTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/actionmode/VerseActionModeControllerTest.kt
@@ -253,11 +253,9 @@ class VerseActionModeControllerTest {
         val menu = inflateMenu()
         controller.onCreateActionMode(mode, menu)
 
-        // The lookup is still pending when the action mode is created, so the item starts hidden.
         controller.onPrepareActionMode(mode, menu)
         assertFalse(menu.findItem(R.id.menuAlkitabGpt).isVisible)
 
-        // The result lands and the action mode is invalidated, which re-runs onPrepareActionMode.
         every { host.hasAlkitabGpt } returns true
         controller.onPrepareActionMode(mode, menu)
         assertTrue(menu.findItem(R.id.menuAlkitabGpt).isVisible)

--- a/Alkitab/src/test/java/yuku/alkitab/base/actionmode/VerseActionModeControllerTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/actionmode/VerseActionModeControllerTest.kt
@@ -1,5 +1,6 @@
 package yuku.alkitab.base.actionmode
 
+import android.content.Intent
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
@@ -19,15 +20,18 @@ import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import yuku.afw.storage.Preferences
 import yuku.alkitab.base.config.AppConfig
+import yuku.alkitab.base.util.AlkitabGptIntegration
 import yuku.alkitab.base.util.ExtensionManager
 import yuku.alkitab.base.util.ShareUrl
 import yuku.alkitab.base.verses.VersesDataModel
@@ -82,6 +86,7 @@ class VerseActionModeControllerTest {
         every { host.root } returns android.widget.FrameLayout(activity)
         every { host.chapter_1 } returns 1
         every { host.hasEsvsbAsal } returns false
+        every { host.alkitabGptLaunchIntent } returns null
         every { host.activeSplit0Book } returns makeBook("Gen")
         every { host.activeSplit0Version } returns mockk(relaxed = true) {
             every { shortName } returns "KJV"
@@ -232,6 +237,35 @@ class VerseActionModeControllerTest {
     }
 
     @Test
+    fun `onPrepareActionMode hides the Alkitab GPT item when that app is not installed`() {
+        every { host.selectedVersesSplit0_1 } returns ints(1)
+        every { host.alkitabGptLaunchIntent } returns null
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+
+        assertFalse(menu.findItem(R.id.menuAlkitabGpt).isVisible)
+    }
+
+    @Test
+    fun `onPrepareActionMode reveals the Alkitab GPT item once the asynchronous lookup has found the app installed`() {
+        every { host.selectedVersesSplit0_1 } returns ints(1)
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+
+        // The lookup is still pending when the action mode is created, so the item starts hidden.
+        controller.onPrepareActionMode(mode, menu)
+        assertFalse(menu.findItem(R.id.menuAlkitabGpt).isVisible)
+
+        // The result lands and the action mode is invalidated, which re-runs onPrepareActionMode.
+        every { host.alkitabGptLaunchIntent } returns Intent(Intent.ACTION_VIEW).setPackage(AlkitabGptIntegration.PACKAGE_NAME)
+        controller.onPrepareActionMode(mode, menu)
+        assertTrue(menu.findItem(R.id.menuAlkitabGpt).isVisible)
+    }
+
+    @Test
     fun `onPrepareActionMode hides Guide, Commentary, and Dictionary when AppConfig disables them`() {
         every { host.selectedVersesSplit0_1 } returns ints(1)
         every { AppConfig.get() } returns newAppConfig(menuGuide = false, menuCommentary = false, menuDictionary = false)
@@ -303,6 +337,45 @@ class VerseActionModeControllerTest {
         // Ari.encode(bookId=0, chapter=1, verse=2) = (0<<16) | (1<<8) | 2 = 258
         // Ari.encode(bookId=0, chapter=1, verse=3) = 259
         assertEquals(setOf(258, 259), arisSlot.captured)
+    }
+
+    @Test
+    fun `clicking the Alkitab GPT menu item starts the resolved intent with the ARI, reference, and plain verse text of the selection`() {
+        val template = Intent("org.sabda.gpt.action.VIEW").setPackage(AlkitabGptIntegration.PACKAGE_NAME)
+
+        every { host.activeSplit0Book } returns makeBook("Gen").apply { bookId = 0 }
+        every { host.selectedVersesSplit0_1 } returns ints(1, 2)
+        every { host.dataSplit0 } returns makeData("@@In the @9beginning@7...", "And the earth...")
+        every { host.alkitabGptLaunchIntent } returns template
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+        controller.onActionItemClicked(mode, menu.findItem(R.id.menuAlkitabGpt))
+
+        val started = shadowOf(activity).nextStartedActivity
+        assertEquals("org.sabda.gpt.action.VIEW", started.action)
+        assertEquals(AlkitabGptIntegration.PACKAGE_NAME, started.getPackage())
+        // Ari.encode(bookId=0, chapter=1, verse=1) = (1<<8) | 1 = 257
+        assertEquals(257, started.getIntExtra(AlkitabGptIntegration.EXTRA_ARI, 0))
+        assertEquals("Gen 1:1-2", started.getStringExtra(AlkitabGptIntegration.EXTRA_REFERENCE))
+        assertEquals("In the beginning...\nAnd the earth...", started.getStringExtra(AlkitabGptIntegration.EXTRA_VERSE_TEXT))
+
+        // The template is shared across taps, so it must not have picked up the extras itself.
+        assertFalse(template.hasExtra(AlkitabGptIntegration.EXTRA_ARI))
+    }
+
+    @Test
+    fun `clicking the Alkitab GPT menu item starts nothing when the app is not installed`() {
+        every { host.selectedVersesSplit0_1 } returns ints(1)
+        every { host.alkitabGptLaunchIntent } returns null
+
+        val menu = inflateMenu()
+        controller.onCreateActionMode(mode, menu)
+        controller.onPrepareActionMode(mode, menu)
+        controller.onActionItemClicked(mode, menu.findItem(R.id.menuAlkitabGpt))
+
+        assertNull(shadowOf(activity).nextStartedActivity)
     }
 
     @Test

--- a/Alkitab/src/test/java/yuku/alkitab/base/util/AlkitabGptIntegrationTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/util/AlkitabGptIntegrationTest.kt
@@ -17,13 +17,6 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowPackageManager
 
-/**
- * Robolectric is required here: the whole point of [AlkitabGptIntegration] is what PackageManager
- * answers, so the tests install and omit the companion app through `ShadowPackageManager`.
- *
- * The key names and the action asserted below are Alkitab GPT's published contract (its README
- * and `ChatContextFactory`), so these tests double as a guard against drifting away from it.
- */
 @RunWith(RobolectricTestRunner::class)
 @Config(application = yuku.afw.App::class, sdk = [34])
 class AlkitabGptIntegrationTest {

--- a/Alkitab/src/test/java/yuku/alkitab/base/util/AlkitabGptIntegrationTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/util/AlkitabGptIntegrationTest.kt
@@ -8,7 +8,7 @@ import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,6 +20,9 @@ import org.robolectric.shadows.ShadowPackageManager
 /**
  * Robolectric is required here: the whole point of [AlkitabGptIntegration] is what PackageManager
  * answers, so the tests install and omit the companion app through `ShadowPackageManager`.
+ *
+ * The key names and the action asserted below are Alkitab GPT's published contract (its README
+ * and `ChatContextFactory`), so these tests double as a guard against drifting away from it.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(application = yuku.afw.App::class, sdk = [34])
@@ -35,68 +38,57 @@ class AlkitabGptIntegrationTest {
     }
 
     @Test
-    fun `resolveLaunchIntent returns null when Alkitab GPT is not installed`() = runBlocking {
-        assertNull(AlkitabGptIntegration.resolveLaunchIntent(context))
+    fun `isChatPopupAvailable is false when Alkitab GPT is not installed`() = runBlocking {
+        assertFalse(AlkitabGptIntegration.isChatPopupAvailable(context))
     }
 
     @Test
-    fun `resolveLaunchIntent prefers the verse-lookup action when Alkitab GPT declares it`() = runBlocking {
-        installViewActivity()
-        installLauncherActivity()
+    fun `isChatPopupAvailable is false when only the launcher activity is present, so a build too old for the popup never shows the menu item`() = runBlocking {
+        installActivity("MainActivity", IntentFilter(Intent.ACTION_MAIN).apply {
+            addCategory(Intent.CATEGORY_LAUNCHER)
+            addCategory(Intent.CATEGORY_DEFAULT)
+        })
 
-        val intent = AlkitabGptIntegration.resolveLaunchIntent(context)
-
-        assertEquals("org.sabda.gpt.action.VIEW", intent?.action)
-        assertEquals(AlkitabGptIntegration.PACKAGE_NAME, intent?.getPackage())
+        assertFalse(AlkitabGptIntegration.isChatPopupAvailable(context))
     }
 
     @Test
-    fun `resolveLaunchIntent falls back to the launcher entry point when the verse-lookup action is not declared`() = runBlocking {
-        installLauncherActivity()
+    fun `isChatPopupAvailable is true once Alkitab GPT declares the chat-popup action`() = runBlocking {
+        installChatPopupActivity()
 
-        val intent = AlkitabGptIntegration.resolveLaunchIntent(context)
-
-        assertEquals(Intent.ACTION_MAIN, intent?.action)
-        assertEquals(AlkitabGptIntegration.PACKAGE_NAME, intent?.component?.packageName)
+        assertTrue(AlkitabGptIntegration.isChatPopupAvailable(context))
     }
 
     @Test
-    fun `withVerse attaches the verse extras to a copy, leaving the shared template untouched`() {
-        val template = Intent("org.sabda.gpt.action.VIEW").setPackage(AlkitabGptIntegration.PACKAGE_NAME)
+    fun `chatPopupIntent targets Alkitab GPT's chat popup and carries the passage in the keys its ChatContextFactory reads`() {
+        val intent = AlkitabGptIntegration.chatPopupIntent(bookName = "Kejadian", chapter_1 = 1, verseStart_1 = 1, verseEnd_1 = 3)
 
-        val intent = AlkitabGptIntegration.withVerse(template, ari = 257, reference = "Gen 1:1", verseText = "In the beginning...")
+        assertEquals("org.sabda.gpt.action.SHOW_CHAT_POPUP", intent.action)
+        assertEquals("org.sabda.gpt", intent.getPackage())
+        assertEquals("Kejadian", intent.getStringExtra("bookName"))
+        assertEquals(1, intent.getIntExtra("chapter", -1))
+        assertEquals(1, intent.getIntExtra("verseStart", -1))
+        assertEquals(3, intent.getIntExtra("verseEnd", -1))
+        assertEquals("Apps Alkitab", intent.getStringExtra("source"))
+    }
 
-        assertEquals("org.sabda.gpt.action.VIEW", intent.action)
-        assertEquals(AlkitabGptIntegration.PACKAGE_NAME, intent.getPackage())
-        assertEquals(257, intent.getIntExtra(AlkitabGptIntegration.EXTRA_ARI, 0))
-        assertEquals("Gen 1:1", intent.getStringExtra(AlkitabGptIntegration.EXTRA_REFERENCE))
-        assertEquals("In the beginning...", intent.getStringExtra(AlkitabGptIntegration.EXTRA_VERSE_TEXT))
-        assertEquals(
-            Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK,
-            intent.flags,
+    @Test
+    fun `chatPopupIntent carries no flags, because the chat popup is a translucent activity meant to sit on top of the calling task`() {
+        val intent = AlkitabGptIntegration.chatPopupIntent(bookName = "Kejadian", chapter_1 = 1, verseStart_1 = 1, verseEnd_1 = 1)
+
+        assertEquals(0, intent.flags)
+    }
+
+    private fun installChatPopupActivity() {
+        installActivity(
+            "ChatPopUpActivity",
+            IntentFilter(AlkitabGptIntegration.ACTION_SHOW_CHAT_POPUP).apply { addCategory(Intent.CATEGORY_DEFAULT) },
         )
-
-        assertFalse(template.hasExtra(AlkitabGptIntegration.EXTRA_ARI))
     }
 
-    private fun installViewActivity() {
-        val component = ComponentName(AlkitabGptIntegration.PACKAGE_NAME, "${AlkitabGptIntegration.PACKAGE_NAME}.ViewActivity")
+    private fun installActivity(simpleName: String, filter: IntentFilter) {
+        val component = ComponentName(AlkitabGptIntegration.PACKAGE_NAME, "${AlkitabGptIntegration.PACKAGE_NAME}.$simpleName")
         shadowPm.addActivityIfNotPresent(component)
-        shadowPm.addIntentFilterForActivity(
-            component,
-            IntentFilter("org.sabda.gpt.action.VIEW").apply { addCategory(Intent.CATEGORY_DEFAULT) },
-        )
-    }
-
-    private fun installLauncherActivity() {
-        val component = ComponentName(AlkitabGptIntegration.PACKAGE_NAME, "${AlkitabGptIntegration.PACKAGE_NAME}.MainActivity")
-        shadowPm.addActivityIfNotPresent(component)
-        shadowPm.addIntentFilterForActivity(
-            component,
-            IntentFilter(Intent.ACTION_MAIN).apply {
-                addCategory(Intent.CATEGORY_LAUNCHER)
-                addCategory(Intent.CATEGORY_DEFAULT)
-            },
-        )
+        shadowPm.addIntentFilterForActivity(component, filter)
     }
 }

--- a/Alkitab/src/test/java/yuku/alkitab/base/util/AlkitabGptIntegrationTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/util/AlkitabGptIntegrationTest.kt
@@ -1,0 +1,102 @@
+package yuku.alkitab.base.util
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowPackageManager
+
+/**
+ * Robolectric is required here: the whole point of [AlkitabGptIntegration] is what PackageManager
+ * answers, so the tests install and omit the companion app through `ShadowPackageManager`.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = yuku.afw.App::class, sdk = [34])
+class AlkitabGptIntegrationTest {
+
+    private lateinit var context: Context
+    private lateinit var shadowPm: ShadowPackageManager
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        shadowPm = shadowOf(context.packageManager)
+    }
+
+    @Test
+    fun `resolveLaunchIntent returns null when Alkitab GPT is not installed`() = runBlocking {
+        assertNull(AlkitabGptIntegration.resolveLaunchIntent(context))
+    }
+
+    @Test
+    fun `resolveLaunchIntent prefers the verse-lookup action when Alkitab GPT declares it`() = runBlocking {
+        installViewActivity()
+        installLauncherActivity()
+
+        val intent = AlkitabGptIntegration.resolveLaunchIntent(context)
+
+        assertEquals("org.sabda.gpt.action.VIEW", intent?.action)
+        assertEquals(AlkitabGptIntegration.PACKAGE_NAME, intent?.getPackage())
+    }
+
+    @Test
+    fun `resolveLaunchIntent falls back to the launcher entry point when the verse-lookup action is not declared`() = runBlocking {
+        installLauncherActivity()
+
+        val intent = AlkitabGptIntegration.resolveLaunchIntent(context)
+
+        assertEquals(Intent.ACTION_MAIN, intent?.action)
+        assertEquals(AlkitabGptIntegration.PACKAGE_NAME, intent?.component?.packageName)
+    }
+
+    @Test
+    fun `withVerse attaches the verse extras to a copy, leaving the shared template untouched`() {
+        val template = Intent("org.sabda.gpt.action.VIEW").setPackage(AlkitabGptIntegration.PACKAGE_NAME)
+
+        val intent = AlkitabGptIntegration.withVerse(template, ari = 257, reference = "Gen 1:1", verseText = "In the beginning...")
+
+        assertEquals("org.sabda.gpt.action.VIEW", intent.action)
+        assertEquals(AlkitabGptIntegration.PACKAGE_NAME, intent.getPackage())
+        assertEquals(257, intent.getIntExtra(AlkitabGptIntegration.EXTRA_ARI, 0))
+        assertEquals("Gen 1:1", intent.getStringExtra(AlkitabGptIntegration.EXTRA_REFERENCE))
+        assertEquals("In the beginning...", intent.getStringExtra(AlkitabGptIntegration.EXTRA_VERSE_TEXT))
+        assertEquals(
+            Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK,
+            intent.flags,
+        )
+
+        assertFalse(template.hasExtra(AlkitabGptIntegration.EXTRA_ARI))
+    }
+
+    private fun installViewActivity() {
+        val component = ComponentName(AlkitabGptIntegration.PACKAGE_NAME, "${AlkitabGptIntegration.PACKAGE_NAME}.ViewActivity")
+        shadowPm.addActivityIfNotPresent(component)
+        shadowPm.addIntentFilterForActivity(
+            component,
+            IntentFilter("org.sabda.gpt.action.VIEW").apply { addCategory(Intent.CATEGORY_DEFAULT) },
+        )
+    }
+
+    private fun installLauncherActivity() {
+        val component = ComponentName(AlkitabGptIntegration.PACKAGE_NAME, "${AlkitabGptIntegration.PACKAGE_NAME}.MainActivity")
+        shadowPm.addActivityIfNotPresent(component)
+        shadowPm.addIntentFilterForActivity(
+            component,
+            IntentFilter(Intent.ACTION_MAIN).apply {
+                addCategory(Intent.CATEGORY_LAUNCHER)
+                addCategory(Intent.CATEGORY_DEFAULT)
+            },
+        )
+    }
+}


### PR DESCRIPTION
Adds an **Alkitab GPT** item to the verse-selection action mode that opens Alkitab GPT's chat popup on the selected passage. Like the existing `yuku.esvsbasal` item, it only shows up when the companion app is already installed, so the menu is unchanged for everyone else.

## Detection never touches the main thread

This is the main difference from the `esvsbasal` check, which does a blocking `getApplicationInfo` inside a `by lazy` that first resolves on the main thread in `onCreateActionMode`.

`AlkitabGptIntegration.isChatPopupAvailable` suspends on `Dispatchers.IO`. `IsiActivity` kicks it off in `onCreate` and records the answer in `hasAlkitabGpt`; the click path builds its intent from data already in hand, so it touches PackageManager too.

Because the answer can land after the action mode is already showing (the user can select a verse before the lookup finishes), visibility is decided in `onPrepareActionMode` rather than `onCreateActionMode`, and the activity calls `actionMode?.invalidate()` when the lookup completes.

## The integration contract

Taken from Alkitab GPT's own source (its README and `ChatContextFactory`), not guessed:

| | |
|---|---|
| Action | `org.sabda.gpt.action.SHOW_CHAT_POPUP` → `ChatPopUpActivity` (exported, `CATEGORY_DEFAULT`, no permission) |
| Extras | `bookName` (String), `chapter` (Int), `verseStart` (Int), `verseEnd` (Int), `source` (String) |

Three details worth calling out:

- **`source` is `"Apps Alkitab"`**, a value Alkitab GPT already knows. `ChatPopupBrandingManager` maps it to the Alkitab header colors, `LogoUtil` to the Alkitab logo, and `ChatContext.threadPrefix()` to the `apps_alkitab` thread prefix. It has to match that string exactly to get the right branding.
- **The intent carries no flags.** `ChatPopUpActivity` uses a translucent theme and finishes itself in `onPause`; it is designed to sit on top of the calling app's task. `FLAG_ACTIVITY_CLEAR_TASK` would have torn down the reader behind it.
- **`verseStart` / `verseEnd` are the ends of the selection.** Alkitab GPT's `ChatContext.buildVerseContext` renders them as `Kejadian 1:1-3`, collapsing to `Kejadian 1:1` when they are equal. A non-contiguous selection is sent as the range that spans it, since the popup takes a passage rather than a verse list.

Availability means the chat-popup action *resolves*, not merely that the package exists. A build of Alkitab GPT too old to declare that action leaves the menu item hidden rather than offering an action that goes nowhere.

## Changes

- `util/AlkitabGptIntegration.kt` (new) — the action and extra-key constants, `isChatPopupAvailable` (suspending, IO), and `chatPopupIntent`.
- `IsiActivity.kt` — `hasAlkitabGpt` state plus `resolveAlkitabGptAsync()` driven from `onCreate`.
- `VerseActionModeHost.kt` — `hasAlkitabGpt: Boolean` on the host surface, alongside `hasEsvsbAsal`.
- `VerseActionModeController.kt` — menu visibility in `onPrepareActionMode` and click routing.
- `res/menu/context_isi.xml` — the `menuAlkitabGpt` item, hidden by default.
- `AndroidManifest.xml` — `org.sabda.gpt` added to `<queries>` so the lookup is allowed on API 30+.

## Testing

Verified locally, not just in CI:

- `./gradlew assemblePlainDebug` — BUILD SUCCESSFUL
- `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` (the CI invocation) — BUILD SUCCESSFUL

7 new Robolectric tests:

- `AlkitabGptIntegrationTest` (5) — not installed; installed but only the launcher activity, i.e. too old for the popup; the chat-popup action declared; the intent's action, package, and extra keys; and the no-flags guard.
- `VerseActionModeControllerTest` (2 visibility + 2 routing) — the item is hidden while the lookup is pending and appears on the next `onPrepareActionMode` once it resolves; clicking it opens the popup on the right book, chapter, and verse range; a non-contiguous selection is sent as the spanning range.

The integration tests assert the literal key names and action string, so they double as a guard against drifting away from Alkitab GPT's published contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RZBnj8ja4qP1jT5TXv94k