### PR TITLE
Give each flavor its own PR-preview APK filename prefix

### DIFF
--- a/tools/cloudflare/pr-preview/make_dist.py
+++ b/tools/cloudflare/pr-preview/make_dist.py
@@ -38,11 +38,9 @@ FLAVOR_LABELS = {
     "sabda_alkitab": "Sabda Alkitab",
 }
 
-# Gradle's outputFileName (Alkitab/build.gradle.kts) always starts every
-# flavor's APK with the literal "Alkitab" prefix, so the three production
-# downloads are otherwise indistinguishable by filename alone. Swap it here
-# for the per-flavor prefix instead of touching the shared Gradle naming,
-# which other consumers (local builds, CI artifact names) still rely on.
+# Gradle's outputFileName (Alkitab/build.gradle.kts) starts every flavor's
+# APK with the literal "Alkitab" prefix; swap it for a per-flavor one here
+# rather than in the shared Gradle naming, which other consumers still use.
 FLAVOR_APK_PREFIXES = {
     "yuku_alkitab": "Alkitab",
     "yuku_quick_bible": "QuickBible",

--- a/tools/cloudflare/pr-preview/make_dist.py
+++ b/tools/cloudflare/pr-preview/make_dist.py
@@ -38,6 +38,18 @@ FLAVOR_LABELS = {
     "sabda_alkitab": "Sabda Alkitab",
 }
 
+# Gradle's outputFileName (Alkitab/build.gradle.kts) always starts every
+# flavor's APK with the literal "Alkitab" prefix, so the three production
+# downloads are otherwise indistinguishable by filename alone. Swap it here
+# for the per-flavor prefix instead of touching the shared Gradle naming,
+# which other consumers (local builds, CI artifact names) still rely on.
+FLAVOR_APK_PREFIXES = {
+    "yuku_alkitab": "Alkitab",
+    "yuku_quick_bible": "QuickBible",
+    "sabda_alkitab": "SabdaAlkitab",
+}
+GRADLE_APK_PREFIX = "Alkitab"
+
 PAGE = """<!doctype html>
 <html lang="en">
 <meta charset="utf-8">
@@ -124,6 +136,13 @@ def flavor_order(name: str) -> tuple[int, str]:
     return (known.index(name), "") if name in known else (len(known), name)
 
 
+def apk_file_name(flavor: str, gradle_name: str) -> str:
+    prefix = FLAVOR_APK_PREFIXES.get(flavor)
+    if prefix is None or not gradle_name.startswith(GRADLE_APK_PREFIX):
+        return gradle_name
+    return prefix + gradle_name.removeprefix(GRADLE_APK_PREFIX)
+
+
 def collect_apks(apk_dir: Path) -> list[dict]:
     """One entry per flavor directory found under apk_dir."""
     apks = []
@@ -153,7 +172,7 @@ def collect_apks(apk_dir: Path) -> list[dict]:
                 "applicationId": meta.get("applicationId", "?"),
                 "versionName": str(element.get("versionName", "?")),
                 "versionCode": str(element.get("versionCode", "?")),
-                "file": apk.name,
+                "file": apk_file_name(flavor_dir.name, apk.name),
                 "size": human_size(apk.stat().st_size),
                 "path": apk,
             }


### PR DESCRIPTION
## Summary

Gradle's `outputFileName` (`Alkitab/build.gradle.kts`) always starts every flavor's APK with the literal `Alkitab-` prefix, so the PR preview download page and PR comment showed the same-looking filename for all three production flavors — only the trailing `applicationId` segment (e.g. `yuku.alkitab.kjv`, `org.sabda.alkitab`) told them apart.

`tools/cloudflare/pr-preview/make_dist.py` now renames the staged copy of each APK it publishes to the Cloudflare preview worker, swapping the `Alkitab-` prefix for a per-flavor one:

| Flavor | Prefix |
| --- | --- |
| `yuku_alkitab` | `Alkitab-` (unchanged) |
| `yuku_quick_bible` | `QuickBible-` |
| `sabda_alkitab` | `SabdaAlkitab-` |

This only affects the filename of the copy staged for the PR-preview download (and thus what a browser saves it as) — the shared Gradle `outputFileName` used by local builds, `assemblePlainDebug`, and the per-flavor CI artifact uploads is untouched, so nothing else changes.

## Test plan

- [x] Ran `apk_file_name()` against the exact filenames from a recent PR preview comment (`yuku_alkitab`, `yuku_quick_bible`, `sabda_alkitab`) and confirmed the expected renamed output, plus a no-op check for an unlisted flavor (`plain`)
- [x] `python3 -m py_compile make_dist.py`
- [ ] Next PR's preview comment shows `Alkitab-…`, `QuickBible-…`, `SabdaAlkitab-…` download links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qF2QKixMn1k5UWzN8ixYZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012qF2QKixMn1k5UWzN8ixYZ)_