### PR TITLE
Sign the sabda_alkitab flavor with its own upload key

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -177,11 +177,15 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Decode signing keystore
+      # Two keystores: sabda_alkitab is a separate Play listing with its own
+      # upload key, the other two flavors share the first one.
+      - name: Decode signing keystores
         env:
           SIGN_KEYSTORE_BASE64: ${{ secrets.SIGN_KEYSTORE_BASE64 }}
+          SIGN_SABDA_KEYSTORE_BASE64: ${{ secrets.SIGN_SABDA_KEYSTORE_BASE64 }}
         run: |
           printf '%s' "$SIGN_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.jks"
+          printf '%s' "$SIGN_SABDA_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release-sabda.jks"
 
       # Build a short label used in artifact names. For PRs we use the PR
       # number and the PR head's short SHA (not github.sha, which on
@@ -205,6 +209,9 @@ jobs:
           SIGN_KEYSTORE: ${{ runner.temp }}/release.jks
           SIGN_ALIAS: ${{ secrets.SIGN_ALIAS }}
           SIGN_PASSWORD: ${{ secrets.SIGN_PASSWORD }}
+          SIGN_SABDA_KEYSTORE: ${{ runner.temp }}/release-sabda.jks
+          SIGN_SABDA_ALIAS: ${{ secrets.SIGN_SABDA_ALIAS }}
+          SIGN_SABDA_PASSWORD: ${{ secrets.SIGN_SABDA_PASSWORD }}
           BUILD_DIST: ci
         run: |
           ./gradlew \
@@ -338,6 +345,6 @@ jobs:
             "$sabda_apk" \
             "$qb_apk"
 
-      - name: Wipe keystore from runner
+      - name: Wipe keystores from runner
         if: always()
-        run: rm -f "$RUNNER_TEMP/release.jks"
+        run: rm -f "$RUNNER_TEMP/release.jks" "$RUNNER_TEMP/release-sabda.jks"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,11 +89,15 @@ jobs:
           fi
           echo "Releasing as $TAG"
 
-      - name: Decode signing keystore
+      # Two keystores: sabda_alkitab is a separate Play listing with its own
+      # upload key, the other two flavors share the first one.
+      - name: Decode signing keystores
         env:
           SIGN_KEYSTORE_BASE64: ${{ secrets.SIGN_KEYSTORE_BASE64 }}
+          SIGN_SABDA_KEYSTORE_BASE64: ${{ secrets.SIGN_SABDA_KEYSTORE_BASE64 }}
         run: |
           printf '%s' "$SIGN_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.jks"
+          printf '%s' "$SIGN_SABDA_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release-sabda.jks"
 
       - name: Build signed release (all production flavors)
         env:
@@ -101,6 +105,9 @@ jobs:
           SIGN_KEYSTORE: ${{ runner.temp }}/release.jks
           SIGN_ALIAS: ${{ secrets.SIGN_ALIAS }}
           SIGN_PASSWORD: ${{ secrets.SIGN_PASSWORD }}
+          SIGN_SABDA_KEYSTORE: ${{ runner.temp }}/release-sabda.jks
+          SIGN_SABDA_ALIAS: ${{ secrets.SIGN_SABDA_ALIAS }}
+          SIGN_SABDA_PASSWORD: ${{ secrets.SIGN_SABDA_PASSWORD }}
           VERSION_STAGE: ${{ inputs.stage }}
           VERSION_CODE: ${{ steps.version.outputs.versionCode }}
           BUILD_DIST: ${{ inputs.stage }}
