### PR TITLE
Derive versionName from version.properties and add a release workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,9 +2,9 @@ name: Android CI
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "develop", "release/**" ]
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "develop", "release/**" ]
 
 permissions:
   contents: read
@@ -14,7 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Full history: the build derives the dev version name's counter from
+      # `git rev-list --count HEAD`, which a shallow clone reports as 1.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: set up JDK 21
         uses: actions/setup-java@v5
@@ -150,7 +154,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           # Need full history so `git log <last-release-tag>..HEAD` in the
-          # release step can walk back to the previous release.
+          # release step can walk back to the previous release, and so the
+          # build's dev version counter (`git rev-list --count HEAD`) is right.
           fetch-depth: 0
 
       - name: Check out proprietary overlay

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,213 @@
+# Manually-triggered release build. Produces the signed App Bundles that get
+# uploaded to Google Play, plus the mapping files and native debug symbols that
+# have to be kept for as long as the release is live, and records all of them on
+# a GitHub Release.
+#
+# Everyday pushes to develop are handled by android.yml, which publishes
+# throwaway `-dev.<n>` pre-releases. This workflow is the deliberate one: it
+# builds `-beta.<n>` or final `<x.y.z>` artifacts, whose version names come from
+# version.properties and must be bumped by hand first.
+#
+# Before running with stage=beta:
+#   1. ./gradlew bumpBetaNumber
+#   2. commit version.properties and push
+#   3. run this workflow against that commit
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: 'Release channel to build for'
+        type: choice
+        options:
+          - beta
+          - release
+        default: beta
+      dry_run:
+        description: 'Build and keep the artifacts, but do not create a GitHub Release'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      # For creating the GitHub Release and its tag.
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check out proprietary overlay
+        uses: actions/checkout@v5
+        with:
+          repository: yukuku/androidbible-proprietary
+          ref: master
+          ssh-key: ${{ secrets.PROPRIETARY_DEPLOY_KEY }}
+          path: proprietary
+          persist-credentials: false
+
+      - name: set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'zulu'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # Ask Gradle for the version once and pin the result, so every flavor in
+      # this run shares one versionCode and a re-run of the build step cannot
+      # drift (the default versionCode advances every minute).
+      - name: Resolve version
+        id: version
+        env:
+          VERSION_STAGE: ${{ inputs.stage }}
+        run: |
+          set -euo pipefail
+          ./gradlew -q :Alkitab:printVersion > version-output.txt
+          cat version-output.txt
+          # Filter rather than redirect the whole thing: anything Gradle prints
+          # alongside the task output would otherwise land in GITHUB_OUTPUT.
+          grep -E '^(versionStage|versionName|versionCode)=' version-output.txt >> "$GITHUB_OUTPUT"
+
+      - name: Check the tag is free
+        env:
+          TAG: v${{ steps.version.outputs.versionName }}
+        run: |
+          set -euo pipefail
+          if git rev-parse --verify --quiet "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag $TAG already exists. Run './gradlew bumpBetaNumber' and commit before releasing again."
+            exit 1
+          fi
+          echo "Releasing as $TAG"
+
+      - name: Decode signing keystore
+        env:
+          SIGN_KEYSTORE_BASE64: ${{ secrets.SIGN_KEYSTORE_BASE64 }}
+        run: |
+          printf '%s' "$SIGN_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.jks"
+
+      - name: Build signed release (all production flavors)
+        env:
+          ALKITAB_PROPRIETARY_DIR: ${{ github.workspace }}/proprietary
+          SIGN_KEYSTORE: ${{ runner.temp }}/release.jks
+          SIGN_ALIAS: ${{ secrets.SIGN_ALIAS }}
+          SIGN_PASSWORD: ${{ secrets.SIGN_PASSWORD }}
+          VERSION_STAGE: ${{ inputs.stage }}
+          VERSION_CODE: ${{ steps.version.outputs.versionCode }}
+          BUILD_DIST: ${{ inputs.stage }}
+        run: ./gradlew assembleProductionRelease bundleProductionRelease
+
+      # Guards against the version the workflow announced drifting from the one
+      # actually baked into the artifacts.
+      - name: Verify built version
+        env:
+          EXPECTED_NAME: ${{ steps.version.outputs.versionName }}
+          EXPECTED_CODE: ${{ steps.version.outputs.versionCode }}
+        run: |
+          set -euo pipefail
+          for meta in Alkitab/build/outputs/apk/*/release/output-metadata.json; do
+            name=$(jq -r '.elements[0].versionName' "$meta")
+            code=$(jq -r '.elements[0].versionCode' "$meta")
+            if [ "$name" != "$EXPECTED_NAME" ] || [ "$code" != "$EXPECTED_CODE" ]; then
+              echo "::error::$meta has $name ($code), expected $EXPECTED_NAME ($EXPECTED_CODE)"
+              exit 1
+            fi
+          done
+          echo "All flavors built $EXPECTED_NAME ($EXPECTED_CODE)"
+
+      # Retained far longer than android.yml's 14 days: a mapping file is only
+      # useful while the release it belongs to is still installed somewhere, and
+      # a beta can sit on the open-testing track for months.
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-${{ steps.version.outputs.versionName }}
+          if-no-files-found: error
+          retention-days: 90
+          path: |
+            Alkitab/build/outputs/apk/*/release/*.apk
+            Alkitab/build/outputs/bundle/*Release/*.aab
+            Alkitab/build/outputs/mapping/*Release/mapping.txt
+            Alkitab/build/outputs/native-debug-symbols/*Release/native-debug-symbols.zip
+
+      # The App Bundles are what gets uploaded to Play; the mapping files and
+      # native symbols are attached so a crash report from this build can still
+      # be read after the workflow artifacts expire.
+      - name: Stage release assets
+        if: ${{ !inputs.dry_run }}
+        id: stage
+        env:
+          VERSION_NAME: ${{ steps.version.outputs.versionName }}
+        run: |
+          set -euo pipefail
+          stage=release-staging
+          mkdir -p "$stage"
+          short_hash=$(git log -1 --format=%h)
+          for flavor in yuku_alkitab yuku_quick_bible sabda_alkitab; do
+            case "$flavor" in
+              yuku_alkitab) label=Alkitab ;;
+              yuku_quick_bible) label=QuickBible ;;
+              sabda_alkitab) label=SabdaAlkitab ;;
+            esac
+            base="$label-$VERSION_NAME-$short_hash"
+            cp "Alkitab/build/outputs/bundle/${flavor}Release"/*.aab "$stage/$base.aab"
+            cp "Alkitab/build/outputs/apk/$flavor/release"/*.apk "$stage/$base.apk"
+            cp "Alkitab/build/outputs/mapping/${flavor}Release/mapping.txt" "$stage/$base-mapping.txt"
+            cp "Alkitab/build/outputs/native-debug-symbols/${flavor}Release/native-debug-symbols.zip" \
+               "$stage/$base-native-debug-symbols.zip"
+          done
+          ls -l "$stage"
+
+      # Commits since the previous release built by this workflow. Its tags are
+      # version names (v5.0.0-beta.2), so the glob skips android.yml's
+      # versionCode-based dev tags (v23600000).
+      - name: Write release notes
+        if: ${{ !inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          last_tag=$(git tag --list 'v*.*.*' --sort=-creatordate | head -n1)
+          {
+            echo "## Changes"
+            echo
+            if [ -n "$last_tag" ]; then
+              echo "Since \`$last_tag\`:"
+              echo
+              git log "${last_tag}..HEAD" --pretty=format:"- %s (%h)"
+            else
+              git log HEAD --max-count=50 --pretty=format:"- %s (%h)"
+            fi
+            echo
+          } > release-notes.md
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION_NAME: ${{ steps.version.outputs.versionName }}
+          VERSION_CODE: ${{ steps.version.outputs.versionCode }}
+        run: |
+          set -euo pipefail
+          today=$(date -u +%Y-%m-%d)
+          args=(
+            "v$VERSION_NAME"
+            --target "$GITHUB_SHA"
+            --title "$VERSION_NAME ($VERSION_CODE) $today"
+            --notes-file release-notes.md
+          )
+          if [ "${{ inputs.stage }}" != "release" ]; then
+            args+=(--prerelease)
+          fi
+          gh release create "${args[@]}" release-staging/*
+
+      - name: Wipe keystore from runner
+        if: always()
+        run: rm -f "$RUNNER_TEMP/release.jks"

--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -87,15 +87,21 @@ val gitCommitHash: String = try {
     "0000000"
 }
 
-// Number of commits reachable from HEAD, used as the counter in dev version
-// names. It advances by one per commit and is identical for everyone building
-// that commit. A shallow clone undercounts it, which is why CI checks out with
-// fetch-depth: 0.
-val commitCount: String = try {
-    val count = providers.exec {
-        commandLine("git", "rev-list", "--count", "HEAD")
+// Counter for dev version names: commits since versionBase last changed, so it
+// restarts at 0 for each new release line instead of counting the whole repo.
+// The pickaxe finds that commit; -G matches the versionBase line specifically,
+// so a betaNumber bump does not reset the count.
+val devBuildNumber: String = try {
+    val versionBaseCommit = providers.exec {
+        commandLine(
+            "git", "log", "-1", "--format=format:%H", "-G", "^versionBase=",
+            "--", rootProject.file("version.properties").absolutePath,
+        )
     }.standardOutput.asText.get().trim()
-    count.ifEmpty { "0" }
+    val range = if (versionBaseCommit.isEmpty()) "HEAD" else "$versionBaseCommit..HEAD"
+    providers.exec {
+        commandLine("git", "rev-list", "--count", range)
+    }.standardOutput.asText.get().trim().ifEmpty { "0" }
 } catch (_: Exception) {
     "0"
 }
@@ -118,7 +124,7 @@ val versionStage: String = providers.gradleProperty("versionStage").orNull
 val buildVersionName: String = when (versionStage) {
     "release" -> versionBase
     "beta" -> "$versionBase-beta.${versionProperty("betaNumber")}"
-    "dev" -> "$versionBase-dev.$commitCount"
+    "dev" -> "$versionBase-dev.$devBuildNumber"
     else -> throw GradleException("Unknown versionStage '$versionStage'; expected 'dev', 'beta' or 'release'.")
 }
 
@@ -210,10 +216,6 @@ android {
         }
         release {
             buildConfigField("boolean", "SKIP_FCM_REGISTRATION", "false")
-            // Snappy ships JNI code, so without this the Play Console can only
-            // show raw addresses for native crashes. SYMBOL_TABLE is enough to
-            // get function names and keeps the bundle small; FULL would also
-            // carry DWARF line tables.
             ndk {
                 debugSymbolLevel = "SYMBOL_TABLE"
             }
@@ -441,13 +443,8 @@ tasks.register("printVersion") {
     val versionCode = buildVersionCode
     val stage = versionStage
     doLast {
-        // println rather than logger.lifecycle so `gradlew -q printVersion`
-        // emits these three lines and nothing else; the release workflow
-        // parses them to pin VERSION_CODE for the build that follows.
         println("versionStage=$stage")
         println("versionName=$versionName")
-        // Time-derived unless VERSION_CODE is set, so a later build of the same
-        // commit reports a higher number than this one.
         println("versionCode=$versionCode")
     }
 }

--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import java.time.Instant
+import java.util.Properties
 import javax.inject.Inject
 
 plugins {
@@ -86,8 +87,48 @@ val gitCommitHash: String = try {
     "0000000"
 }
 
-// Version code: (2_000_000 + minutes since 2026-01-01 UTC) * 10
-val buildVersionCode: Int = run {
+// Number of commits reachable from HEAD, used as the counter in dev version
+// names. It advances by one per commit and is identical for everyone building
+// that commit. A shallow clone undercounts it, which is why CI checks out with
+// fetch-depth: 0.
+val commitCount: String = try {
+    val count = providers.exec {
+        commandLine("git", "rev-list", "--count", "HEAD")
+    }.standardOutput.asText.get().trim()
+    count.ifEmpty { "0" }
+} catch (_: Exception) {
+    "0"
+}
+
+val versionProperties = Properties().apply {
+    rootProject.file("version.properties").inputStream().use { load(it) }
+}
+
+fun versionProperty(key: String): String = versionProperties.getProperty(key)
+    ?: throw GradleException("'$key' is missing from version.properties")
+
+val versionBase: String = versionProperty("versionBase")
+
+// Which release channel this build is for: -PversionStage=beta, or the
+// VERSION_STAGE env var, defaulting to "dev". See version.properties.
+val versionStage: String = providers.gradleProperty("versionStage").orNull
+    ?: providers.environmentVariable("VERSION_STAGE").orNull
+    ?: "dev"
+
+val buildVersionName: String = when (versionStage) {
+    "release" -> versionBase
+    "beta" -> "$versionBase-beta.${versionProperty("betaNumber")}"
+    "dev" -> "$versionBase-dev.$commitCount"
+    else -> throw GradleException("Unknown versionStage '$versionStage'; expected 'dev', 'beta' or 'release'.")
+}
+
+// Version code: (2_000_000 + minutes since 2026-01-01 UTC) * 10, so a later
+// build always outranks an earlier one whatever branch or stage produced it.
+// The factor of 10 reserves nine spare codes per minute for per-ABI splits.
+//
+// VERSION_CODE pins it instead. Releases set it so that rebuilding the same
+// commit produces the same artifact; without it the code moves every minute.
+val buildVersionCode: Int = providers.environmentVariable("VERSION_CODE").orNull?.toInt() ?: run {
     val epoch = Instant.parse("2026-01-01T00:00:00Z").epochSecond
     val minutesSinceEpoch = (Instant.now().epochSecond - epoch) / 60
     ((2_000_000 + minutesSinceEpoch) * 10).toInt()
@@ -124,7 +165,7 @@ android {
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = buildVersionCode
-        versionName = "5.0.0-b0"
+        versionName = buildVersionName
         buildConfigField("String", "SERVER_HOST", "\"$serverHost\"")
         buildConfigField("String", "RIBKA_FUNCTIONS_HOST", "\"$ribkaFunctionsHost\"")
         buildConfigField("String", "LAST_COMMIT_HASH", "\"$gitCommitHash\"")
@@ -169,6 +210,13 @@ android {
         }
         release {
             buildConfigField("boolean", "SKIP_FCM_REGISTRATION", "false")
+            // Snappy ships JNI code, so without this the Play Console can only
+            // show raw addresses for native crashes. SYMBOL_TABLE is enough to
+            // get function names and keeps the bundle small; FULL would also
+            // carry DWARF line tables.
+            ndk {
+                debugSymbolLevel = "SYMBOL_TABLE"
+            }
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
@@ -362,6 +410,60 @@ androidComponents {
             }
         }
     }
+}
+
+// Release-flow helpers. The full flow is in docs/build-system.md; in short:
+// `./gradlew bumpBetaNumber`, commit, then run the "Release" workflow (or
+// `./gradlew -PversionStage=beta bundleProductionRelease` locally).
+tasks.register("bumpBetaNumber") {
+    group = "release"
+    description = "Increments betaNumber in version.properties."
+    // Read into locals here rather than inside doLast, so the action does not
+    // capture the project and stays configuration-cache safe.
+    val propertiesFile = rootProject.file("version.properties")
+    val base = versionBase
+    doLast {
+        val text = propertiesFile.readText()
+        val match = Regex("(?m)^betaNumber=(\\d+)[ \\t]*$").find(text)
+            ?: throw GradleException("No 'betaNumber=<number>' line found in $propertiesFile")
+        val current = match.groupValues[1].toInt()
+        val next = current + 1
+        // Rewrite just the one line so the explanatory header survives.
+        propertiesFile.writeText(text.replaceRange(match.range, "betaNumber=$next"))
+        logger.lifecycle("betaNumber $current -> $next; next beta build is $base-beta.$next")
+    }
+}
+
+tasks.register("printVersion") {
+    group = "release"
+    description = "Prints the versionName and versionCode this build would produce."
+    val versionName = buildVersionName
+    val versionCode = buildVersionCode
+    val stage = versionStage
+    doLast {
+        // println rather than logger.lifecycle so `gradlew -q printVersion`
+        // emits these three lines and nothing else; the release workflow
+        // parses them to pin VERSION_CODE for the build that follows.
+        println("versionStage=$stage")
+        println("versionName=$versionName")
+        // Time-derived unless VERSION_CODE is set, so a later build of the same
+        // commit reports a higher number than this one.
+        println("versionCode=$versionCode")
+    }
+}
+
+val productionFlavorSuffixes = proprietaryFlavors.keys.map { flavor -> flavor.replaceFirstChar { it.uppercaseChar() } }
+
+tasks.register("bundleProductionRelease") {
+    group = "release"
+    description = "Builds the release App Bundle for every production flavor."
+    dependsOn(productionFlavorSuffixes.map { "bundle${it}Release" })
+}
+
+tasks.register("assembleProductionRelease") {
+    group = "release"
+    description = "Builds the release APK for every production flavor."
+    dependsOn(productionFlavorSuffixes.map { "assemble${it}Release" })
 }
 
 kotlin {

--- a/Alkitab/src/main/AndroidManifest.xml
+++ b/Alkitab/src/main/AndroidManifest.xml
@@ -9,10 +9,6 @@
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
-	<!-- Needed on API 33+ for the audio playback notification and for sync
-	     notifications. firebase-messaging also merges this in, but the app's own
-	     notifications do not depend on Firebase, so declare it here explicitly
-	     rather than inheriting it from a dependency. -->
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 	<!-- Keeping storage permissions for users who upgrade from an existing versions

--- a/Alkitab/src/main/AndroidManifest.xml
+++ b/Alkitab/src/main/AndroidManifest.xml
@@ -9,6 +9,12 @@
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
+	<!-- Needed on API 33+ for the audio playback notification and for sync
+	     notifications. firebase-messaging also merges this in, but the app's own
+	     notifications do not depend on Firebase, so declare it here explicitly
+	     rather than inheriting it from a dependency. -->
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
 	<!-- Keeping storage permissions for users who upgrade from an existing versions
 	and store their version files in the external storage -->
 	<uses-permission

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Requirements**: JDK 21 (Zulu recommended), Android SDK with compile SDK 36, NDK 28.2.13676358.
 
+**Versioning**: `versionName` comes from `version.properties` (`versionBase` +
+`betaNumber`) combined with a stage: `dev` by default (`5.0.0-dev.<commit
+count>`), `beta` via `-PversionStage=beta` (`5.0.0-beta.<n>`), `release` via
+`-PversionStage=release` (`5.0.0`). `versionCode` is derived from wall-clock
+time and is unrelated to the stage. Never hardcode a version in
+`Alkitab/build.gradle.kts`; see the "Versioning" section of
+`docs/build-system.md`.
+
 The `plain` flavor is the open-source development build and works out of the box with the placeholder `Alkitab/google-services.json` checked into the repo (Firebase features won't function at runtime, but the app builds and runs). Production flavors (`yuku_alkitab`, `yuku_quick_bible`, `sabda_alkitab`) require:
 - `$ALKITAB_PROPRIETARY_DIR/overlay/<applicationId>/text_raw/` — proprietary Bible text
 - `$ALKITAB_PROPRIETARY_DIR/google-services.json` — real Firebase config (one file with client entries for all production applicationIds)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **Requirements**: JDK 21 (Zulu recommended), Android SDK with compile SDK 36, NDK 28.2.13676358.
 
 **Versioning**: `versionName` comes from `version.properties` (`versionBase` +
-`betaNumber`) combined with a stage: `dev` by default (`5.0.0-dev.<commit
-count>`), `beta` via `-PversionStage=beta` (`5.0.0-beta.<n>`), `release` via
-`-PversionStage=release` (`5.0.0`). `versionCode` is derived from wall-clock
+`betaNumber`) combined with a stage: `dev` by default (`5.0.0-dev.<commits
+since versionBase last changed>`), `beta` via `-PversionStage=beta`
+(`5.0.0-beta.<n>`), `release` via `-PversionStage=release` (`5.0.0`). `versionCode` is derived from wall-clock
 time and is unrelated to the stage. Never hardcode a version in
 `Alkitab/build.gradle.kts`; see the "Versioning" section of
 `docs/build-system.md`.
@@ -272,7 +272,7 @@ Detailed documentation for each major feature module:
 
 - **IMPORTANT. Never write change-narrating comments.** Code comments must describe the code as it is *now*, not the history of how it got there. Do not reference past revisions, removed approaches, or the act of editing: no "previously", "used to", "formerly", "earlier iterations", "an earlier version", "we changed/renamed/moved this from…", "now uses…", "no longer…", and the like. Git history is the record of *change*; the code and its comments describe the *present*. When explaining why the current design was chosen over an alternative is genuinely useful, state it as present-tense rationale about the alternative ("the cluster is centered with Spacers because a weighted slot would clip the label"), not as a story about what the code used to do. This applies to all comments, KDoc/Javadoc, and commit-adjacent code. Keep the narrative of change out of the source. The same rule applies to milestone labels: do not tag comments with the sprint or task that produced the code ("(M3)", "Out of scope for M4"), because they date instantly and mean nothing to a later reader.
 - **IMPORTANT. Never use em dashes to join clauses in comments or docs.** The "—" character (U+2014) is hard to read in running prose. Write two plain sentences instead, or use a comma, colon, semicolon, or parentheses, whichever reads most naturally. This applies to code comments, KDoc/Javadoc, Markdown docs, commit messages, and PR descriptions. (Existing prose in older files may still contain them; leave it alone unless you are already editing that comment or were asked to sweep the file.)
-- **Do not over-comment.** Default to writing no comment. A comment earns its place only by explaining a non-obvious *why*: a hidden constraint, a subtle invariant, a threading or lifecycle rule, a workaround for a specific bug, or behavior that would surprise a reader. Never restate what a well-named symbol already says, never narrate the happy path line by line, and never write multi-paragraph rationale where one or two sentences do the job. If deleting a comment would not confuse a future reader, delete it.
+- **IMPORTANT. Do not add explaining comments except for non-obvious code.** Default to writing no comment. A comment earns its place only by explaining a non-obvious *why*: a hidden constraint, a subtle invariant, a threading or lifecycle rule, a workaround for a specific bug, or behavior that would surprise a reader. Never restate what a well-named symbol already says, never narrate the happy path line by line, and never write multi-paragraph rationale where one or two sentences do the job. If deleting a comment would not confuse a future reader, delete it.
 - Mixed Java/Kotlin codebase (Kotlin preferred for new code, many files still Java)
 - JVM toolchain 21 across all modules
 - No obfuscation in ProGuard (`-dontobfuscate`), only shrinking

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -29,6 +29,60 @@ Each flavor can override resources in `src/{flavor}/res/` and Java/Kotlin source
 - **yuku_quick_bibleDebug/Release** — English production
 - **sabda_alkitabDebug/Release** — SABDA partner
 
+## Versioning
+
+`versionName` is assembled at build time from `version.properties` at the repo
+root plus a *stage*, so an artifact's name says which channel produced it:
+
+| Stage | Selected by | Example | Used for |
+|-------|-------------|---------|----------|
+| `dev` | the default | `5.0.0-dev.117` | every ordinary build, local or CI |
+| `beta` | `-PversionStage=beta` or `VERSION_STAGE=beta` | `5.0.0-beta.1` | the Play open-testing track |
+| `release` | `-PversionStage=release` or `VERSION_STAGE=release` | `5.0.0` | the Play production track |
+
+`version.properties` holds only `versionBase` (the marketing version) and
+`betaNumber`. The dev counter is not stored: it is `git rev-list --count HEAD`,
+so it advances once per commit on its own and is the same for anyone building
+that commit. CI therefore has to check out with `fetch-depth: 0`; a shallow
+clone reports a count of 1.
+
+Beta numbers are deliberately manual, because a number that moved on its own
+could not identify the build a tester is reporting against:
+
+```bash
+./gradlew bumpBetaNumber   # betaNumber 1 -> 2
+git commit -am "Bump to 5.0.0-beta.2"
+```
+
+When a release ships, bump `versionBase` and reset `betaNumber` to 1 in the same
+commit.
+
+`versionCode` is independent of all of this: it is
+`(2_000_000 + minutes since 2026-01-01 UTC) * 10`, so any later build outranks
+any earlier one regardless of branch or stage, and Play never sees a number go
+backwards. The `* 10` reserves nine spare codes per minute in case per-ABI
+splits are ever needed. Because it is derived from the clock, two builds of the
+same commit normally get different codes; set `VERSION_CODE` to pin it, which is
+what the release workflow does so all three flavors in a run share one code.
+
+Two consequences worth knowing:
+
+- A dev build published from `develop` gets a *higher* `versionCode` than a beta
+  built yesterday. That is only a problem if both reach the same Play track, so
+  keep dev builds off Play entirely (they live on GitHub pre-releases).
+- If a production hotfix is ever built after a beta, its `versionCode` will
+  exceed the beta's, and Play will serve that hotfix to testers as an upgrade.
+  Rebuild and re-upload the beta afterwards to put testers back ahead.
+
+### Release helper tasks
+
+```bash
+./gradlew printVersion              # versionStage / versionName / versionCode
+./gradlew bumpBetaNumber            # increment betaNumber in version.properties
+./gradlew bundleProductionRelease   # AAB for all three production flavors
+./gradlew assembleProductionRelease # APK for all three production flavors
+```
+
 ## Common Build Commands
 
 ```bash
@@ -50,11 +104,15 @@ Each flavor can override resources in `src/{flavor}/res/` and Java/Kotlin source
 ## CI/CD
 
 GitHub Actions workflow (`.github/workflows/android.yml`):
-- Triggers on push/PR to `develop` branch
+- Triggers on push/PR to `develop` and `release/**` branches
 - Ubuntu latest, JDK 21 (Zulu)
 - `plain-debug` job: runs `testPlainDebugUnitTest`, `testPlainReleaseUnitTest`, `assemblePlainDebug`, `bundlePlainDebug`
 - `signed-release` job (pushes to `develop` and same-repo PRs): builds and signs all production flavors using the proprietary overlay repo, uploads per-flavor artifacts, and on `develop` pushes publishes a GitHub pre-release. On PRs it also uploads a `pr-preview-apks` artifact (APKs and metadata only — no AABs or mapping files)
 - `pr-apk-preview` job (same-repo PRs only): publishes those signed release APKs to a Cloudflare Worker with static assets and comments immutable `*.workers.dev` download links on the PR
+
+A second workflow, `.github/workflows/release.yml`, is manual
+(`workflow_dispatch`) and builds the artifacts that actually go to Google Play.
+See "Release workflow" below.
 
 ### PR APK previews
 
@@ -93,6 +151,8 @@ Environment variables:
 - `ALKITAB_PROPRIETARY_DIR` — directory matching the layout above. Required for `yuku_alkitab`, `yuku_quick_bible`, `sabda_alkitab`. Not used by `plain`.
 - `SIGN_KEYSTORE`, `SIGN_ALIAS`, `SIGN_PASSWORD` — required to sign release builds (any flavor). The signing config in `Alkitab/build.gradle.kts` reads them at config time.
 - `BUILD_DIST` — distribution channel identifier embedded in the APK filename. Defaults to `dev` when unset.
+- `VERSION_STAGE` — `dev` (default), `beta`, or `release`; picks how `versionName` is assembled. `-PversionStage=` does the same and wins if both are given. See "Versioning" above.
+- `VERSION_CODE` — pins `versionCode` instead of deriving it from the clock, so a rebuild of the same commit produces the same number. The release workflow sets it once per run.
 
 What the Gradle build does:
 1. `CopyProprietaryAssetsTask` (per production flavor) copies `$ALKITAB_PROPRIETARY_DIR/overlay/<applicationId>/text_raw/*` into `Alkitab/build/generated/proprietaryAssets/<flavor>/internal/`. Wired into AGP via `androidComponents { onVariants { ... addGeneratedSourceDirectory(...) } }` so every consumer (mergeAssets, lint vital, etc.) automatically depends on it. Fails fast if the env var is unset or the overlay is missing.
@@ -100,8 +160,42 @@ What the Gradle build does:
 3. The git commit hash is read at config time and exposed as `BuildConfig.LAST_COMMIT_HASH` (consumed by `AboutActivity` and `InstallationUtil`).
 4. The release APK is named `Alkitab-{versionCode}-{versionName}-{commitHash}-{applicationId}-{BUILD_DIST}.apk`.
 5. For non-plain release builds, `validate<Variant>FirebaseConfig` reads the post-copy `Alkitab/src/<flavor>/google-services.json` and aborts the build if the API key is missing or a placeholder.
+6. `debugSymbolLevel = "SYMBOL_TABLE"` makes AGP emit `Alkitab/build/outputs/native-debug-symbols/<variant>/native-debug-symbols.zip` and embed the same symbols in the AAB, so the Play Console can symbolicate crashes in the Snappy JNI code.
 
 The `plain` flavor keeps its placeholder `ddd_*` Bible files in `Alkitab/src/plain/assets/internal/` and uses the placeholder `Alkitab/google-services.json`. It needs none of the proprietary env vars.
+
+### Release workflow
+
+`.github/workflows/release.yml` is the manual (`workflow_dispatch`) counterpart
+to the automatic `develop` builds. It takes a `stage` (`beta` or `release`) and
+an optional `dry_run`, and it:
+
+1. Resolves the version once via `./gradlew -q :Alkitab:printVersion`, then pins
+   `VERSION_CODE` so all three flavors in the run share one code.
+2. Fails immediately if the tag `v<versionName>` already exists, which is what
+   catches a forgotten `bumpBetaNumber`.
+3. Builds signed APKs and AABs for all three production flavors, then checks
+   each `output-metadata.json` against the version it announced.
+4. Uploads everything as a workflow artifact with 90-day retention (rather than
+   the 14 days `android.yml` uses), because a mapping file stays useful for as
+   long as the build it belongs to is installed anywhere.
+5. Creates a GitHub Release tagged `v<versionName>`, marked as a pre-release for
+   beta stages, carrying the AAB, APK, `mapping.txt` and native debug symbols
+   for each flavor.
+
+Its tags are version names (`v5.0.0-beta.2`), which keeps them distinct from the
+`versionCode`-based tags (`v23605150`) that `android.yml` creates for dev
+pre-releases.
+
+Releasing a beta, end to end:
+
+```bash
+./gradlew bumpBetaNumber
+git commit -am "Bump to 5.0.0-beta.2" && git push
+# then run the Release workflow against that commit with stage=beta,
+# download the AABs from the GitHub Release, and upload them to the
+# Play open-testing track.
+```
 
 ## ProGuard
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -36,15 +36,20 @@ root plus a *stage*, so an artifact's name says which channel produced it:
 
 | Stage | Selected by | Example | Used for |
 |-------|-------------|---------|----------|
-| `dev` | the default | `5.0.0-dev.117` | every ordinary build, local or CI |
+| `dev` | the default | `5.0.0-dev.42` | every ordinary build, local or CI |
 | `beta` | `-PversionStage=beta` or `VERSION_STAGE=beta` | `5.0.0-beta.1` | the Play open-testing track |
 | `release` | `-PversionStage=release` or `VERSION_STAGE=release` | `5.0.0` | the Play production track |
 
 `version.properties` holds only `versionBase` (the marketing version) and
-`betaNumber`. The dev counter is not stored: it is `git rev-list --count HEAD`,
-so it advances once per commit on its own and is the same for anyone building
-that commit. CI therefore has to check out with `fetch-depth: 0`; a shallow
-clone reports a count of 1.
+`betaNumber`. The dev counter is not stored: it is the number of commits since
+`versionBase` last changed, so it advances once per commit on its own, is the
+same for anyone building that commit, and restarts near zero for each release
+line rather than counting the whole repo's history. A `betaNumber` bump does not
+reset it, so a dev version name is never reused within one `versionBase`.
+
+Finding that starting point needs real history, so CI checks out with
+`fetch-depth: 0`. On a shallow clone the lookup finds nothing and the count
+falls back to however many commits the clone happens to have.
 
 Beta numbers are deliberately manual, because a number that moved on its own
 could not identify the build a tester is reporting against:

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,17 @@
+# Single source of truth for the app's user-visible version name.
+#
+# The build assembles versionName from these fields plus the build stage
+# (-PversionStage=, or the VERSION_STAGE env var; "dev" when unset):
+#
+#   release   5.0.0                 shipped to the Play production track
+#   beta      5.0.0-beta.<n>        shipped to the Play open-testing track
+#   dev       5.0.0-dev.<n>         every other build; <n> is the commit count
+#
+# versionBase is bumped when a release ships, and betaNumber is reset to 1 at
+# the same time. Bump betaNumber with `./gradlew bumpBetaNumber` before every
+# beta upload, so two betas never share a version name.
+#
+# versionCode is not stored here: it is derived from wall-clock time in
+# Alkitab/build.gradle.kts and is always increasing regardless of the stage.
+versionBase=5.0.0
+betaNumber=1


### PR DESCRIPTION
Groundwork for putting 5.0.0 on the Google Play open-testing track.

## Versioning

`versionName` was hardcoded, so every commit since 4.11.2 has called itself `5.0.0-b0`. It is now assembled from a new root-level `version.properties` (`versionBase`, `betaNumber`) plus a *stage*:

| Stage | Selected by | Example |
|-------|-------------|---------|
| `dev` | the default | `5.0.0-dev.42` |
| `beta` | `-PversionStage=beta` / `VERSION_STAGE=beta` | `5.0.0-beta.1` |
| `release` | `-PversionStage=release` / `VERSION_STAGE=release` | `5.0.0` |

The dev counter is the number of commits since `versionBase` last changed, so it advances on its own per commit, is the same for anyone building that commit, and restarts near zero for each release line instead of counting the repo's whole history back to 2010. A `betaNumber` bump does not reset it, so a dev name is never reused within one `versionBase`. Finding that starting point needs real history, so CI now checks out with `fetch-depth: 0`.

Beta numbers stay manual on purpose: a number that moved by itself could not identify the build a tester is reporting against.

`versionCode` keeps its wall-clock derivation, so a later build always outranks an earlier one whatever branch or stage produced it. New `VERSION_CODE` env var pins it, which is what makes one release run give all three flavors the same code and a rebuild reproducible.

New tasks under a `release` group:

```
./gradlew printVersion              # versionStage / versionName / versionCode
./gradlew bumpBetaNumber            # betaNumber 1 -> 2, rewriting just that line
./gradlew bundleProductionRelease   # AAB for all three production flavors
./gradlew assembleProductionRelease # APK for all three production flavors
```

## Release workflow

`.github/workflows/release.yml` is a manual (`workflow_dispatch`) counterpart to the automatic `develop` builds, taking a `stage` (`beta`/`release`) and an optional `dry_run`. It resolves the version once and pins `VERSION_CODE`, fails immediately if the tag `v<versionName>` already exists (catching a forgotten `bumpBetaNumber`), builds all three production flavors, verifies each `output-metadata.json` against the version it announced, and creates a GitHub Release carrying the AAB, APK, `mapping.txt` and native debug symbols per flavor. Artifacts get 90-day retention rather than `android.yml`'s 14 days, since a mapping file stays useful as long as the build it belongs to is installed somewhere.

Its tags are version names (`v5.0.0-beta.2`), so they never collide with the `versionCode`-based tags (`v23605150`) that `android.yml` creates for dev pre-releases.

## Other changes

- `debugSymbolLevel = "SYMBOL_TABLE"` on release builds, so the Play Console can symbolicate crashes in the Snappy JNI code. Play flags a bundle with unsymbolicated native code today.
- `POST_NOTIFICATIONS` declared explicitly in `AndroidManifest.xml`. It was already reaching the merged manifest via firebase-messaging, but the audio-playback and sync notifications do not depend on Firebase.
- CI also runs on `release/**`, which git-flow release branches previously got no coverage on.
- `CLAUDE.md` records the no-explaining-comments rule.

## Verification

Built and tested locally with the Android SDK provisioned per `CLAUDE.md`:

- `./gradlew assemblePlainDebug testPlainDebugUnitTest testPlainReleaseUnitTest` — BUILD SUCCESSFUL, APK named `Alkitab-23605350-5.0.0-dev.0-27862d7-yuku.alkitab.debug-dev.apk`.
- Dev counter verified to reset to `dev.0` at the `versionBase` commit and advance to `dev.1` on the next commit.
- `printVersion` exercised for all three stages, with and without `VERSION_CODE`, plus an invalid stage (fails with a clear message).
- `bumpBetaNumber` round-tripped: `5.0.0-beta.1` → `5.0.0-beta.2`, header comments and trailing newline preserved.
- Merged manifest confirmed to carry `POST_NOTIFICATIONS`.
- Both workflow files parse as YAML.

## Not included

**`targetSdk` is still 35.** It is not a config flip: `Alkitab/src/main/res/values-v35/themes.xml` sets `android:windowOptOutEdgeToEdgeEnforcement`, and Android 16 ignores that flag for apps targeting API 36. Bumping the target would silently force edge-to-edge on Android 16 while Android 15 keeps the opt-out, so the same build would lay out differently on the two releases. That needs the opt-out removed and every activity checked on a device, which is its own change. Worth doing before the beta reaches Play, since the annual target-API requirement likely blocks uploads below API 36.

Also left out: `CHANGELOG.md` has no 5.0.0 entry yet, and there is no runtime `POST_NOTIFICATIONS` request, so on Android 13+ the permission stays denied by default and notifications do not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iqeCBnMgaEzpufC1d6LpH