### PR TITLE
Fix three bugs in the Compose verse item

### DIFF
--- a/Alkitab/src/main/java/yuku/alkitab/base/S.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/S.kt
@@ -94,18 +94,7 @@ object S {
     }
 
     private object CalculatedDimensionsHolder {
-        /**
-         * Snapshot-backed so Compose readers subscribe to it: a preference
-         * change (pinch-to-zoom, the text appearance panel) must repaint the
-         * already-composed verse rows, not only the ones composed afterwards.
-         * [CalculatedDimensions] has identity equality, so every
-         * [recalculate] publishes a distinct value and is also usable as a
-         * `remember` key.
-         *
-         * Reads and writes outside a snapshot go straight to the global one,
-         * so non-Compose callers on any thread behave as with a plain
-         * `@Volatile` field.
-         */
+        /** Snapshot state so Compose readers repaint when [recalculate] republishes. */
         val applied = mutableStateOf(calculateDimensionsFromPreferences())
     }
 
@@ -119,11 +108,7 @@ object S {
         CalculatedDimensionsHolder.applied.value = calculateDimensionsFromPreferences()
     }
 
-    /**
-     * Publishes [dimensions] as though [recalculate] had derived them, so
-     * rendering tests can pin deterministic metrics without reaching into the
-     * holder reflectively. Production code calls [recalculate].
-     */
+    /** Pins deterministic dimensions for rendering tests. Production code calls [recalculate]. */
     @VisibleForTesting
     fun overrideAppliedDimensions(dimensions: CalculatedDimensions) {
         CalculatedDimensionsHolder.applied.value = dimensions

--- a/Alkitab/src/main/java/yuku/alkitab/base/S.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/S.kt
@@ -2,6 +2,8 @@ package yuku.alkitab.base
 
 import android.graphics.Color
 import android.graphics.Typeface
+import androidx.annotation.VisibleForTesting
+import androidx.compose.runtime.mutableStateOf
 import yuku.afw.storage.Preferences
 import yuku.alkitab.base.config.AppConfig
 import yuku.alkitab.base.model.MVersion
@@ -92,18 +94,39 @@ object S {
     }
 
     private object CalculatedDimensionsHolder {
-        @Volatile
-        var applied: CalculatedDimensions = calculateDimensionsFromPreferences()
+        /**
+         * Snapshot-backed so Compose readers subscribe to it: a preference
+         * change (pinch-to-zoom, the text appearance panel) must repaint the
+         * already-composed verse rows, not only the ones composed afterwards.
+         * [CalculatedDimensions] has identity equality, so every
+         * [recalculate] publishes a distinct value and is also usable as a
+         * `remember` key.
+         *
+         * Reads and writes outside a snapshot go straight to the global one,
+         * so non-Compose callers on any thread behave as with a plain
+         * `@Volatile` field.
+         */
+        val applied = mutableStateOf(calculateDimensionsFromPreferences())
     }
 
     @JvmStatic
     fun applied(): CalculatedDimensions {
-        return CalculatedDimensionsHolder.applied
+        return CalculatedDimensionsHolder.applied.value
     }
 
     /** Re-derive [applied] from current preferences. Call after preference changes. */
     fun recalculate() {
-        CalculatedDimensionsHolder.applied = calculateDimensionsFromPreferences()
+        CalculatedDimensionsHolder.applied.value = calculateDimensionsFromPreferences()
+    }
+
+    /**
+     * Publishes [dimensions] as though [recalculate] had derived them, so
+     * rendering tests can pin deterministic metrics without reaching into the
+     * holder reflectively. Production code calls [recalculate].
+     */
+    @VisibleForTesting
+    fun overrideAppliedDimensions(dimensions: CalculatedDimensions) {
+        CalculatedDimensionsHolder.applied.value = dimensions
     }
 
     /**

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
@@ -331,13 +331,20 @@ private class DictionaryLinkHit(val start: Int, val end: Int, val info: Dictiona
  * correct glyphs (or synthesise cleanly). A raw FontFamily(Typeface)
  * wrapper only carries the regular variant and silently renders
  * italic upright.
+ *
+ * For the same reason a wrapped typeface also ignores `FontWeight.Bold`:
+ * Compose applies no synthesis to a family built from a ready-made
+ * [android.graphics.Typeface]. Custom fonts ship as a single `-Regular.ttf`
+ * (see [yuku.alkitab.base.util.FontManager]), so [bold] resolves the style
+ * through `Typeface.create` instead, which is what makes the platform draw
+ * the faux-bold that `TextView.setTypeface(tf, BOLD)` produces.
  */
-internal fun composeFontFamilyFor(tf: android.graphics.Typeface?): FontFamily = when (tf) {
+internal fun composeFontFamilyFor(tf: android.graphics.Typeface?, bold: Boolean = false): FontFamily = when (tf) {
     null, android.graphics.Typeface.DEFAULT -> FontFamily.Default
     android.graphics.Typeface.SERIF -> FontFamily.Serif
     android.graphics.Typeface.MONOSPACE -> FontFamily.Monospace
     android.graphics.Typeface.SANS_SERIF -> FontFamily.SansSerif
-    else -> FontFamily(ComposeTypeface(tf))
+    else -> FontFamily(ComposeTypeface(if (bold) android.graphics.Typeface.create(tf, android.graphics.Typeface.BOLD) else tf))
 }
 
 /** Whether the attribute column will draw at least one icon. */
@@ -620,7 +627,8 @@ private fun VerseTextRegion(state: VerseItemComposeState, checked: Boolean, line
         state.typeface,
         state.fontBold,
     ) {
-        val fontFamily = composeFontFamilyFor(state.typeface)
+        val bold = state.fontBold == android.graphics.Typeface.BOLD
+        val fontFamily = composeFontFamilyFor(state.typeface, bold)
         TextStyle(
             color = textColor,
             fontSize = state.fontSizeDp.sp,
@@ -629,7 +637,7 @@ private fun VerseTextRegion(state: VerseItemComposeState, checked: Boolean, line
                 alignment = LineHeightStyle.Alignment.Proportional,
                 trim = LineHeightStyle.Trim.None,
             ),
-            fontWeight = if (state.fontBold == android.graphics.Typeface.BOLD) FontWeight.Bold else FontWeight.Normal,
+            fontWeight = if (bold) FontWeight.Bold else FontWeight.Normal,
             platformStyle = PlatformTextStyle(includeFontPadding = false),
             fontFamily = fontFamily,
         )
@@ -647,6 +655,7 @@ private fun VerseTextRegion(state: VerseItemComposeState, checked: Boolean, line
                     layoutResultProvider = { textLayoutResult },
                     inlineLinks = state.render.inlineLinks,
                     onClick = state.onInlineLinkClick,
+                    onMiss = state.onClick,
                 ),
             onTextLayout = { textLayoutResult = it },
         )
@@ -925,17 +934,28 @@ private fun Modifier.dragHoverOverlay(dragHover: Boolean): Modifier {
  * range, computes the link's bounding rect via the [TextLayoutResult], and
  * picks the nearest link whose squared distance from the tap is within (24dp)².
  * Lets users hit small footnote/xref markers without pixel-precise aim.
+ *
+ * A tap that lands near no link runs [onMiss]. The pointer-input modifier sits
+ * below the row's own tap handler and consumes every tap that reaches the text,
+ * so without this the row would be unselectable wherever a verse happens to
+ * carry a footnote or cross-reference. [yuku.alkitab.base.widget.VerseTextView]
+ * gets the same effect by returning false from `onTouchEvent`.
  */
 private fun Modifier.inlineLinkTapDetector(
     layoutResultProvider: () -> TextLayoutResult?,
     inlineLinks: List<VerseRendererCompose.InlineLinkRange>,
     onClick: (VerseInlineLinkSpan.Type, Int) -> Unit,
+    onMiss: () -> Unit,
 ): Modifier {
     if (inlineLinks.isEmpty()) return this
-    return this.pointerInput(inlineLinks) {
+    return this.pointerInput(inlineLinks, onClick, onMiss) {
         val maxDistanceSquaredPx = (24.dp.toPx()).let { (it * it).toInt() }
         detectTapGestures(onTap = { offset ->
-            val layout = layoutResultProvider() ?: return@detectTapGestures
+            val layout = layoutResultProvider()
+            if (layout == null) {
+                onMiss()
+                return@detectTapGestures
+            }
             var best: VerseRendererCompose.InlineLinkRange? = null
             var bestDistSq = Int.MAX_VALUE
             for (link in inlineLinks) {
@@ -954,7 +974,7 @@ private fun Modifier.inlineLinkTapDetector(
                 }
                 if (bestDistSq == 0) break
             }
-            best?.let { onClick(it.type, it.arif) }
+            if (best != null) onClick(best.type, best.arif) else onMiss()
         })
     }
 }

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VerseItemCompose.kt
@@ -330,14 +330,10 @@ private class DictionaryLinkHit(val start: Int, val end: Int, val info: Dictiona
  * registered, so FontStyle.Italic / FontWeight.Bold resolve to the
  * correct glyphs (or synthesise cleanly). A raw FontFamily(Typeface)
  * wrapper only carries the regular variant and silently renders
- * italic upright.
- *
- * For the same reason a wrapped typeface also ignores `FontWeight.Bold`:
- * Compose applies no synthesis to a family built from a ready-made
- * [android.graphics.Typeface]. Custom fonts ship as a single `-Regular.ttf`
- * (see [yuku.alkitab.base.util.FontManager]), so [bold] resolves the style
- * through `Typeface.create` instead, which is what makes the platform draw
- * the faux-bold that `TextView.setTypeface(tf, BOLD)` produces.
+ * italic upright, and ignores `FontWeight.Bold`. Custom fonts ship as a single
+ * `-Regular.ttf`, so [bold] bakes the weight into the typeface instead, which
+ * is what makes the platform draw the faux-bold that
+ * `TextView.setTypeface(tf, BOLD)` produces.
  */
 internal fun composeFontFamilyFor(tf: android.graphics.Typeface?, bold: Boolean = false): FontFamily = when (tf) {
     null, android.graphics.Typeface.DEFAULT -> FontFamily.Default
@@ -935,11 +931,8 @@ private fun Modifier.dragHoverOverlay(dragHover: Boolean): Modifier {
  * picks the nearest link whose squared distance from the tap is within (24dp)².
  * Lets users hit small footnote/xref markers without pixel-precise aim.
  *
- * A tap that lands near no link runs [onMiss]. The pointer-input modifier sits
- * below the row's own tap handler and consumes every tap that reaches the text,
- * so without this the row would be unselectable wherever a verse happens to
- * carry a footnote or cross-reference. [yuku.alkitab.base.widget.VerseTextView]
- * gets the same effect by returning false from `onTouchEvent`.
+ * A tap near no link runs [onMiss]: this detector consumes every tap that
+ * reaches the text, so the row's own tap handler never sees one.
  */
 private fun Modifier.inlineLinkTapDetector(
     layoutResultProvider: () -> TextLayoutResult?,

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
@@ -854,8 +854,13 @@ class VersesComposeControllerImpl(
         val verse_1 = index + 1
         val checked = position in checkedPositionsState
         val context = LocalContext.current
+        // Reading the dimensions here subscribes this row to preference
+        // changes, and keying the row state on them rebuilds it: a data-class
+        // `ui` copy carrying the same values would otherwise leave the row
+        // rendered at the previous font size.
+        val applied = App.services.uiDimensions.applied()
 
-        val state = remember(data, ui, listeners, position, checked) {
+        val state = remember(data, ui, listeners, position, checked, applied) {
             buildVerseItemComposeState(
                 context = context,
                 data = data,
@@ -980,7 +985,10 @@ internal fun PericopeHeaderComposeItem(
         }
         val paddingBottomPx = applied.pericopeSpacingBottom
 
-        val fontFamily = remember(applied.fontFace) { composeFontFamilyFor(applied.fontFace) }
+        // The title is bold regardless of the bold preference, matching
+        // Appearances.applyPericopeTitleAppearance.
+        val titleFontFamily = remember(applied.fontFace) { composeFontFamilyFor(applied.fontFace, bold = true) }
+        val parallelsFontFamily = remember(applied.fontFace) { composeFontFamilyFor(applied.fontFace) }
         val titleSizeDp = applied.fontSize2dp * ui.textSizeMult
         val titleLineMetrics = remember(applied.fontFace, titleSizeDp, applied.lineSpacingMult, unscaledDensity.density) {
             computeLineMetrics(applied.fontFace, titleSizeDp, android.graphics.Typeface.BOLD, applied.lineSpacingMult, unscaledDensity.density)
@@ -1003,7 +1011,7 @@ internal fun PericopeHeaderComposeItem(
                     color = Color(applied.fontColor),
                     fontSize = titleSizeDp.sp,
                     fontWeight = FontWeight.Bold,
-                    fontFamily = fontFamily,
+                    fontFamily = titleFontFamily,
                     textAlign = TextAlign.Center,
                     lineHeight = titleLineMetrics.lineHeightSp.sp,
                     lineHeightStyle = LineHeightStyle(
@@ -1030,7 +1038,7 @@ internal fun PericopeHeaderComposeItem(
                     style = TextStyle(
                         color = Color(applied.fontColor),
                         fontSize = parallelsSizeDp.sp,
-                        fontFamily = fontFamily,
+                        fontFamily = parallelsFontFamily,
                         textAlign = TextAlign.Center,
                         lineHeight = parallelsLineMetrics.lineHeightSp.sp,
                         lineHeightStyle = LineHeightStyle(

--- a/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
+++ b/Alkitab/src/main/java/yuku/alkitab/base/verses/VersesComposeControllerImpl.kt
@@ -854,10 +854,8 @@ class VersesComposeControllerImpl(
         val verse_1 = index + 1
         val checked = position in checkedPositionsState
         val context = LocalContext.current
-        // Reading the dimensions here subscribes this row to preference
-        // changes, and keying the row state on them rebuilds it: a data-class
-        // `ui` copy carrying the same values would otherwise leave the row
-        // rendered at the previous font size.
+        // Read here to subscribe the row to preference changes, and keyed on
+        // below so the state is rebuilt at the new font size.
         val applied = App.services.uiDimensions.applied()
 
         val state = remember(data, ui, listeners, position, checked, applied) {
@@ -985,8 +983,6 @@ internal fun PericopeHeaderComposeItem(
         }
         val paddingBottomPx = applied.pericopeSpacingBottom
 
-        // The title is bold regardless of the bold preference, matching
-        // Appearances.applyPericopeTitleAppearance.
         val titleFontFamily = remember(applied.fontFace) { composeFontFamilyFor(applied.fontFace, bold = true) }
         val parallelsFontFamily = remember(applied.fontFace) { composeFontFamilyFor(applied.fontFace) }
         val titleSizeDp = applied.fontSize2dp * ui.textSizeMult

--- a/Alkitab/src/test/java/yuku/alkitab/base/AppliedDimensionsTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/AppliedDimensionsTest.kt
@@ -1,0 +1,55 @@
+package yuku.alkitab.base
+
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import yuku.afw.App as AfwApp
+
+/**
+ * The verse list composes against [S.applied], so a preference change
+ * (pinch-to-zoom, the text appearance panel) has to reach the rows that are
+ * already on screen, not only the ones composed after it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = AfwApp::class, sdk = [34])
+class AppliedDimensionsTest {
+
+    @Before
+    fun setUp() {
+        AfwApp.initWithAppContext(ApplicationProvider.getApplicationContext())
+    }
+
+    @Test
+    fun `recalculating notifies the snapshot observers that read the dimensions`() {
+        val read = mutableSetOf<Any>()
+        Snapshot.observe(readObserver = { read += it }) { S.applied() }
+        assertTrue("S.applied() must be readable as snapshot state", read.isNotEmpty())
+
+        val notified = mutableListOf<Set<Any>>()
+        val handle = Snapshot.registerApplyObserver { changed, _ -> notified += changed }
+        try {
+            S.recalculate()
+            Snapshot.sendApplyNotifications()
+        } finally {
+            handle.dispose()
+        }
+
+        assertTrue(
+            "recalculate must invalidate the readers of S.applied(), notified $notified",
+            notified.any { changed -> changed.any(read::contains) },
+        )
+    }
+
+    @Test
+    fun `each recalculation publishes a distinct instance, so it works as a remember key`() {
+        val before = S.applied()
+        S.recalculate()
+        assertNotSame(before, S.applied())
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/AppliedDimensionsTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/AppliedDimensionsTest.kt
@@ -12,9 +12,8 @@ import org.robolectric.annotation.Config
 import yuku.afw.App as AfwApp
 
 /**
- * The verse list composes against [S.applied], so a preference change
- * (pinch-to-zoom, the text appearance panel) has to reach the rows that are
- * already on screen, not only the ones composed after it.
+ * The verse list composes against [S.applied], so a preference change has to
+ * reach the rows already on screen, not only the ones composed after it.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(application = AfwApp::class, sdk = [34])

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/ReaderSideBySideSnapshotTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/ReaderSideBySideSnapshotTest.kt
@@ -105,10 +105,7 @@ class ReaderSideBySideSnapshotTest {
             pericopeSpacingTop = 14
             pericopeSpacingBottom = 4
         }
-        S.applied()
-        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
-        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
-        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, dims)
+        S.overrideAppliedDimensions(dims)
     }
 
     private fun idleLoopers() {

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemComposeDictionaryTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemComposeDictionaryTest.kt
@@ -92,10 +92,7 @@ class VerseItemComposeDictionaryTest {
             verseNumberColor = 0xff445566.toInt()
             lineSpacingMult = 1.15f
         }
-        S.applied()
-        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
-        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
-        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, dims)
+        S.overrideAppliedDimensions(dims)
     }
 
     private fun registerDictionaryProvider() {

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemComposeInteractionTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemComposeInteractionTest.kt
@@ -40,9 +40,9 @@ class VerseItemComposeInteractionTest {
 
     private val ROW_WIDTH_PX = 360
 
-    private val LONG_BODY = "In the beginning God created the heavens and the earth, and the earth " +
-        "was without form and void, and darkness was upon the face of the deep, and the Spirit " +
-        "of God moved upon the face of the waters."
+    private val LONG_BODY = "A bowl of steaming noodles arrived at the table, topped with a soft " +
+        "boiled egg, spring onions and a spoonful of chili oil, and the broth smelled of ginger, " +
+        "garlic and slowly braised beef."
 
     @Before
     fun setUp() {
@@ -107,9 +107,8 @@ class VerseItemComposeInteractionTest {
     }
 
     private fun composeRow(text: String, recorder: TapRecorder): VerseItemComposeView {
-        // `setup()` runs the activity through onResume so its decor view is
-        // attached, which is what lets AbstractComposeView find a
-        // WindowRecomposer.
+        // `setup()` runs through onResume so the decor view is attached, which
+        // is what lets AbstractComposeView find a WindowRecomposer.
         val activity = Robolectric.buildActivity(AppCompatActivity::class.java).setup().get()
         activity.setTheme(androidx.appcompat.R.style.Theme_AppCompat)
 
@@ -155,20 +154,19 @@ class VerseItemComposeInteractionTest {
     }
 
     @Test
-    // Own sdk so this test gets a fresh Robolectric sandbox: only the first
-    // activity of a sandbox gets a recomposition frame clock that ticks, and
-    // without one BasicText never reports a TextLayoutResult to hit-test
-    // against.
+    // Own sdk for a fresh Robolectric sandbox: only its first activity gets a
+    // ticking frame clock, and without one BasicText never reports a
+    // TextLayoutResult to hit-test against.
     @Config(sdk = [33])
     fun `a tap near the footnote marker opens it and a tap away from it selects the verse`() {
         val recorder = TapRecorder()
-        // The footnote marker sits at the very start of the verse, so the
-        // bottom of a multi-line row is well outside its 24dp easy-hit radius.
+        // The marker sits at the very start of the verse, so the bottom of a
+        // multi-line row is well outside its 24dp easy-hit radius.
         val view = composeRow("@@@<f1@>@/$LONG_BODY", recorder)
         assertTrue("row should wrap onto several lines", view.measuredHeight > 60)
 
-        // Hitting the marker first also proves the text layout is live, so the
-        // miss below is a real miss rather than an absent layout.
+        // Hitting the marker first also proves the layout is live, so the miss
+        // below is a real miss rather than an absent layout.
         tap(view, 3f, 6f)
         assertEquals(listOf(VerseInlineLinkSpan.Type.footnote to (Ari.encode(1, 2, 1) shl 8 or 1)), recorder.linkClicks)
         assertEquals(0, recorder.verseClicks)
@@ -197,8 +195,8 @@ class VerseItemComposeInteractionTest {
 
     @Test
     fun `a custom typeface asked for bold resolves to a bold face, so the platform can fake the weight`() {
-        // A font loaded from a file is none of the stock singletons, so it maps
-        // to a wrapped-typeface FontFamily, which Compose never synthesises for.
+        // Not one of the stock singletons, so it maps to a wrapped-typeface
+        // FontFamily, which Compose never synthesises for.
         val custom = Typeface.create("cursive", Typeface.NORMAL)
 
         assertTrue(resolveTypeface(custom, bold = true).isBold)

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemComposeInteractionTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemComposeInteractionTest.kt
@@ -1,0 +1,213 @@
+package yuku.alkitab.base.verses
+
+import android.app.Activity
+import android.graphics.Typeface
+import android.os.Looper
+import android.os.SystemClock
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import yuku.afw.App as AfwApp
+import yuku.alkitab.base.S
+import yuku.alkitab.base.widget.AttributeView
+import yuku.alkitab.base.widget.VerseInlineLinkSpan
+import yuku.alkitab.base.widget.VerseRendererCompose
+import yuku.alkitab.util.Ari
+
+/**
+ * Tap routing and typeface resolution for the Compose verse row.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = AfwApp::class, sdk = [34], qualifiers = "w360dp-h640dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class VerseItemComposeInteractionTest {
+
+    private val ROW_WIDTH_PX = 360
+
+    private val LONG_BODY = "In the beginning God created the heavens and the earth, and the earth " +
+        "was without form and void, and darkness was upon the face of the deep, and the Spirit " +
+        "of God moved upon the face of the waters."
+
+    @Before
+    fun setUp() {
+        AfwApp.initWithAppContext(ApplicationProvider.getApplicationContext())
+
+        S.overrideAppliedDimensions(
+            S.CalculatedDimensions().apply {
+                fontSize2dp = 17f
+                fontFace = Typeface.DEFAULT
+                fontBold = Typeface.NORMAL
+                fontColor = 0xff202020.toInt()
+                fontRedColor = 0xffcc0000.toInt()
+                verseNumberColor = 0xff445566.toInt()
+                backgroundColor = 0xffffffff.toInt()
+                lineSpacingMult = 1.15f
+                indentParagraphFirst = 38
+                indentParagraphRest = 5
+            }
+        )
+    }
+
+    private class TapRecorder {
+        var verseClicks = 0
+        val linkClicks = mutableListOf<Pair<VerseInlineLinkSpan.Type, Int>>()
+    }
+
+    private fun buildState(text: String, recorder: TapRecorder): VerseItemComposeState {
+        val ari = Ari.encode(1, 2, 1)
+        val applied = S.applied()
+        return VerseItemComposeState(
+            render = VerseRendererCompose.render(
+                isVerseNumberShown = false,
+                ari = ari,
+                text = text,
+                verseNumberText = "1",
+                highlightInfo = null,
+                checked = false,
+            ),
+            fontSizeDp = applied.fontSize2dp,
+            verseNumberFontSizeDp = applied.fontSize2dp * 0.7f,
+            fontColor = applied.fontColor,
+            verseNumberColor = applied.verseNumberColor,
+            lineSpacingMult = applied.lineSpacingMult,
+            typeface = applied.fontFace,
+            fontBold = applied.fontBold,
+            attribute = AttributeState(
+                bookmarkCount = 0,
+                noteCount = 0,
+                progressMarkBits = 0,
+                hasMaps = false,
+                scale = 1f,
+                version = null,
+                versionId = null,
+                ari = ari,
+                attributeListener = object : VersesController.AttributeListener() {},
+                progressMarkCaptions = List(AttributeView.PROGRESS_MARK_TOTAL_COUNT) { null },
+            ),
+            onClick = { recorder.verseClicks++ },
+            onInlineLinkClick = { type, arif -> recorder.linkClicks += type to arif },
+            onPinDropped = {},
+        )
+    }
+
+    private fun composeRow(text: String, recorder: TapRecorder): VerseItemComposeView {
+        // `setup()` runs the activity through onResume so its decor view is
+        // attached, which is what lets AbstractComposeView find a
+        // WindowRecomposer.
+        val activity = Robolectric.buildActivity(AppCompatActivity::class.java).setup().get()
+        activity.setTheme(androidx.appcompat.R.style.Theme_AppCompat)
+
+        val view = VerseItemComposeView(activity)
+        attachAndLayout(activity, view)
+        view.bind(buildState(text, recorder))
+        layoutRow(view)
+        return view
+    }
+
+    private fun attachAndLayout(activity: Activity, view: View) {
+        val frame = FrameLayout(activity)
+        frame.addView(
+            view,
+            ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT),
+        )
+        activity.setContentView(frame)
+        idleLoopers()
+    }
+
+    private fun layoutRow(view: View) {
+        repeat(2) {
+            idleLoopers()
+            view.measure(
+                View.MeasureSpec.makeMeasureSpec(ROW_WIDTH_PX, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+            )
+            view.layout(0, 0, view.measuredWidth, view.measuredHeight.coerceAtLeast(1))
+            idleLoopers()
+        }
+    }
+
+    private fun tap(view: View, x: Float, y: Float) {
+        val down = SystemClock.uptimeMillis()
+        view.dispatchTouchEvent(MotionEvent.obtain(down, down, MotionEvent.ACTION_DOWN, x, y, 0))
+        idleLoopers()
+        view.dispatchTouchEvent(MotionEvent.obtain(down, down + 20, MotionEvent.ACTION_UP, x, y, 0))
+        idleLoopers()
+    }
+
+    private fun idleLoopers() {
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+    }
+
+    @Test
+    // Own sdk so this test gets a fresh Robolectric sandbox: only the first
+    // activity of a sandbox gets a recomposition frame clock that ticks, and
+    // without one BasicText never reports a TextLayoutResult to hit-test
+    // against.
+    @Config(sdk = [33])
+    fun `a tap near the footnote marker opens it and a tap away from it selects the verse`() {
+        val recorder = TapRecorder()
+        // The footnote marker sits at the very start of the verse, so the
+        // bottom of a multi-line row is well outside its 24dp easy-hit radius.
+        val view = composeRow("@@@<f1@>@/$LONG_BODY", recorder)
+        assertTrue("row should wrap onto several lines", view.measuredHeight > 60)
+
+        // Hitting the marker first also proves the text layout is live, so the
+        // miss below is a real miss rather than an absent layout.
+        tap(view, 3f, 6f)
+        assertEquals(listOf(VerseInlineLinkSpan.Type.footnote to (Ari.encode(1, 2, 1) shl 8 or 1)), recorder.linkClicks)
+        assertEquals(0, recorder.verseClicks)
+
+        tap(view, 40f, view.measuredHeight - 6f)
+        assertEquals(1, recorder.verseClicks)
+        assertEquals("the far tap must not reach the footnote", 1, recorder.linkClicks.size)
+    }
+
+    @Test
+    fun `tapping a verse with no inline links selects it`() {
+        val recorder = TapRecorder()
+        val view = composeRow("@@$LONG_BODY", recorder)
+
+        tap(view, 40f, view.measuredHeight - 6f)
+
+        assertEquals(1, recorder.verseClicks)
+    }
+
+    private fun resolveTypeface(typeface: Typeface?, bold: Boolean): Typeface {
+        val family = composeFontFamilyFor(typeface, bold)
+        val resolver = createFontFamilyResolver(ApplicationProvider.getApplicationContext())
+        val weight = if (bold) FontWeight.Bold else FontWeight.Normal
+        return resolver.resolve(family, weight).value as Typeface
+    }
+
+    @Test
+    fun `a custom typeface asked for bold resolves to a bold face, so the platform can fake the weight`() {
+        // A font loaded from a file is none of the stock singletons, so it maps
+        // to a wrapped-typeface FontFamily, which Compose never synthesises for.
+        val custom = Typeface.create("cursive", Typeface.NORMAL)
+
+        assertTrue(resolveTypeface(custom, bold = true).isBold)
+        assertFalse(resolveTypeface(custom, bold = false).isBold)
+    }
+
+    @Test
+    fun `a stock typeface keeps mapping to its stock family, which resolves bold on its own`() {
+        assertTrue(resolveTypeface(Typeface.SERIF, bold = true).isBold)
+        assertFalse(resolveTypeface(Typeface.SERIF, bold = false).isBold)
+    }
+}

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemSideBySideSnapshotTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseItemSideBySideSnapshotTest.kt
@@ -115,14 +115,7 @@ class VerseItemSideBySideSnapshotTest {
             indentSpacing4 = INDENT_4
             indentSpacingExtra = INDENT_EXTRA
         }
-        S.applied()
-        overrideAppliedDimensions(dims)
-    }
-
-    private fun overrideAppliedDimensions(d: S.CalculatedDimensions) {
-        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
-        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
-        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, d)
+        S.overrideAppliedDimensions(dims)
     }
 
     @Test

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseTextColorSnapshotTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VerseTextColorSnapshotTest.kt
@@ -182,10 +182,7 @@ class VerseTextColorSnapshotTest {
             indentSpacing4 = 70
             indentSpacingExtra = 6
         }
-        S.applied()
-        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
-        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
-        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, dims)
+        S.overrideAppliedDimensions(dims)
 
         val ftr = VerseRenderer.FormattedTextResult()
         VerseRenderer.render(ari = Ari.encode(48, 4, 16), text = SAMPLE, ftr = ftr)

--- a/Alkitab/src/test/java/yuku/alkitab/base/verses/VersesComposeListCompositionTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/verses/VersesComposeListCompositionTest.kt
@@ -75,14 +75,7 @@ class VersesComposeListCompositionTest {
             pericopeSpacingTop = 14
             pericopeSpacingBottom = 4
         }
-        S.applied()
-        overrideAppliedDimensions(dims)
-    }
-
-    private fun overrideAppliedDimensions(d: S.CalculatedDimensions) {
-        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
-        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
-        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, d)
+        S.overrideAppliedDimensions(dims)
     }
 
     private fun idleLoopers() {

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/VerseRendererComposeCheckedHighlightTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/VerseRendererComposeCheckedHighlightTest.kt
@@ -35,10 +35,7 @@ class VerseRendererComposeCheckedHighlightTest {
             backgroundColor = BACKGROUND
             indentParagraphRest = 5
         }
-        S.applied()
-        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
-        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
-        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, dims)
+        S.overrideAppliedDimensions(dims)
     }
 
     private fun partialYellow(text: String, start: Int, end: Int) = Highlights.Info().apply {

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/VerseRendererGoldenGen.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/VerseRendererGoldenGen.kt
@@ -70,13 +70,7 @@ class VerseRendererGoldenGen {
             indentSpacingExtra = INDENT_EXTRA
         }
 
-        // Trigger holder init, then overwrite `applied` — same trick as
-        // VerseRendererTest. S.applied() is @JvmStatic so mockkObject doesn't
-        // cleanly intercept it; reflection is the most reliable override.
-        S.applied()
-        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
-        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
-        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, dims)
+        S.overrideAppliedDimensions(dims)
     }
 
     @Test

--- a/Alkitab/src/test/java/yuku/alkitab/base/widget/VerseRendererTest.kt
+++ b/Alkitab/src/test/java/yuku/alkitab/base/widget/VerseRendererTest.kt
@@ -42,12 +42,9 @@ import yuku.alkitab.debug.R
  * initialisation of its [S.CalculatedDimensions] from Preferences and Resources) has a
  * live Context to use.
  *
- * Why reflection instead of `mockkObject(S)`? `S.applied()` is `@JvmStatic`, and mockk's
- * object intercept does not cleanly redirect the Java-level static invocation that
- * [VerseRenderer] (a Java class) uses. The simplest and most reliable override is to reach
- * into S's private `CalculatedDimensionsHolder` via reflection and set our own
- * [S.CalculatedDimensions] — the same object that S.applied() would otherwise return. This
- * avoids fighting with static-method interception and keeps test setup trivial.
+ * Why [S.overrideAppliedDimensions] instead of `mockkObject(S)`? `S.applied()` is
+ * `@JvmStatic`, and mockk's object intercept does not cleanly redirect the Java-level
+ * static invocation that [VerseRenderer] (a Java class) uses.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(application = yuku.afw.App::class, sdk = [34])
@@ -87,16 +84,7 @@ class VerseRendererTest {
             indentSpacingExtra = INDENT_EXTRA
         }
 
-        // Trigger the Holder's one-time init so its backing Java class is loaded and its
-        // INSTANCE field exists, then overwrite `applied` with our deterministic dims.
-        S.applied()
-        overrideAppliedDimensions(dims)
-    }
-
-    private fun overrideAppliedDimensions(d: S.CalculatedDimensions) {
-        val holderClass = Class.forName("${S::class.java.name}\$CalculatedDimensionsHolder")
-        val instance = holderClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
-        holderClass.getDeclaredField("applied").apply { isAccessible = true }.set(instance, d)
+        S.overrideAppliedDimensions(dims)
     }
 
     // region simpleRender: text that does not start with "@@"


### PR DESCRIPTION
Three fixes to the "Verse (Compose)" reader path.

### 1. A verse with a footnote or cross-reference could not be selected

`inlineLinkTapDetector` is a `pointerInput` on the verse text, which sits below the row's own tap handler. `detectTapGestures` consumes every tap that reaches it, so a tap that landed near no link was swallowed and never fell through to verse selection: any verse carrying a footnote or xref was effectively unselectable.

It now runs the row's `onClick` when no link is hit, which is what `VerseTextView` achieves by returning `false` from `onTouchEvent`. The 24dp easy-hit radius is unchanged. The detector is also keyed on the two callbacks now, so a rebuilt row state no longer leaves a stale lambda captured.

### 2. Pinch-to-zoom did not resize the verses already on screen

The rows read `S.applied()`, a plain field Compose cannot observe, and the `VersesUiModel` copy that `IsiActivity.applyPreferences` publishes is structurally equal to the previous one, so `mutableStateOf` dropped it and nothing recomposed. Only rows composed afterwards (while scrolling) picked up the new size, which is exactly the reported symptom.

The applied dimensions now live in a snapshot state, so reading them during composition subscribes the row, and `CalculatedDimensions` has identity equality so every recalculation publishes a distinct value. `VerseRow` keys its row state on them, so the state is rebuilt rather than returned from `remember`.

### 3. Pericope headers lost their bold with a custom font

Compose applies no synthesis to a `FontFamily` built from a ready-made `android.graphics.Typeface`, and custom fonts ship as a single `-Regular.ttf`, so `FontWeight.Bold` on a pericope title rendered at normal weight. `composeFontFamilyFor` now resolves the requested style through `Typeface.create` for wrapped typefaces, which is what makes the platform draw the faux-bold that `TextView.setTypeface(tf, BOLD)` produces (`Appearances.applyPericopeTitleAppearance`). The verse body follows the bold preference the same way; stock typefaces keep mapping to their stock families, which synthesise on their own.

### Tests

- `VerseItemComposeInteractionTest` (new): taps a composed row on and away from a footnote marker and asserts where each tap lands; resolves the font family through a `FontFamilyResolver` and asserts the bold face for custom and stock typefaces.
- `AppliedDimensionsTest` (new): recalculating notifies the snapshot observers that read the dimensions, and each recalculation publishes a distinct instance so it works as a `remember` key.
- Both new tests were confirmed to fail against the unfixed code.
- The seven test classes that pinned deterministic metrics by reflecting into `S`'s private `CalculatedDimensionsHolder` now go through a `@VisibleForTesting` `S.overrideAppliedDimensions` seam.

Verified locally with `./gradlew assemblePlainDebug testPlainDebugUnitTest testPlainReleaseUnitTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5R6QNzMZN2u1qEDhvxMwd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5R6QNzMZN2u1qEDhvxMwd)_