@@ -208,6 +215,6 @@ jobs:
           fi
           gh release create "${args[@]}" release-staging/*
 
-      - name: Wipe keystore from runner
+      - name: Wipe keystores from runner
         if: always()
-        run: rm -f "$RUNNER_TEMP/release.jks"
+        run: rm -f "$RUNNER_TEMP/release.jks" "$RUNNER_TEMP/release-sabda.jks"

--- a/Alkitab/build.gradle.kts
+++ b/Alkitab/build.gradle.kts
@@ -179,6 +179,9 @@ val proprietaryFlavors = mapOf(
 )
 val proprietaryDir: String? = providers.environmentVariable("ALKITAB_PROPRIETARY_DIR").orNull
 
+val sabdaFlavorName = "sabda_alkitab"
+val sabdaSigningConfigName = "releaseSabda"
+
 // Server endpoints inlined here (and in AlkitabFeedback) — these are app-specific
 // constants previously held in root build.gradle's ext block.
 val serverHost = "https://api.alkitab.app"
@@ -192,6 +195,16 @@ android {
             keyPassword = System.getenv("SIGN_PASSWORD")
             storeFile = file(System.getenv("SIGN_KEYSTORE") ?: "/dev/null")
             storePassword = System.getenv("SIGN_PASSWORD")
+        }
+        // org.sabda.alkitab is a separate Play listing with its own upload key,
+        // so it cannot be signed with the keystore the yuku_* flavors use.
+        // Deliberately no fallback to SIGN_*: signing this flavor with the wrong
+        // key produces an artifact Play rejects only after upload.
+        create(sabdaSigningConfigName) {
+            keyAlias = System.getenv("SIGN_SABDA_ALIAS")
+            keyPassword = System.getenv("SIGN_SABDA_PASSWORD")
+            storeFile = file(System.getenv("SIGN_SABDA_KEYSTORE") ?: "/dev/null")
+            storePassword = System.getenv("SIGN_SABDA_PASSWORD")
         }
     }
     compileSdk = libs.versions.compileSdk.get().toInt()
@@ -363,6 +376,38 @@ androidComponents {
                 "copyProprietaryAssets${flavorName.replaceFirstChar { it.uppercaseChar() }}"
             )
             variant.sources.assets?.addGeneratedSourceDirectory(copyTask) { it.outputDir }
+        }
+    }
+}
+
+// Sign the sabda_alkitab release from its own keystore. The build type's
+// signingConfig covers every other release variant; overriding it per variant
+// (rather than on the product flavor) keeps sabda_alkitabDebug on the debug key.
+androidComponents {
+    onVariants(
+        selector().withFlavor("playStoreApplicationId" to sabdaFlavorName).withBuildType("release")
+    ) { variant ->
+        variant.signingConfig.setConfig(android.signingConfigs.getByName(sabdaSigningConfigName))
+
+        // Read into locals here rather than inside doLast, so the action does not
+        // capture the project and stays configuration-cache safe.
+        val missingVars = listOf("SIGN_SABDA_KEYSTORE", "SIGN_SABDA_ALIAS", "SIGN_SABDA_PASSWORD")
+            .filter { System.getenv(it).isNullOrEmpty() }
+        val variantName = variant.name
+        val flavorName = sabdaFlavorName
+        val validateTask = tasks.register("validate${variantName.replaceFirstChar { it.uppercaseChar() }}SigningConfig") {
+            doLast {
+                if (missingVars.isNotEmpty()) {
+                    throw GradleException(
+                        "Release build '$variantName' is missing its signing credentials: " +
+                            "${missingVars.joinToString(", ")} not set. The '$flavorName' flavor is signed " +
+                            "with its own upload key, not the one in SIGN_KEYSTORE."
+                    )
+                }
+            }
+        }
+        tasks.matching { it.name == "pre${variantName.replaceFirstChar { it.uppercaseChar() }}Build" }.configureEach {
+            dependsOn(validateTask)
         }
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ time and is unrelated to the stage. Never hardcode a version in
 The `plain` flavor is the open-source development build and works out of the box with the placeholder `Alkitab/google-services.json` checked into the repo (Firebase features won't function at runtime, but the app builds and runs). Production flavors (`yuku_alkitab`, `yuku_quick_bible`, `sabda_alkitab`) require:
 - `$ALKITAB_PROPRIETARY_DIR/overlay/<applicationId>/text_raw/` — proprietary Bible text
 - `$ALKITAB_PROPRIETARY_DIR/google-services.json` — real Firebase config (one file with client entries for all production applicationIds)
-- Signing-key env vars: `SIGN_KEYSTORE`, `SIGN_ALIAS`, `SIGN_PASSWORD`
+- Signing-key env vars: `SIGN_KEYSTORE`, `SIGN_ALIAS`, `SIGN_PASSWORD`. The `sabda_alkitab` flavor has its own upload key and needs `SIGN_SABDA_KEYSTORE`, `SIGN_SABDA_ALIAS`, `SIGN_SABDA_PASSWORD` instead (there is no fallback to `SIGN_*`)
 
 With those set, build with a plain `./gradlew assembleYuku_alkitabRelease` (or any other production flavor).
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Notes
 -----
 
 - The repository contains placeholder Bible data in `Alkitab/src/plain/assets/internal` and a placeholder `Alkitab/google-services.json`, so the open-source `plainDebug` build works out of the box once the Android SDK and NDK are installed (Firebase features won't actually function with the placeholder, but the build and the rest of the app do).
-- Release packaging is pure Gradle. Production flavors expect the signing env vars (`SIGN_KEYSTORE`, `SIGN_ALIAS`, `SIGN_PASSWORD`) and `ALKITAB_PROPRIETARY_DIR`, which must contain `overlay/<applicationId>/text_raw/` (Bible text) and `google-services.json` (real Firebase config covering every production applicationId). With those set, `./gradlew assembleYuku_alkitabRelease` (or any other production flavor) builds and signs the APK directly. Set `BUILD_DIST` to override the `dev` suffix in the output filename.
+- Release packaging is pure Gradle. Production flavors expect the signing env vars (`SIGN_KEYSTORE`, `SIGN_ALIAS`, `SIGN_PASSWORD`, plus `SIGN_SABDA_KEYSTORE`, `SIGN_SABDA_ALIAS`, `SIGN_SABDA_PASSWORD` for the `sabda_alkitab` flavor, which has its own upload key) and `ALKITAB_PROPRIETARY_DIR`, which must contain `overlay/<applicationId>/text_raw/` (Bible text) and `google-services.json` (real Firebase config covering every production applicationId). With those set, `./gradlew assembleYuku_alkitabRelease` (or any other production flavor) builds and signs the APK directly. Set `BUILD_DIST` to override the `dev` suffix in the output filename.
 - Product flavors currently include `plain`, `yuku_alkitab`, `yuku_quick_bible`, and `sabda_alkitab`.
 
 License

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -158,7 +158,8 @@ $ALKITAB_PROPRIETARY_DIR/
 
 Environment variables:
 - `ALKITAB_PROPRIETARY_DIR` — directory matching the layout above. Required for `yuku_alkitab`, `yuku_quick_bible`, `sabda_alkitab`. Not used by `plain`.
-- `SIGN_KEYSTORE`, `SIGN_ALIAS`, `SIGN_PASSWORD` — required to sign release builds (any flavor). The signing config in `Alkitab/build.gradle.kts` reads them at config time.
+- `SIGN_KEYSTORE`, `SIGN_ALIAS`, `SIGN_PASSWORD` — required to sign release builds of `plain`, `yuku_alkitab` and `yuku_quick_bible`.
+- `SIGN_SABDA_KEYSTORE`, `SIGN_SABDA_ALIAS`, `SIGN_SABDA_PASSWORD` — required to sign release builds of `sabda_alkitab`. See "Signing keys" below.
 - `BUILD_DIST` — distribution channel identifier embedded in the APK filename. Defaults to `dev` when unset.
 - `VERSION_STAGE` — `dev` (default), `beta`, or `release`; picks how `versionName` is assembled. `-PversionStage=` does the same and wins if both are given. See "Versioning" above.
 - `VERSION_CODE` — pins `versionCode` instead of deriving it from the clock, so a rebuild of the same commit produces the same number. The release workflow sets it once per run.
@@ -172,6 +173,46 @@ What the Gradle build does:
 6. `debugSymbolLevel = "SYMBOL_TABLE"` makes AGP emit `Alkitab/build/outputs/native-debug-symbols/<variant>/native-debug-symbols.zip` and embed the same symbols in the AAB, so the Play Console can symbolicate crashes in the Snappy JNI code.
 
 The `plain` flavor keeps its placeholder `ddd_*` Bible files in `Alkitab/src/plain/assets/internal/` and uses the placeholder `Alkitab/google-services.json`. It needs none of the proprietary env vars.
+
+### Signing keys
+
+Two keystores, because `org.sabda.alkitab` is a separate Play listing with its
+own upload key:
+
+| Signing config | Variants | Env vars |
+|----------------|----------|----------|
+| `release` | `plainRelease`, `yuku_alkitabRelease`, `yuku_quick_bibleRelease` | `SIGN_KEYSTORE`, `SIGN_ALIAS`, `SIGN_PASSWORD` |
+| `releaseSabda` | `sabda_alkitabRelease` | `SIGN_SABDA_KEYSTORE`, `SIGN_SABDA_ALIAS`, `SIGN_SABDA_PASSWORD` |
+
+The `release` config is attached to the `release` build type, so it covers every
+release variant by default. `androidComponents.onVariants` then overrides just
+`sabda_alkitabRelease` with `releaseSabda`. Overriding per variant rather than on
+the product flavor keeps `sabda_alkitabDebug` on the ordinary debug key.
+
+`SIGN_SABDA_*` deliberately has no fallback to `SIGN_*`: a bundle signed with the
+wrong upload key is only rejected once it reaches Play, so
+`validateSabda_alkitabReleaseSigningConfig` fails the build up front when the
+variables are missing.
+
+`./gradlew :Alkitab:signingReport` prints the resolved keystore and certificate
+fingerprint per variant, which is the quickest way to confirm a machine or a CI
+run has both keys wired up correctly.
+
+CI reads the keystores from repository secrets, base64-encoded because Actions
+secrets are text:
+
+| Secret | Contents |
+|--------|----------|
+| `SIGN_KEYSTORE_BASE64` | `base64 -w0 release.jks` |
+| `SIGN_ALIAS` / `SIGN_PASSWORD` | alias and password for that keystore |
+| `SIGN_SABDA_KEYSTORE_BASE64` | `base64 -w0 release-sabda.jks` |
+| `SIGN_SABDA_ALIAS` / `SIGN_SABDA_PASSWORD` | alias and password for the sabda keystore |
+
+Both `android.yml` and `release.yml` decode them into `$RUNNER_TEMP` before the
+build step and delete them afterwards in an `if: always()` step.
+
+Each keystore's store password and key password have to be the same value: the
+build feeds one variable to both `storePassword` and `keyPassword`.
 
 ### Release workflow
 

--- a/docs/play-publishing.md
+++ b/docs/play-publishing.md
@@ -179,9 +179,10 @@ untouched on Play.
   `Alkitab/build.gradle.kts`; check the requirement in the Play Console
   before a release, because the upload fails validation rather than warning.
 - **Signing key.** The bundle must be signed with each app's Play *upload*
-  key. All three flavors are signed with the one keystore from
-  `SIGN_KEYSTORE`, so that key has to be the upload key registered for all
-  three apps.
+  key. `yuku_alkitab` and `yuku_quick_bible` share the keystore from
+  `SIGN_KEYSTORE`, so that key has to be the upload key registered for both;
+  `sabda_alkitab` uses its own from `SIGN_SABDA_KEYSTORE`. See "Signing keys"
+  in [Build System](build-system.md).
 - **versionCode.** Derived from wall-clock time in
   `Alkitab/build.gradle.kts`, so it always increases, and all three flavors
   share the value. That is fine: they are three separate Play apps.


### PR DESCRIPTION
## Summary

`org.sabda.alkitab` is a separate Play listing and needs a different upload key than the one `yuku_alkitab` and `yuku_quick_bible` share. Until now a single `release` signing config on the `release` build type covered all three flavors.

- Adds a `releaseSabda` signing config in `Alkitab/build.gradle.kts`, driven by `SIGN_SABDA_KEYSTORE` / `SIGN_SABDA_ALIAS` / `SIGN_SABDA_PASSWORD`.
- Applies it to `sabda_alkitabRelease` only, through `androidComponents.onVariants`. Overriding per variant rather than on the product flavor keeps `sabda_alkitabDebug` on the ordinary debug key.
- No fallback to `SIGN_*`: a bundle signed with the wrong upload key is only rejected once it reaches Play, so `validateSabda_alkitabReleaseSigningConfig` fails the build up front when the variables are missing.
- Both CI workflows decode a second base64-encoded keystore into `$RUNNER_TEMP` and wipe it in the `if: always()` cleanup step.
- Docs updated: a "Signing keys" section in `docs/build-system.md` (config/variant/env-var table, the CI secret names, the `signingReport` check), plus the signing notes in `README.md`, `CLAUDE.md` and `docs/play-publishing.md`.

## Required before merge

Two new repository secrets have to exist, or the `signed-release` job will fail at `sabda_alkitabRelease`:

| Secret | Contents |
|--------|----------|
| `SIGN_SABDA_KEYSTORE_BASE64` | `base64 -w0` of the sabda keystore file |
| `SIGN_SABDA_ALIAS` | key alias inside that keystore |
| `SIGN_SABDA_PASSWORD` | password (store and key password must be the same value) |

## Test plan

- [x] `./gradlew :Alkitab:signingReport` with both keystores set: `plainRelease`, `yuku_alkitabRelease` and `yuku_quick_bibleRelease` resolve to `Config: release` with the first certificate fingerprint; `sabda_alkitabRelease` resolves to `Config: releaseSabda` with a different fingerprint; `sabda_alkitabDebug` still resolves to `Config: debug`.
- [x] With `SIGN_SABDA_*` unset, `validateSabda_alkitabReleaseSigningConfig` fails naming the three missing variables.
- [x] `./gradlew assemblePlainDebug` still builds with no signing environment at all.
- [ ] First `signed-release` CI run after the secrets are added produces a sabda APK whose signer differs from the other two (`apksigner verify --print-certs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDQPdQGRqFzfsUp5Lx5ukD

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDQPdQGRqFzfsUp5Lx5ukD)_