### PR TITLE
Fix verse text color on a selected highlight and dictionary links

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/util/TextColorUtil.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/util/TextColorUtil.kt
@@ -4,6 +4,9 @@ import androidx.core.graphics.ColorUtils
 
 object TextColorUtil {
 
+    /** Alpha for the selection overlay on a checked verse row. */
+    const val CHECKED_VERSE_OVERLAY_ALPHA = 0xa0
+
     @JvmStatic
     fun getSearchKeywordByBrightness(brightness: Float): Int {
         return if (brightness < 0.5f) {
@@ -19,6 +22,28 @@ object TextColorUtil {
             0xff000000.toInt()
         } else {
             0xffffffff.toInt()
+        }
+    }
+
+    /**
+     * Text color for a highlighted run inside a checked verse.
+     *
+     * The highlight band is drawn on top of the selection overlay. So the color from
+     * [getForCheckedVerse] can be wrong there, for example white text on a yellow highlight.
+     * This picks whichever color, the reading color or the checked-verse color, has better
+     * contrast against what the band actually paints.
+     */
+    @JvmStatic
+    fun getForCheckedVerseHighlight(fontColor: Int, checkedVerseBgColor: Int, pageBackgroundColor: Int, highlightBand: Int): Int {
+        val checkedTextColor = getForCheckedVerse(checkedVerseBgColor)
+        val overlay = ColorUtils.setAlphaComponent(checkedVerseBgColor, CHECKED_VERSE_OVERLAY_ALPHA)
+        val selection = ColorUtils.compositeColors(overlay, pageBackgroundColor or 0xff000000.toInt())
+        val painted = ColorUtils.compositeColors(highlightBand, selection)
+        val readingColor = fontColor or 0xff000000.toInt()
+        return if (ColorUtils.calculateContrast(checkedTextColor, painted) >= ColorUtils.calculateContrast(readingColor, painted)) {
+            checkedTextColor
+        } else {
+            readingColor
         }
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItem.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItem.kt
@@ -17,6 +17,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
 import yuku.afw.storage.Preferences
 import yuku.alkitab.base.App
+import yuku.alkitab.base.util.TextColorUtil
 import yuku.alkitab.base.widget.AttributeView
 import yuku.alkitab.base.widget.LeftDrawer.PROGRESS_MARK_DRAG_MIME_TYPE
 import yuku.alkitab.base.widget.VerseTextView
@@ -191,7 +192,7 @@ class VerseItem(context: Context, attrs: AttributeSet) : RelativeLayout(context,
         if (checked) {
             val solid = checkedPaintSolid
             val colorRgb = Preferences.getInt(R.string.pref_selectedVerseBgColor_key, R.integer.pref_selectedVerseBgColor_default)
-            val color = ColorUtils.setAlphaComponent(colorRgb, 0xa0)
+            val color = ColorUtils.setAlphaComponent(colorRgb, TextColorUtil.CHECKED_VERSE_OVERLAY_ALPHA)
             solid.color = color
 
             canvas.drawRect(0f, 0f, w.toFloat(), h.toFloat(), solid)

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
@@ -62,6 +62,7 @@ import androidx.core.net.toUri
 import yuku.afw.storage.Preferences
 import yuku.alkitab.base.App
 import yuku.alkitab.base.util.AppLog
+import yuku.alkitab.base.util.TextColorUtil
 import yuku.alkitab.base.util.safeQuery
 import yuku.alkitab.base.widget.AttributeView
 import yuku.alkitab.base.widget.DictionaryLinkInfo
@@ -271,7 +272,8 @@ internal fun verseItemContentDescription(context: Context, s: VerseItemComposeSt
 /**
  * Runs the rendered verse text through the dictionary app's analyzer content
  * provider and wraps every recognized word in an underlined, tappable
- * [LinkAnnotation] that opens the dictionary.
+ * [LinkAnnotation] that opens the dictionary. The word keeps whatever color
+ * the surrounding text has.
  *
  * Returns [render] unchanged when the provider is unavailable, reports
  * nothing, or the query fails.
@@ -279,7 +281,6 @@ internal fun verseItemContentDescription(context: Context, s: VerseItemComposeSt
 internal fun addDictionaryLinks(
     context: Context,
     render: VerseRendererCompose.Result,
-    linkColor: Int,
     dictionaryListener: (DictionaryLinkInfo) -> Unit,
 ): VerseRendererCompose.Result {
     // we have to exclude the verse numbers from analyze text
@@ -314,7 +315,7 @@ internal fun addDictionaryLinks(
     val decorated = buildAnnotatedString {
         append(render.text)
         for (hit in hits) {
-            addStyle(SpanStyle(color = Color(linkColor), textDecoration = TextDecoration.Underline), hit.start, hit.end)
+            addStyle(SpanStyle(textDecoration = TextDecoration.Underline), hit.start, hit.end)
             addLink(LinkAnnotation.Clickable("dictionary") { dictionaryListener(hit.info) }, hit.start, hit.end)
         }
     }
@@ -411,7 +412,7 @@ fun buildVerseItemComposeState(
     val render = if (ari in ui.dictionaryModeAris ||
         checked && Preferences.getBoolean(context.getString(R.string.pref_autoDictionaryAnalyze_key), context.resources.getBoolean(R.bool.pref_autoDictionaryAnalyze_default))
     ) {
-        addDictionaryLinks(context, renderResult, applied.fontColor, listeners.dictionaryListener_)
+        addDictionaryLinks(context, renderResult, listeners.dictionaryListener_)
     } else {
         renderResult
     }
@@ -605,7 +606,7 @@ internal fun computeLineMetrics(
 @Composable
 private fun VerseTextRegion(state: VerseItemComposeState, checked: Boolean, lineMetrics: LineMetrics, modifier: Modifier = Modifier) {
     val textColor = if (checked) {
-        Color(yuku.alkitab.base.util.TextColorUtil.getForCheckedVerse(
+        Color(TextColorUtil.getForCheckedVerse(
             Preferences.getInt(R.string.pref_selectedVerseBgColor_key, R.integer.pref_selectedVerseBgColor_default)
         ))
     } else {
@@ -849,7 +850,7 @@ private fun scaledAttributeBitmap(
 
 private fun Modifier.checkedOverlay(checked: Boolean): Modifier = if (!checked) this else this.drawBehind {
     val colorRgb = Preferences.getInt(R.string.pref_selectedVerseBgColor_key, R.integer.pref_selectedVerseBgColor_default)
-    val color = ColorUtils.setAlphaComponent(colorRgb, 0xa0)
+    val color = ColorUtils.setAlphaComponent(colorRgb, TextColorUtil.CHECKED_VERSE_OVERLAY_ALPHA)
     drawRect(color = Color(color))
 }
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/DictionaryLinkSpan.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/DictionaryLinkSpan.kt
@@ -1,5 +1,6 @@
 package yuku.alkitab.base.widget
 
+import android.text.TextPaint
 import android.text.style.ClickableSpan
 import android.view.View
 
@@ -11,5 +12,10 @@ class DictionaryLinkSpan(
 ) : ClickableSpan() {
     override fun onClick(widget: View) {
         onClickListener(data)
+    }
+
+    /** Underline only. The word keeps whatever color the surrounding text has. */
+    override fun updateDrawState(ds: TextPaint) {
+        ds.isUnderlineText = true
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/VerseRenderer.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/VerseRenderer.kt
@@ -13,8 +13,11 @@ import android.text.style.StyleSpan
 import android.view.View
 import android.widget.TextView
 import android.widget.Toast
+import yuku.afw.storage.Preferences
 import yuku.alkitab.base.App
 import yuku.alkitab.base.util.Highlights
+import yuku.alkitab.base.util.TextColorUtil
+import yuku.alkitab.debug.R
 import yuku.alkitab.util.Ari
 
 object VerseRenderer {
@@ -113,7 +116,7 @@ object VerseRenderer {
 
         processFormattingCodes(text, text_c, text_len, sb, startPosAfterVerseNumber, verseNumberText, checked, ari, inlineLinkSpanFactory)
 
-        applyHighlight(sb, highlightInfo, startPosAfterVerseNumber)
+        applyHighlight(sb, highlightInfo, startPosAfterVerseNumber, checked)
 
         bindToTextViews(lText, lVerseNumber, sb, isVerseNumberShown, startPosAfterVerseNumber, verseNumberText)
 
@@ -232,21 +235,33 @@ object VerseRenderer {
      * Attaches a [BackgroundColorSpan] for the highlight. A partial highlight whose hash still
      * matches the rendered body covers only its stored offsets; otherwise the whole verse body
      * (after the verse-number prefix) is highlighted.
+     *
+     * In a checked verse, the run under the band gets its own text color, picked against the
+     * band instead of the selection color used for the rest of the verse.
      */
-    private fun applyHighlight(sb: SpannableStringBuilder, highlightInfo: Highlights.Info?, startPosAfterVerseNumber: Int) {
+    private fun applyHighlight(sb: SpannableStringBuilder, highlightInfo: Highlights.Info?, startPosAfterVerseNumber: Int, checked: Boolean) {
         if (highlightInfo == null) return
 
-        val span = BackgroundColorSpan(Highlights.blendOver(highlightInfo.colorRgb, App.services.uiDimensions.applied().backgroundColor))
+        val applied = App.services.uiDimensions.applied()
+        val band = Highlights.blendOver(highlightInfo.colorRgb, applied.backgroundColor)
+
+        val start: Int
+        val end: Int
         if (highlightInfo.shouldRenderAsPartialForVerseText(sb.subSequence(startPosAfterVerseNumber, sb.length))) {
-            val start = startPosAfterVerseNumber + highlightInfo.partial!!.startOffset
-            val end = startPosAfterVerseNumber + highlightInfo.partial!!.endOffset
-            if (end > start) {
-                sb.setSpan(span, start, end, 0)
-            } else {
-                sb.setSpan(span, end, start, 0)
-            }
+            val rawStart = startPosAfterVerseNumber + highlightInfo.partial!!.startOffset
+            val rawEnd = startPosAfterVerseNumber + highlightInfo.partial!!.endOffset
+            start = minOf(rawStart, rawEnd)
+            end = maxOf(rawStart, rawEnd)
         } else {
-            sb.setSpan(span, startPosAfterVerseNumber, sb.length, 0)
+            start = startPosAfterVerseNumber
+            end = sb.length
+        }
+
+        sb.setSpan(BackgroundColorSpan(band), start, end, 0)
+        if (checked) {
+            val selectedVerseBgColor = Preferences.getInt(R.string.pref_selectedVerseBgColor_key, R.integer.pref_selectedVerseBgColor_default)
+            val textColor = TextColorUtil.getForCheckedVerseHighlight(applied.fontColor, selectedVerseBgColor, applied.backgroundColor, band)
+            sb.setSpan(ForegroundColorSpan(textColor), start, end, 0)
         }
     }
 
@@ -365,20 +380,7 @@ object VerseRenderer {
             sb.setSpan(createLeadingMarginSpan(App.services.uiDimensions.applied().indentParagraphRest), 0, sb.length, 0)
         }
 
-        if (highlightInfo != null) {
-            val span = BackgroundColorSpan(Highlights.blendOver(highlightInfo.colorRgb, App.services.uiDimensions.applied().backgroundColor))
-            if (highlightInfo.shouldRenderAsPartialForVerseText(text)) {
-                val start = startPosAfterVerseNumber + highlightInfo.partial!!.startOffset
-                val end = startPosAfterVerseNumber + highlightInfo.partial!!.endOffset
-                if (end > start) {
-                    sb.setSpan(span, start, end, 0)
-                } else {
-                    sb.setSpan(span, end, start, 0)
-                }
-            } else {
-                sb.setSpan(span, startPosAfterVerseNumber, sb.length, 0)
-            }
-        }
+        applyHighlight(sb, highlightInfo, startPosAfterVerseNumber, checked)
 
         lText?.text = sb
 

--- a/Alkitab/src/main/java/yuku/alkitab/base/widget/VerseRendererCompose.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/widget/VerseRendererCompose.kt
@@ -13,8 +13,11 @@ import androidx.compose.ui.text.style.TextIndent
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
+import yuku.afw.storage.Preferences
 import yuku.alkitab.base.App
 import yuku.alkitab.base.util.Highlights
+import yuku.alkitab.base.util.TextColorUtil
+import yuku.alkitab.debug.R
 import yuku.alkitab.util.Ari
 
 /**
@@ -100,7 +103,7 @@ object VerseRendererCompose {
         processFormattingCodes(text, text_c, text_len, sb, startPosAfterVerseNumber, verseNumberText, checked, ari, inlineLinks)
 
         val built = sb.toAnnotatedString()
-        val withHighlight = applyHighlight(built, highlightInfo, startPosAfterVerseNumber)
+        val withHighlight = applyHighlight(built, highlightInfo, startPosAfterVerseNumber, checked)
 
         return Result(
             text = withHighlight,
@@ -233,9 +236,22 @@ object VerseRendererCompose {
         applyParaStyle(sb, paraType, startPara, verseNumberText, startPosAfterVerseNumber > 0)
     }
 
-    private fun applyHighlight(text: AnnotatedString, highlightInfo: Highlights.Info?, startPosAfterVerseNumber: Int): AnnotatedString {
+    /**
+     * In a checked verse, the run under the band gets its own text color, picked against the
+     * band instead of the selection color used for the rest of the verse.
+     */
+    private fun applyHighlight(text: AnnotatedString, highlightInfo: Highlights.Info?, startPosAfterVerseNumber: Int, checked: Boolean): AnnotatedString {
         if (highlightInfo == null) return text
-        val background = Color(Highlights.blendOver(highlightInfo.colorRgb, App.services.uiDimensions.applied().backgroundColor))
+        val applied = App.services.uiDimensions.applied()
+        val band = Highlights.blendOver(highlightInfo.colorRgb, applied.backgroundColor)
+        val textColor = if (checked) {
+            val selectedVerseBgColor = Preferences.getInt(R.string.pref_selectedVerseBgColor_key, R.integer.pref_selectedVerseBgColor_default)
+            Color(TextColorUtil.getForCheckedVerseHighlight(applied.fontColor, selectedVerseBgColor, applied.backgroundColor, band))
+        } else {
+            Color.Unspecified
+        }
+        val style = SpanStyle(color = textColor, background = Color(band))
+
         val builder = AnnotatedString.Builder(text)
         val verseBody = text.subSequence(startPosAfterVerseNumber, text.length)
         if (highlightInfo.shouldRenderAsPartialForVerseText(verseBody.text)) {
@@ -244,10 +260,10 @@ object VerseRendererCompose {
             val start = minOf(rawStart, rawEnd)
             val end = maxOf(rawStart, rawEnd)
             if (end > start) {
-                builder.addStyle(SpanStyle(background = background), start, end)
+                builder.addStyle(style, start, end)
             }
         } else {
-            builder.addStyle(SpanStyle(background = background), startPosAfterVerseNumber, text.length)
+            builder.addStyle(style, startPosAfterVerseNumber, text.length)
         }
         return builder.toAnnotatedString()
     }
@@ -368,7 +384,7 @@ object VerseRendererCompose {
         }
 
         val built = sb.toAnnotatedString()
-        val withHighlight = applyHighlight(built, highlightInfo, startPosAfterVerseNumber)
+        val withHighlight = applyHighlight(built, highlightInfo, startPosAfterVerseNumber, checked)
 
         return Result(
             text = withHighlight,

--- a/Alkitab/src/test/java/yuku/alkitab/base/util/TextColorUtilTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/util/TextColorUtilTest.kt
@@ -1,0 +1,55 @@
+package yuku.alkitab.base.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class TextColorUtilTest {
+
+    private val BLACK = 0xff000000.toInt()
+    private val WHITE = 0xffffffff.toInt()
+    private val LIGHT_PAGE = 0xfff0f0f0.toInt()
+    private val LIGHT_PAGE_TEXT = 0xff212121.toInt()
+    private val NIGHT_PAGE = 0xff000000.toInt()
+    private val NIGHT_PAGE_TEXT = 0xffaeaeae.toInt()
+    private val BLUE_SELECTION = 0xff0277bd.toInt()
+    private val LIGHT_YELLOW_SELECTION = 0xfffff59d.toInt()
+
+    @Test
+    fun `getForCheckedVerse picks white on a dark selection and black on a light one`() {
+        assertEquals(WHITE, TextColorUtil.getForCheckedVerse(BLUE_SELECTION))
+        assertEquals(BLACK, TextColorUtil.getForCheckedVerse(LIGHT_YELLOW_SELECTION))
+    }
+
+    @Test
+    fun `a yellow band on a light page keeps the reading color even though the blue selection alone would force white`() {
+        val band = Highlights.blendOver(0xffff00, LIGHT_PAGE)
+        val color = TextColorUtil.getForCheckedVerseHighlight(LIGHT_PAGE_TEXT, BLUE_SELECTION, LIGHT_PAGE, band)
+        assertEquals(LIGHT_PAGE_TEXT, color)
+    }
+
+    @Test
+    fun `a band that stays dark on the night page keeps the white the blue selection picks`() {
+        val band = Highlights.blendOver(0x0080ff, NIGHT_PAGE)
+        val color = TextColorUtil.getForCheckedVerseHighlight(NIGHT_PAGE_TEXT, BLUE_SELECTION, NIGHT_PAGE, band)
+        assertEquals(WHITE, color)
+    }
+
+    @Test
+    fun `a light selection under a yellow band stays black because black reads better than the grey reading color`() {
+        val band = Highlights.blendOver(0xffff00, LIGHT_PAGE)
+        val color = TextColorUtil.getForCheckedVerseHighlight(0xff606060.toInt(), LIGHT_YELLOW_SELECTION, LIGHT_PAGE, band)
+        assertEquals(BLACK, color)
+    }
+
+    @Test
+    fun `a reading color without an alpha channel is treated as opaque`() {
+        val band = Highlights.blendOver(0xffff00, LIGHT_PAGE)
+        val color = TextColorUtil.getForCheckedVerseHighlight(0x212121, BLUE_SELECTION, LIGHT_PAGE, band)
+        assertEquals(LIGHT_PAGE_TEXT, color)
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemComposeDictionaryTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemComposeDictionaryTest.kt
@@ -9,6 +9,7 @@ import android.database.MatrixCursor
 import android.graphics.Typeface
 import android.net.Uri
 import android.view.View
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.test.core.app.ApplicationProvider
@@ -155,10 +156,14 @@ class VerseItemComposeDictionaryTest {
             assertEquals(FakeDictionaryProvider.RECOGNIZED_WORD, fullText.substring(link.start, link.end))
         }
 
-        // Each linked word range is underlined, like the legacy ClickableSpan.
+        // Each linked word range is underlined, like the legacy ClickableSpan, and carries no
+        // color of its own so it keeps the color of the run it sits in.
         val underlined = state.render.text.spanStyles.filter { it.item.textDecoration == TextDecoration.Underline }
         assertEquals(2, underlined.size)
         assertEquals(links.map { it.start to it.end }.toSet(), underlined.map { it.start to it.end }.toSet())
+        for (style in underlined) {
+            assertEquals(Color.Unspecified, style.item.color)
+        }
 
         // Tapping a link reports the word and the analyzer's key.
         val first = links.minByOrNull { it.start }!!.item as LinkAnnotation.Clickable

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseTextColorSnapshotTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseTextColorSnapshotTest.kt
@@ -1,0 +1,487 @@
+package yuku.alkitab.base.verses
+
+import android.app.Activity
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.ProviderInfo
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.net.Uri
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.graphics.ColorUtils
+import androidx.test.core.app.ApplicationProvider
+import java.io.File
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import yuku.afw.App as AfwApp
+import yuku.alkitab.base.S
+import yuku.alkitab.base.util.Highlights
+import yuku.alkitab.base.util.TextColorUtil
+import yuku.alkitab.base.widget.VerseRenderer
+import yuku.alkitab.debug.R
+import yuku.alkitab.model.SingleChapterVerses
+import yuku.alkitab.util.Ari
+
+/**
+ * Fake dictionary analyzer that links every occurrence of a few fixed words, so each rendered
+ * verse carries dictionary links both inside and outside a partial highlight.
+ */
+class WordListDictionaryProvider : ContentProvider() {
+    override fun onCreate(): Boolean = true
+
+    override fun query(uri: Uri, projection: Array<String>?, selection: String?, selectionArgs: Array<String>?, sortOrder: String?): Cursor {
+        val text = uri.getQueryParameter("text").orEmpty().lowercase()
+        val cursor = MatrixCursor(arrayOf("offset", "len", "key"))
+        for (word in WORDS) {
+            var index = text.indexOf(word)
+            while (index >= 0) {
+                cursor.addRow(arrayOf<Any>(index, word.length, "key_$word"))
+                index = text.indexOf(word, index + 1)
+            }
+        }
+        return cursor
+    }
+
+    override fun getType(uri: Uri): String? = null
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+    override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    companion object {
+        val WORDS = listOf("body", "love")
+    }
+}
+
+/**
+ * Visual matrix of verse text colors: every reading theme, selection color, highlight color
+ * and selection state, each rendered through both the legacy [VerseItem] and the Compose
+ * [VerseItemComposeView] bind paths exactly as the reader does it. Every verse carries
+ * words of Jesus and dictionary-linked words so their colors can be checked in the same row.
+ *
+ * Per-block PNGs (one per theme and selection color), per-theme contact sheets and an
+ * `index.html` land in `Alkitab/build/snapshots/verse-text-color/`. Nothing is pixel-compared:
+ * the test asserts only that the report was produced.
+ *
+ * The whole matrix runs in the shared unit-test JVM, so it reuses one activity per pipeline
+ * and recycles every bitmap as soon as it has been composited.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = AfwApp::class, sdk = [34], qualifiers = "w360dp-h640dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class VerseTextColorSnapshotTest {
+
+    private val ROW_WIDTH_PX = 360
+    private val COLUMN_GAP_PX = 12
+    private val ROW_GAP_PX = 4
+    private val LABEL_HEIGHT_PX = 30
+    private val BLOCK_HEADER_PX = 40
+    private val SHEET_GUTTER_PX = 20
+    private val SHEET_HEADER_PX = 48
+
+    private val SAMPLE = "@@The whole body is fitted together perfectly. @6As each part does its work, the body grows@5 and builds itself up in love. @6Love one another.@5"
+
+    private class Theme(val name: String, val background: Int, val fontColor: Int, val fontRedColor: Int, val verseNumberColor: Int)
+
+    private class Selection(val name: String, val rgb: Int)
+
+    private class Highlight(val name: String, val rgb: Int)
+
+    private class Row(val highlight: Highlight?, val partial: Boolean, val checked: Boolean) {
+        val label: String
+            get() = listOf(
+                highlight?.name ?: "no highlight",
+                if (highlight == null) null else if (partial) "partial" else "full",
+                if (checked) "selected" else "not selected",
+            ).filterNotNull().joinToString(" · ")
+    }
+
+    private class Pipeline(val controller: ActivityController<AppCompatActivity>, val frame: FrameLayout) {
+        val activity: Activity get() = controller.get()
+    }
+
+    private val themes = listOf(
+        Theme("light-default", 0xfff0f0f0.toInt(), 0xff212121.toInt(), 0xffb71c1c.toInt(), 0xff828282.toInt()),
+        Theme("white", 0xffffffff.toInt(), 0xff000000.toInt(), 0xffb71c1c.toInt(), 0xff828282.toInt()),
+        Theme("sepia", 0xfffff8e7.toInt(), 0xff3b3021.toInt(), 0xff8b2c1c.toInt(), 0xff8a7a5c.toInt()),
+        Theme("dark-grey", 0xff303030.toInt(), 0xffdddddd.toInt(), 0xffef9a9a.toInt(), 0xff9e9e9e.toInt()),
+        Theme("night-default", 0xff000000.toInt(), 0xffaeaeae.toInt(), 0xffa25c5c.toInt(), 0xff6c6cb3.toInt()),
+    )
+
+    private val selections = listOf(
+        Selection("blue-default", 0x0277bd),
+        Selection("light-yellow", 0xfff59d),
+        Selection("green", 0x4caf50),
+        Selection("red", 0xe53935),
+        Selection("dark", 0x37474f),
+    )
+
+    private val highlights = listOf(
+        Highlight("yellow", 0xffff00),
+        Highlight("green", 0x00ff00),
+        Highlight("azure", 0x0080ff),
+        Highlight("rose", 0xff0080),
+    )
+
+    private val rows: List<Row> = buildList {
+        add(Row(null, partial = false, checked = false))
+        add(Row(null, partial = false, checked = true))
+        for (highlight in highlights) {
+            add(Row(highlight, partial = false, checked = false))
+            add(Row(highlight, partial = false, checked = true))
+            add(Row(highlight, partial = true, checked = true))
+        }
+    }
+
+    private class FakeVerses(private val texts: List<String>) : SingleChapterVerses {
+        override val verseCount: Int get() = texts.size
+        override fun getVerse(verse_0: Int): String = texts[verse_0]
+    }
+
+    private lateinit var context: Context
+    private lateinit var dims: S.CalculatedDimensions
+    private lateinit var verseBody: String
+    private var partialStart = 0
+    private var partialEnd = 0
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        AfwApp.initWithAppContext(context)
+
+        Robolectric.buildContentProvider(WordListDictionaryProvider::class.java).create(
+            ProviderInfo().apply { authority = "org.sabda.kamus.provider" }
+        )
+
+        dims = S.CalculatedDimensions().apply {
+            fontSize2dp = 17f
+            fontFace = Typeface.DEFAULT
+            fontBold = Typeface.NORMAL
+            lineSpacingMult = 1.15f
+            indentParagraphFirst = 38
+            indentParagraphRest = 5
+            indentSpacing1 = 22
+            indentSpacing2 = 38
+            indentSpacing3 = 54
+            indentSpacing4 = 70
+            indentSpacingExtra = 6
+        }
+        S.applied()
+        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
+        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
+        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, dims)
+
+        val ftr = VerseRenderer.FormattedTextResult()
+        VerseRenderer.render(ari = Ari.encode(48, 4, 16), text = SAMPLE, ftr = ftr)
+        verseBody = ftr.result.toString()
+        partialStart = verseBody.indexOf("body is fitted")
+        partialEnd = verseBody.indexOf("does its work,") + "does its work,".length
+        assertTrue(partialStart in 0 until partialEnd)
+    }
+
+    @Test
+    fun `render every theme, selection color, highlight color and selection state through both verse pipelines for visual review`() {
+        val outputDir = resolveSnapshotDir()
+        outputDir.mkdirs()
+
+        val html = StringBuilder()
+        html.append(
+            """
+            <!doctype html>
+            <html><head><meta charset="utf-8"/><title>Verse text color across themes, selections and highlights</title>
+            <style>
+            body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 24px; background: #fafafa; }
+            h2 { margin-top: 36px; }
+            pre { color: #555; font-size: 12px; }
+            img { display: block; max-width: 100%; border: 1px solid #ccc; }
+            ul { font-size: 13px; }
+            </style></head>
+            <body>
+            <h1>Verse text color: theme × selection color × highlight × selection state</h1>
+            <p>Each block is one reading theme and one selection color. Rows go from no highlight through every
+            highlight color, first not selected, then selected with a full highlight, then selected with a partial
+            highlight. The left column is the legacy VerseItem, the right the Compose VerseItemComposeView. Every verse
+            has words of Jesus (red text when not selected) and dictionary-linked words (underlined: "body", "love").</p>
+            <p>The label above each row gives the text color used on the highlight band and its contrast ratio against
+            what the band actually paints, then the color used on the rest of the verse and its contrast against the
+            selection overlay (or the page when not selected).</p>
+            """.trimIndent()
+        )
+
+        val legacy = buildPipeline()
+        val compose = buildPipeline()
+        try {
+            for (theme in themes) {
+                applyTheme(theme, legacy, compose)
+                val blocks = mutableListOf<Pair<Selection, Bitmap>>()
+                for (selection in selections) {
+                    pinSelection(selection)
+                    val block = renderBlock(theme, selection, legacy, compose)
+                    blocks += selection to block
+                    write(block, File(outputDir, "${theme.name}--${selection.name}.png"))
+                }
+                val sheetFile = File(outputDir, "${theme.name}.png")
+                val sheet = renderThemeSheet(theme, blocks)
+                write(sheet, sheetFile)
+                sheet.recycle()
+                for ((_, block) in blocks) block.recycle()
+
+                html.append("<h2>${theme.name}</h2>\n")
+                html.append(
+                    "<pre>page #%06x   text #%06x   words of Jesus #%06x   verse number #%06x</pre>\n".format(
+                        theme.background and 0xffffff, theme.fontColor and 0xffffff, theme.fontRedColor and 0xffffff, theme.verseNumberColor and 0xffffff,
+                    )
+                )
+                html.append("<img src=\"${sheetFile.name}\"/>\n<ul>\n")
+                for ((selection, _) in blocks) {
+                    html.append("<li><a href=\"${theme.name}--${selection.name}.png\">${selection.name} block</a></li>\n")
+                }
+                html.append("</ul>\n")
+            }
+        } finally {
+            legacy.controller.pause().stop().destroy()
+            compose.controller.pause().stop().destroy()
+        }
+
+        html.append("</body></html>")
+        val indexFile = File(outputDir, "index.html")
+        indexFile.writeText(html.toString())
+
+        println("Verse text color report written to: ${indexFile.absolutePath}")
+        assertTrue("index.html should exist", indexFile.exists())
+    }
+
+    private fun applyTheme(theme: Theme, vararg pipelines: Pipeline) {
+        dims.backgroundColor = theme.background
+        dims.fontColor = theme.fontColor
+        dims.fontRedColor = theme.fontRedColor
+        dims.verseNumberColor = theme.verseNumberColor
+        for (pipeline in pipelines) pipeline.frame.setBackgroundColor(theme.background)
+    }
+
+    private fun pinSelection(selection: Selection) {
+        yuku.afw.storage.Preferences.setInt(context.getString(R.string.pref_selectedVerseBgColor_key), 0xff000000.toInt() or selection.rgb)
+    }
+
+    private fun renderBlock(theme: Theme, selection: Selection, legacy: Pipeline, compose: Pipeline): Bitmap {
+        val data = buildData()
+        val ui = VersesUiModel.EMPTY.copy(
+            isVerseNumberShown = true,
+            dictionaryModeAris = rows.indices.map { Ari.encodeWithBc(data.ari_bc_, it + 1) }.toSet(),
+        )
+
+        val rendered = rows.mapIndexed { index, row ->
+            Triple(row, renderLegacy(legacy, data, ui, index, row.checked), renderCompose(compose, data, ui, index, row.checked))
+        }
+
+        val blockWidth = ROW_WIDTH_PX * 2 + COLUMN_GAP_PX
+        val blockHeight = BLOCK_HEADER_PX + rendered.sumOf { (_, left, right) -> LABEL_HEIGHT_PX + maxOf(left.height, right.height) + ROW_GAP_PX }
+        val bitmap = Bitmap.createBitmap(blockWidth, blockHeight, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(theme.background)
+
+        val title = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = theme.fontColor
+            textSize = 14f
+            typeface = Typeface.create(Typeface.SANS_SERIF, Typeface.BOLD)
+        }
+        val caption = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = theme.fontColor
+            textSize = 11f
+            typeface = Typeface.SANS_SERIF
+        }
+
+        canvas.drawText("selection ${selection.name} #%06x".format(selection.rgb), 4f, 16f, title)
+        canvas.drawText("legacy VerseItem", 4f, 32f, caption)
+        canvas.drawText("Compose VerseItemComposeView", (ROW_WIDTH_PX + COLUMN_GAP_PX + 4).toFloat(), 32f, caption)
+        title.textSize = 11f
+
+        var y = BLOCK_HEADER_PX
+        for ((row, left, right) in rendered) {
+            canvas.drawText(row.label, 4f, (y + 11).toFloat(), title)
+            canvas.drawText(describeColors(theme, selection, row), 4f, (y + 24).toFloat(), caption)
+            y += LABEL_HEIGHT_PX
+            canvas.drawBitmap(left, 0f, y.toFloat(), null)
+            canvas.drawBitmap(right, (ROW_WIDTH_PX + COLUMN_GAP_PX).toFloat(), y.toFloat(), null)
+            y += maxOf(left.height, right.height) + ROW_GAP_PX
+            left.recycle()
+            right.recycle()
+        }
+
+        return bitmap
+    }
+
+    private fun describeColors(theme: Theme, selection: Selection, row: Row): String {
+        val selectionArgb = 0xff000000.toInt() or selection.rgb
+        val overlay = ColorUtils.setAlphaComponent(selectionArgb, TextColorUtil.CHECKED_VERSE_OVERLAY_ALPHA)
+        val restBackground = if (row.checked) ColorUtils.compositeColors(overlay, theme.background) else theme.background
+        val restText = if (row.checked) TextColorUtil.getForCheckedVerse(selectionArgb) else theme.fontColor
+        val rest = "rest #%06x %.1f:1".format(restText and 0xffffff, ColorUtils.calculateContrast(restText, restBackground))
+
+        val highlight = row.highlight ?: return rest
+        val band = Highlights.blendOver(highlight.rgb, theme.background)
+        val painted = ColorUtils.compositeColors(band, restBackground)
+        val bandText = if (row.checked) {
+            TextColorUtil.getForCheckedVerseHighlight(theme.fontColor, selectionArgb, theme.background, band)
+        } else {
+            theme.fontColor
+        }
+        return "band a=%02x text #%06x %.1f:1   %s".format((band ushr 24) and 0xff, bandText and 0xffffff, ColorUtils.calculateContrast(bandText, painted), rest)
+    }
+
+    private fun buildData(): VersesDataModel {
+        val attributes = VersesAttributes.createEmpty(rows.size)
+        for ((index, row) in rows.withIndex()) {
+            val highlight = row.highlight ?: continue
+            attributes.highlightInfoMap_[index] = Highlights.Info().apply {
+                colorRgb = highlight.rgb
+                partial = if (row.partial) {
+                    Highlights.Info.Partial().apply {
+                        hashCode = Highlights.hashCode(verseBody)
+                        startOffset = partialStart
+                        endOffset = partialEnd
+                    }
+                } else {
+                    null
+                }
+            }
+        }
+        return VersesDataModel(
+            ari_bc_ = Ari.encode(48, 4, 0),
+            verses_ = FakeVerses(List(rows.size) { SAMPLE }),
+            versesAttributes = attributes,
+        )
+    }
+
+    private fun renderLegacy(pipeline: Pipeline, data: VersesDataModel, ui: VersesUiModel, index: Int, checked: Boolean): Bitmap {
+        val item = pipeline.activity.layoutInflater.inflate(R.layout.item_verse, pipeline.frame, false) as VerseItem
+        pipeline.frame.addView(item, ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+        idleLoopers()
+        VerseTextHolder(item).bind(data, ui, VersesListeners.EMPTY, Attention(), AudioHighlight(), checked, {}, index)
+        val bitmap = measureAndDraw(item, dims.backgroundColor)
+        pipeline.frame.removeView(item)
+        return bitmap
+    }
+
+    private fun renderCompose(pipeline: Pipeline, data: VersesDataModel, ui: VersesUiModel, index: Int, checked: Boolean): Bitmap {
+        val view = VerseItemComposeView(pipeline.activity)
+        pipeline.frame.addView(view, ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT))
+        idleLoopers()
+        val state = buildVerseItemComposeState(
+            context = pipeline.activity,
+            data = data,
+            ui = ui,
+            listeners = VersesListeners.EMPTY,
+            index = index,
+            checked = checked,
+            currentPosition = { index },
+            toggleChecked = {},
+            inlineLinkViewProvider = { view },
+        )
+        view.bind(state)
+        view.checked = checked
+        idleLoopers()
+        val bitmap = measureAndDraw(view, dims.backgroundColor)
+        pipeline.frame.removeView(view)
+        idleLoopers()
+        return bitmap
+    }
+
+    private fun renderThemeSheet(theme: Theme, blocks: List<Pair<Selection, Bitmap>>): Bitmap {
+        val blockWidth = blocks.maxOf { it.second.width }
+        val blockHeight = blocks.maxOf { it.second.height }
+        val width = SHEET_GUTTER_PX + blocks.size * (blockWidth + SHEET_GUTTER_PX)
+        val height = SHEET_HEADER_PX + blockHeight + SHEET_GUTTER_PX
+
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(0xfffafafa.toInt())
+
+        val title = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0xff111111.toInt()
+            textSize = 16f
+            typeface = Typeface.create(Typeface.SANS_SERIF, Typeface.BOLD)
+        }
+        val caption = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = 0xff555555.toInt()
+            textSize = 13f
+            typeface = Typeface.SANS_SERIF
+        }
+        canvas.drawText(theme.name, SHEET_GUTTER_PX.toFloat(), 22f, title)
+        canvas.drawText(
+            "page #%06x   text #%06x   words of Jesus #%06x   verse number #%06x".format(
+                theme.background and 0xffffff, theme.fontColor and 0xffffff, theme.fontRedColor and 0xffffff, theme.verseNumberColor and 0xffffff,
+            ),
+            SHEET_GUTTER_PX.toFloat(),
+            40f,
+            caption,
+        )
+
+        var x = SHEET_GUTTER_PX
+        for ((_, block) in blocks) {
+            canvas.drawBitmap(block, x.toFloat(), SHEET_HEADER_PX.toFloat(), null)
+            x += blockWidth + SHEET_GUTTER_PX
+        }
+        return bitmap
+    }
+
+    private fun buildPipeline(): Pipeline {
+        val controller = Robolectric.buildActivity(AppCompatActivity::class.java).setup()
+        val activity = controller.get()
+        activity.setTheme(androidx.appcompat.R.style.Theme_AppCompat)
+        val frame = FrameLayout(activity).apply {
+            layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        }
+        activity.setContentView(frame)
+        idleLoopers()
+        return Pipeline(controller, frame)
+    }
+
+    private fun measureAndDraw(view: View, background: Int): Bitmap {
+        repeat(2) {
+            view.measure(
+                View.MeasureSpec.makeMeasureSpec(ROW_WIDTH_PX, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+            )
+            view.layout(0, 0, view.measuredWidth, view.measuredHeight.coerceAtLeast(1))
+            idleLoopers()
+        }
+
+        val bitmap = Bitmap.createBitmap(view.measuredWidth.coerceAtLeast(1), view.measuredHeight.coerceAtLeast(1), Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        canvas.drawColor(background)
+        view.draw(canvas)
+        return bitmap
+    }
+
+    private fun idleLoopers() {
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    private fun resolveSnapshotDir(): File {
+        val override = System.getenv("VERSE_TEXT_COLOR_SNAPSHOT_DIR")
+        if (!override.isNullOrBlank()) return File(override)
+        val moduleDir = File(System.getProperty("user.dir") ?: ".")
+        return File(moduleDir, "build/snapshots/verse-text-color")
+    }
+
+    private fun write(bitmap: Bitmap, file: File) {
+        file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/DictionaryLinkSpanTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/DictionaryLinkSpanTest.kt
@@ -1,0 +1,28 @@
+package yuku.alkitab.base.widget
+
+import android.text.TextPaint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class DictionaryLinkSpanTest {
+
+    @Test
+    fun `a dictionary link underlines the word but leaves the color of the surrounding run alone`() {
+        val span = DictionaryLinkSpan(DictionaryLinkInfo("body", "key_body")) {}
+        val paint = TextPaint().apply {
+            color = 0xff123456.toInt()
+            linkColor = 0xffabcdef.toInt()
+        }
+
+        span.updateDrawState(paint)
+
+        assertTrue(paint.isUnderlineText)
+        assertEquals(0xff123456.toInt(), paint.color)
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/VerseRendererComposeCheckedHighlightTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/VerseRendererComposeCheckedHighlightTest.kt
@@ -1,0 +1,91 @@
+package yuku.alkitab.base.widget
+
+import androidx.compose.ui.graphics.Color
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import yuku.alkitab.base.S
+import yuku.alkitab.base.util.Highlights
+import yuku.alkitab.base.util.TextColorUtil
+import yuku.alkitab.debug.R
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = yuku.afw.App::class, sdk = [34])
+class VerseRendererComposeCheckedHighlightTest {
+
+    private val FONT_COLOR = 0xff212121.toInt()
+    private val BACKGROUND = 0xfff0f0f0.toInt()
+    private val BLUE_SELECTION = 0xff0277bd.toInt()
+    private val ARI = 0x010203
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        yuku.afw.App.initWithAppContext(context)
+        yuku.afw.storage.Preferences.setInt(context.getString(R.string.pref_selectedVerseBgColor_key), BLUE_SELECTION)
+
+        val dims = S.CalculatedDimensions().apply {
+            fontColor = FONT_COLOR
+            fontRedColor = 0xffb71c1c.toInt()
+            verseNumberColor = 0xff828282.toInt()
+            backgroundColor = BACKGROUND
+            indentParagraphRest = 5
+        }
+        S.applied()
+        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
+        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
+        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, dims)
+    }
+
+    private fun partialYellow(text: String, start: Int, end: Int) = Highlights.Info().apply {
+        colorRgb = 0xffff00
+        partial = Highlights.Info.Partial().apply {
+            hashCode = Highlights.hashCode(text)
+            startOffset = start
+            endOffset = end
+        }
+    }
+
+    @Test
+    fun `in a checked verse the highlighted run carries the text color chosen against the band`() {
+        val text = "Hello world"
+        val result = VerseRendererCompose.render(
+            isVerseNumberShown = true,
+            ari = ARI,
+            text = text,
+            verseNumberText = "1",
+            highlightInfo = partialYellow(text, 0, 5),
+            checked = true,
+        )
+
+        val band = Highlights.blendOver(0xffff00, BACKGROUND)
+        val bandStyles = result.text.spanStyles.filter { it.item.background == Color(band) }
+        assertEquals(1, bandStyles.size)
+        assertEquals(3, bandStyles[0].start)
+        assertEquals(8, bandStyles[0].end)
+        assertEquals(Color(TextColorUtil.getForCheckedVerseHighlight(FONT_COLOR, BLUE_SELECTION, BACKGROUND, band)), bandStyles[0].item.color)
+        assertEquals(Color(FONT_COLOR), bandStyles[0].item.color)
+    }
+
+    @Test
+    fun `an unchecked highlighted verse leaves the run color unspecified so the reading color shows through the band`() {
+        val text = "Hello world"
+        val result = VerseRendererCompose.render(
+            isVerseNumberShown = true,
+            ari = ARI,
+            text = text,
+            verseNumberText = "1",
+            highlightInfo = partialYellow(text, 0, 5),
+            checked = false,
+        )
+
+        val band = Highlights.blendOver(0xffff00, BACKGROUND)
+        val bandStyles = result.text.spanStyles.filter { it.item.background == Color(band) }
+        assertEquals(1, bandStyles.size)
+        assertEquals(Color.Unspecified, bandStyles[0].item.color)
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/VerseRendererTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/VerseRendererTest.kt
@@ -18,6 +18,8 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import yuku.alkitab.base.S
 import yuku.alkitab.base.util.Highlights
+import yuku.alkitab.base.util.TextColorUtil
+import yuku.alkitab.debug.R
 
 /**
  * Characterization tests for [VerseRenderer].
@@ -51,6 +53,7 @@ import yuku.alkitab.base.util.Highlights
 @Config(application = yuku.afw.App::class, sdk = [34])
 class VerseRendererTest {
 
+    private val FONT_COLOR = 0xff212121.toInt()
     private val FONT_RED = 0xff112233.toInt()
     private val VERSE_NUMBER_COLOR = 0xff445566.toInt()
     private val BACKGROUND = 0xfff0f0f0.toInt()
@@ -71,6 +74,7 @@ class VerseRendererTest {
         yuku.afw.App.initWithAppContext(ApplicationProvider.getApplicationContext())
 
         dims = S.CalculatedDimensions().apply {
+            fontColor = FONT_COLOR
             fontRedColor = FONT_RED
             verseNumberColor = VERSE_NUMBER_COLOR
             backgroundColor = BACKGROUND
@@ -546,6 +550,57 @@ class VerseRendererTest {
         // Entire body is highlighted because the partial-validity check failed.
         assertEquals(3, sb.getSpanStart(bgs[0]))
         assertEquals(sb.length, sb.getSpanEnd(bgs[0]))
+    }
+
+    @Test
+    fun `in a checked verse the highlighted run gets its own text color chosen against the band rather than the selection`() {
+        pinSelectedVerseBgColor(0xff0277bd.toInt())
+        val text = "Hello world"
+        val info = Highlights.Info().apply {
+            colorRgb = 0xffff00
+            partial = Highlights.Info.Partial().apply {
+                hashCode = Highlights.hashCode(text)
+                startOffset = 0
+                endOffset = 5
+            }
+        }
+        val sb = renderToSb(text = text, verseNumberText = "1", highlight = info, checked = true)
+        val fgs = sb.getSpans(0, sb.length, ForegroundColorSpan::class.java)
+
+        assertEquals(1, fgs.size)
+        assertEquals(3, sb.getSpanStart(fgs[0]))
+        assertEquals(8, sb.getSpanEnd(fgs[0]))
+        // A yellow band is opaque on the light page, so the reading color beats the white that
+        // the blue selection alone would force.
+        assertEquals(FONT_COLOR, fgs[0].foregroundColor)
+        assertEquals(
+            TextColorUtil.getForCheckedVerseHighlight(FONT_COLOR, 0xff0277bd.toInt(), BACKGROUND, Highlights.blendOver(0xffff00, BACKGROUND)),
+            fgs[0].foregroundColor,
+        )
+    }
+
+    @Test
+    fun `a checked verse without a highlight attaches no ForegroundColorSpan and leaves the text color to the host`() {
+        pinSelectedVerseBgColor(0xff0277bd.toInt())
+        val sb = renderToSb(text = "Hello", verseNumberText = "1", checked = true)
+
+        assertEquals(0, sb.getSpans(0, sb.length, ForegroundColorSpan::class.java).size)
+    }
+
+    @Test
+    fun `an unchecked highlighted verse attaches no ForegroundColorSpan so the reading color shows through the band`() {
+        val info = Highlights.Info().apply {
+            colorRgb = 0xffff00
+            partial = null
+        }
+        val sb = renderToSb(text = "Hello", verseNumberText = "1", highlight = info)
+
+        assertEquals(0, sb.getSpans(0, sb.length, ForegroundColorSpan::class.java).size)
+    }
+
+    private fun pinSelectedVerseBgColor(argb: Int) {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        yuku.afw.storage.Preferences.setInt(context.getString(R.string.pref_selectedVerseBgColor_key), argb)
     }
 
     // endregion

--- a/docs/text-rendering.md
+++ b/docs/text-rendering.md
@@ -75,6 +75,16 @@ Pericopes (section headers like "The Sermon on the Mount") are rendered as disti
 - Accessibility (TalkBack support with verse number and text)
 - Highlight color painting on the background canvas
 
+### Text color in a selected verse
+
+A checked verse paints the selection color over the page at `TextColorUtil.CHECKED_VERSE_OVERLAY_ALPHA`. The host then forces the text to black or white via `TextColorUtil.getForCheckedVerse`, based on the selection color alone.
+
+A highlight band is drawn on top of that overlay. So both renderers give a highlighted run its own color through `TextColorUtil.getForCheckedVerseHighlight`, which picks whichever of the reading color or the forced color has better contrast against what the band actually paints. Words of Jesus lose their red in a checked verse and follow the same per-run color.
+
+Dictionary links (`DictionaryLinkSpan`, and the Compose `addDictionaryLinks`) only underline. They never set their own color, so they follow the run they sit in.
+
+`VerseTextColorSnapshotTest` renders every theme, selection color, highlight color and selection state through both pipelines into `Alkitab/build/snapshots/verse-text-color/` for visual review.
+
 ## Text Sizing
 
 Font size is controlled by:


### PR DESCRIPTION
## Problem

When a verse is checked (selected), its text color is forced to black or white to contrast with the selection color alone. A highlight band is painted on top of the selection overlay, so the forced color can clash badly with the band, e.g. a light highlight color like yellow forced to white text.

Two issues reported, both in the reading screen:

1. The selection-contrast override doesn't account for the highlight band actually painted over it (including partial highlights and Words-of-Jesus de-coloring on selection).
2. Dictionary-linked (underlined) words are colored differently from the run they sit in.

## Fix

- `TextColorUtil.getForCheckedVerseHighlight` composites the selection overlay over the page, then the highlight band over that, and picks whichever of the reading color or the forced black/white contrasts more with what's actually painted. Applied per run in both `VerseRenderer.applyHighlight` (legacy) and `VerseRendererCompose.applyHighlight` (Compose), so a partial highlight only affects its own range and Words of Jesus follow the same rule once their red is dropped on selection.
- `DictionaryLinkSpan.updateDrawState` and the Compose `addDictionaryLinks` now only underline; links no longer set their own color and instead follow the surrounding run.
- The selection overlay alpha, previously a duplicated `0xa0` literal in `VerseItem` and `VerseItemCompose`, is now one shared constant (`TextColorUtil.CHECKED_VERSE_OVERLAY_ALPHA`) used by the painters and the new contrast computation.

Both the legacy `VerseItem`/`VerseRenderer` pipeline and the Compose `VerseItemComposeView`/`VerseRendererCompose` pipeline are covered and tested for parity.

## Testing

- `./gradlew testPlainDebugUnitTest testPlainReleaseUnitTest` — full suite passes (706 tests in the debug variant), including new tests for `TextColorUtil`, both `VerseRenderer`/`VerseRendererCompose` checked+highlight paths, and the dictionary link spans.
- `VerseTextColorSnapshotTest` renders every reading theme × selected-verse background color × highlight color × selection state through both pipelines side by side into `Alkitab/build/snapshots/verse-text-color/` for visual review (not a pixel gate, an eyeballing report per the existing `HighlightBlendSnapshotTest` convention).
- `./gradlew assemblePlainDebug` — builds.